### PR TITLE
Add per-request `request_key` to ghosts DB, migration, and search wiring

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -21,6 +21,11 @@ pub fn run() {
                             directory_name_lower TEXT NOT NULL
                         );",
                         kind: tauri_plugin_sql::MigrationKind::Up,
+                    }, tauri_plugin_sql::Migration {
+                        version: 2,
+                        description: "add_request_key_to_ghosts",
+                        sql: "ALTER TABLE ghosts ADD COLUMN request_key TEXT NOT NULL DEFAULT '';\nCREATE INDEX IF NOT EXISTS idx_ghosts_request_key ON ghosts(request_key);\nCREATE INDEX IF NOT EXISTS idx_ghosts_request_key_name_lower ON ghosts(request_key, name_lower);\nCREATE INDEX IF NOT EXISTS idx_ghosts_request_key_directory_name_lower ON ghosts(request_key, directory_name_lower);",
+                        kind: tauri_plugin_sql::MigrationKind::Up,
                     }],
                 )
                 .build(),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import { useSearch } from "./hooks/useSearch";
 import { AppHeader } from "./components/AppHeader";
 import { GhostContent } from "./components/GhostContent";
 import { SettingsPanel } from "./components/SettingsPanel";
+import { buildAdditionalFolders, buildRequestKey } from "./lib/ghostScanUtils";
 
 const useStyles = makeStyles({
   app: {
@@ -70,6 +71,9 @@ function App() {
   const [searchQuery, setSearchQuery] = useState("");
   const [settingsOpen, setSettingsOpen] = useState(false);
   const deferredSearchQuery = useDeferredValue(searchQuery);
+  const searchRequestKey = sspPath
+    ? buildRequestKey(sspPath, buildAdditionalFolders(ghostFolders))
+    : null;
 
   const [offset, setOffset] = useState(0);
   const LIMIT = 100;
@@ -90,6 +94,7 @@ function App() {
   }, [deferredSearchQuery]);
 
   const { ghosts: searchResultGhosts, total: searchTotal, loading: searchLoading, dbError } = useSearch(
+    searchRequestKey,
     deferredSearchQuery,
     LIMIT,
     offset,

--- a/src/hooks/useSearch.test.ts
+++ b/src/hooks/useSearch.test.ts
@@ -1,7 +1,12 @@
-import { describe, it, expect } from "vitest";
-import { renderHook } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
 import { useSearch } from "./useSearch";
 import type { GhostView } from "../types";
+import { searchGhosts } from "../lib/ghostDatabase";
+
+vi.mock("../lib/ghostDatabase", () => ({
+  searchGhosts: vi.fn(),
+}));
 
 const mockGhosts: GhostView[] = [
   {
@@ -23,26 +28,62 @@ const mockGhosts: GhostView[] = [
 ];
 
 describe("useSearch", () => {
-  it("空クエリでは全件返す", () => {
-    const { result } = renderHook(() => useSearch(mockGhosts, ""));
-    expect(result.current).toHaveLength(2);
+  beforeEach(() => {
+    vi.clearAllMocks();
   });
-  it("name で部分一致フィルタリングする", () => {
-    const { result } = renderHook(() => useSearch(mockGhosts, "reim"));
-    expect(result.current).toHaveLength(1);
-    expect(result.current[0].name).toBe("Reimu");
+
+  it("requestKey が null の場合は検索しない", async () => {
+    const { result } = renderHook(() => useSearch(null, "", 100, 0, 0));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(searchGhosts).not.toHaveBeenCalled();
+    expect(result.current.ghosts).toEqual([]);
+    expect(result.current.total).toBe(0);
   });
-  it("directory_name で部分一致フィルタリングする", () => {
-    const { result } = renderHook(() => useSearch(mockGhosts, "kiris"));
-    expect(result.current).toHaveLength(1);
-    expect(result.current[0].directory_name).toBe("kirisame");
+
+  it("requestKey を渡すと SQLite 検索結果を返す", async () => {
+    vi.mocked(searchGhosts).mockResolvedValueOnce({
+      ghosts: mockGhosts,
+      total: mockGhosts.length,
+    });
+
+    const { result } = renderHook(() => useSearch("rk1", "", 100, 0, 0));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+      expect(result.current.ghosts).toHaveLength(2);
+    });
+
+    expect(searchGhosts).toHaveBeenCalledWith("rk1", "", 100, 0);
+    expect(result.current.total).toBe(2);
   });
-  it("大文字小文字を区別しない", () => {
-    const { result } = renderHook(() => useSearch(mockGhosts, "REIMU"));
-    expect(result.current).toHaveLength(1);
-  });
-  it("スペースのみのクエリでは全件返す", () => {
-    const { result } = renderHook(() => useSearch(mockGhosts, "  "));
-    expect(result.current).toHaveLength(2);
+
+  it("offset > 0 の場合は結果を追記する", async () => {
+    vi.mocked(searchGhosts)
+      .mockResolvedValueOnce({ ghosts: [mockGhosts[0]], total: 2 })
+      .mockResolvedValueOnce({ ghosts: [mockGhosts[1]], total: 2 });
+
+    const { result, rerender } = renderHook(
+      ({ offset }) => useSearch("rk1", "", 1, offset, 0),
+      { initialProps: { offset: 0 } }
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+      expect(result.current.ghosts).toHaveLength(1);
+    });
+
+    rerender({ offset: 1 });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+      expect(result.current.ghosts).toHaveLength(2);
+    });
+
+    expect(result.current.ghosts[0].name).toBe("Reimu");
+    expect(result.current.ghosts[1].name).toBe("Marisa");
   });
 });

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -3,6 +3,7 @@ import type { GhostView } from "../types";
 import { searchGhosts } from "../lib/ghostDatabase";
 
 export function useSearch(
+  requestKey: string | null,
   query: string,
   limit: number,
   offset: number,
@@ -17,10 +18,18 @@ export function useSearch(
     let isActive = true;
 
     async function fetchGhosts() {
+      if (!requestKey) {
+        setGhosts([]);
+        setTotal(0);
+        setDbError(null);
+        setLoading(false);
+        return;
+      }
+
       setLoading(true);
       setDbError(null);
       try {
-        const result = await searchGhosts(query, limit, offset);
+        const result = await searchGhosts(requestKey, query, limit, offset);
         if (isActive) {
           setGhosts((prev) => offset === 0 ? result.ghosts : [...prev, ...result.ghosts]);
           setTotal(result.total);
@@ -42,7 +51,7 @@ export function useSearch(
     return () => {
       isActive = false;
     };
-  }, [query, limit, offset, refreshTrigger]);
+  }, [requestKey, query, limit, offset, refreshTrigger]);
 
   return { ghosts, total, loading, dbError };
 }

--- a/src/lib/ghostDatabase.ts
+++ b/src/lib/ghostDatabase.ts
@@ -12,13 +12,13 @@ export async function getDb(): Promise<Database> {
   return dbInstance;
 }
 
-export async function clearGhosts(): Promise<void> {
+export async function clearGhostsByRequestKey(requestKey: string): Promise<void> {
   const db = await getDb();
-  await db.execute("DELETE FROM ghosts");
-  console.log("[ghostDatabase] Cleared ghosts table");
+  await db.execute("DELETE FROM ghosts WHERE request_key = ?", [requestKey]);
+  console.log(`[ghostDatabase] Cleared ghosts table for requestKey=${requestKey}`);
 }
 
-export async function insertGhostsBatch(ghosts: Ghost[]): Promise<void> {
+export async function insertGhostsBatch(requestKey: string, ghosts: Ghost[]): Promise<void> {
   if (ghosts.length === 0) return;
   const db = await getDb();
 
@@ -28,12 +28,13 @@ export async function insertGhostsBatch(ghosts: Ghost[]): Promise<void> {
   for (let i = 0; i < ghosts.length; i += chunkSize) {
     const chunk = ghosts.slice(i, i + chunkSize);
 
-    let sql = "INSERT INTO ghosts (name, directory_name, path, source, name_lower, directory_name_lower) VALUES ";
+    let sql = "INSERT INTO ghosts (request_key, name, directory_name, path, source, name_lower, directory_name_lower) VALUES ";
     const placeholders: string[] = [];
     const params: string[] = [];
 
     for (const ghost of chunk) {
-      placeholders.push("(?, ?, ?, ?, ?, ?)");
+      placeholders.push("(?, ?, ?, ?, ?, ?, ?)");
+      params.push(requestKey);
       params.push(ghost.name);
       params.push(ghost.directory_name);
       params.push(ghost.path);
@@ -46,29 +47,46 @@ export async function insertGhostsBatch(ghosts: Ghost[]): Promise<void> {
     await db.execute(sql, params);
     inserted += chunk.length;
   }
-  console.log(`[ghostDatabase] Inserted ${inserted} ghosts into SQLite`);
+  console.log(`[ghostDatabase] Inserted ${inserted} ghosts into SQLite for requestKey=${requestKey}`);
 }
 
-export async function searchGhosts(query: string, limit: number, offset: number): Promise<{ ghosts: GhostView[], total: number }> {
+export async function replaceGhostsByRequestKey(requestKey: string, ghosts: Ghost[]): Promise<void> {
+  const db = await getDb();
+  await db.execute("BEGIN IMMEDIATE TRANSACTION");
+  try {
+    await db.execute("DELETE FROM ghosts WHERE request_key = ?", [requestKey]);
+    await insertGhostsBatch(requestKey, ghosts);
+    await db.execute("COMMIT");
+    console.log(`[ghostDatabase] Replaced ghosts for requestKey=${requestKey}`);
+  } catch (error) {
+    try {
+      await db.execute("ROLLBACK");
+    } catch (rollbackError) {
+      console.error("[ghostDatabase] ROLLBACK failed", rollbackError);
+    }
+    throw error;
+  }
+}
+
+export async function searchGhosts(requestKey: string, query: string, limit: number, offset: number): Promise<{ ghosts: GhostView[], total: number }> {
   const db = await getDb();
 
   const likePattern = `%${query.toLowerCase()}%`;
 
   // SQLite では ? プレースホルダを使う ($1/$2 は PostgreSQL 構文)
   const countResult = await db.select<{ count: number }[]>(
-    "SELECT COUNT(*) as count FROM ghosts WHERE name_lower LIKE ? OR directory_name_lower LIKE ?",
-    [likePattern, likePattern]
+    "SELECT COUNT(*) as count FROM ghosts WHERE request_key = ? AND (name_lower LIKE ? OR directory_name_lower LIKE ?)",
+    [requestKey, likePattern, likePattern]
   );
 
   const total = countResult.length > 0 ? countResult[0].count : 0;
-  console.log(`[ghostDatabase] searchGhosts("${query}", limit=${limit}, offset=${offset}) → total=${total}`);
+  console.log(`[ghostDatabase] searchGhosts(requestKey=${requestKey}, query="${query}", limit=${limit}, offset=${offset}) → total=${total}`);
 
   const rows = await db.select<GhostView[]>(
-    "SELECT name, directory_name, path, source, name_lower, directory_name_lower FROM ghosts WHERE name_lower LIKE ? OR directory_name_lower LIKE ? ORDER BY name_lower ASC LIMIT ? OFFSET ?",
-    [likePattern, likePattern, limit, offset]
+    "SELECT name, directory_name, path, source, name_lower, directory_name_lower FROM ghosts WHERE request_key = ? AND (name_lower LIKE ? OR directory_name_lower LIKE ?) ORDER BY name_lower ASC LIMIT ? OFFSET ?",
+    [requestKey, likePattern, likePattern, limit, offset]
   );
 
   console.log(`[ghostDatabase] Fetched ${rows.length} rows`);
   return { ghosts: rows, total };
 }
-


### PR DESCRIPTION
### Motivation
- Separate and cache scan results per-request by introducing a `request_key` so multiple SSP paths / folder sets can coexist in the SQLite store.
- Ensure searches and cache validation only operate on the relevant request scope to avoid cross-talk between different scans.
- Make DB writes atomic per-request and avoid marking fingerprints as saved if DB persistence fails.

### Description
- Added a new SQLite migration (version 2) to add `request_key` to `ghosts` and create indexes on `request_key` and combinations with `name_lower`/`directory_name_lower` in `src-tauri/src/lib.rs`.
- Introduced `requestKey` propagation through the UI by computing `searchRequestKey` in `src/App.tsx` and passing it into `useSearch`.
- Reworked database module `src/lib/ghostDatabase.ts` to store and query by `request_key`, updated `insertGhostsBatch` to include `request_key`, added `replaceGhostsByRequestKey` transactional upsert, and namespaced the `DELETE` operation to a `requestKey`-scoped clear.
- Updated `useGhosts` in `src/hooks/useGhosts.ts` to validate cache by checking SQLite rows scoped to the `requestKey`, use `replaceGhostsByRequestKey` for persistence, and only write the fingerprint when DB persistence succeeds, with improved error handling.
- Changed `useSearch` in `src/hooks/useSearch.ts` to accept a `requestKey` parameter and skip DB queries when `requestKey` is `null`, and to pass the `requestKey` to `searchGhosts`.
- Added and updated unit tests in `src/hooks/useSearch.test.ts` to mock `searchGhosts` and verify behavior when `requestKey` is `null`, when results are returned for a `requestKey`, and when paging (`offset`) appends results.

### Testing
- Ran unit tests for the search hook with `vitest` (updated `src/hooks/useSearch.test.ts`) to validate `requestKey`-scoped behavior and pagination; tests passed.
- Exercised the scanning flow locally to verify fingerprints are only stored after successful DB replacement and that searches return only request-scoped rows (manual verification during development).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1247b1b9c8322afd2c796bcfbe7f8)