### PR TITLE
fix: migration 3 の DEFAULT CURRENT_TIMESTAMP を修正（起動時クラッシュ）

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,3 +26,6 @@ serde_json = "1"
 encoding_rs = "0.8"
 sha2 = "0.10"
 tauri-plugin-sql = { version = "2", features = ["sqlite"] }
+
+[dev-dependencies]
+rusqlite = { version = "0.31", features = ["bundled"] }


### PR DESCRIPTION
## 問題

`npm run tauri dev` 実行時に以下のエラーが表示され、ゴースト一覧が取得できない。

```
ゴースト一覧の取得に失敗しました。（詳細: while executing migration 3: error returned from database: (code: 1) Cannot add a column with non-constant default）
```

## 原因

Migration 3 の SQL:

```sql
ALTER TABLE ghosts ADD COLUMN updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP;
```

SQLite は `ALTER TABLE ADD COLUMN` の `DEFAULT` 句で関数呼び出し（`CURRENT_TIMESTAMP` 等）を受け付けない。リテラル値のみ許容される。

## 修正

`DEFAULT CURRENT_TIMESTAMP` → `DEFAULT ''` に変更。

安全な理由:
- 同じ migration 内の `DELETE FROM ghosts;` が既存の全行を削除するため、デフォルト値が実際に使われることはない
- 新規 INSERT 時は TypeScript 側の `ghostDatabase.ts` の VALUES 句で `CURRENT_TIMESTAMP` を渡している

## Test plan

- [x] `npm run tauri dev` でエラーなく起動すること
- [x] ゴースト一覧が正常に表示されること
- [x] `cargo test` がグリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)