### PR TITLE
feat: 起動履歴・ソート切り替え・ランダム起動

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ ghost_launcher/
 ### バックエンド（`src-tauri/src/` + `crates/ghost-meta/`）
 
 - `lib.rs` — Tauri アプリビルダー。コマンド・プラグイン登録・SQLite マイグレーション
-- `commands/ghost/` — ゴーストスキャン・DB 書き込み・フィンガープリントコマンド群。`scan.rs`（Rayon 並列スキャン + 型変換）、`store.rs`（rusqlite 直接書き込み）、`fingerprint.rs`（2 層差分検知）、`path_utils.rs`（パス正規化）、`types.rs`（型定義）
+- `commands/ghost/` — ゴーストスキャン・DB 書き込み・フィンガープリントコマンド群。`scan.rs`（Rayon 並列スキャン + 型変換）、`store.rs`（rusqlite 差分 UPSERT）、`fingerprint.rs`（2 層差分検知）、`path_utils.rs`（パス正規化）、`types.rs`（型定義）
 - `commands/ssp.rs` — `launch_ghost` コマンド。`ssp.exe /g {ghost}` を起動
 - `crates/ghost-meta/` — ゴーストメタデータ解析ワークスペースクレート。`descript.txt` パーサー・ゴースト走査・サムネイル解決
 

--- a/e2e/CLAUDE.md
+++ b/e2e/CLAUDE.md
@@ -22,3 +22,23 @@ npm run e2e
 
 - セレクタは日英両言語対応（XPath で `text()='起動' or text()='Launch'` のように記述）
 - SSP パス未設定など環境依存のテストは `test.skip()` で安全にスキップ
+
+## テスト追加の手順
+
+1. `e2e/` に `*.e2e.ts` ファイルを作成（`ghost-list.e2e.ts` をテンプレートにする）
+2. `base.extend<{ harness: Harness }>` で harness フィクスチャを定義し、`createHarness`/`disposeHarness` でセッションを管理
+3. `helpers/ui.ts` のヘルパーを使う: `waitForAppReady`（初期ロード待機）、`waitForGhosts`（スキャン完了待機）、`openSettings`/`closeSettings`
+4. 要素取得は `data-testid` 属性を優先（`By.css("[data-testid='...']")`）。テキストマッチが必要な場合は XPath で日英両方を記述
+
+## 主要な data-testid 一覧
+
+| testid | 要素 | ファイル |
+|--------|------|----------|
+| `settings-button` | ヘッダー設定ボタン | AppHeader.tsx |
+| `open-settings-button` | 空状態の設定誘導ボタン | GhostContent.tsx |
+| `settings-close-button` | 設定ダイアログ閉じるボタン | App.tsx |
+| `launch-button` | ゴースト起動ボタン | GhostCard.tsx |
+| `ghost-name` | ゴースト名テキスト | GhostCard.tsx |
+| `ghost-list-viewport` | 仮想スクロールコンテナ | GhostList.tsx |
+| `empty-state` | 空状態メッセージ | GhostList.tsx / GhostContent.tsx |
+| `random-launch-button` | ランダム起動ボタン | AppHeader.tsx |

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -79,6 +79,12 @@ pub(crate) fn migrations() -> Vec<tauri_plugin_sql::Migration> {
             sql: "ALTER TABLE ghost_fingerprints ADD COLUMN parent_mtimes TEXT NOT NULL DEFAULT '';",
             kind: tauri_plugin_sql::MigrationKind::Up,
         },
+        tauri_plugin_sql::Migration {
+            version: 11,
+            description: "create_ghost_launches_table",
+            sql: "CREATE TABLE IF NOT EXISTS ghost_launches (\n  id INTEGER PRIMARY KEY AUTOINCREMENT,\n  ghost_identity_key TEXT NOT NULL,\n  launched_at TEXT NOT NULL\n);\nCREATE INDEX IF NOT EXISTS idx_ghost_launches_identity ON ghost_launches(ghost_identity_key);\nCREATE INDEX IF NOT EXISTS idx_ghost_launches_at ON ghost_launches(launched_at DESC);",
+            kind: tauri_plugin_sql::MigrationKind::Up,
+        },
     ]
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,9 @@ import { AppHeader } from "./components/AppHeader";
 import { GhostContent } from "./components/GhostContent";
 import { SettingsPanel } from "./components/SettingsPanel";
 import { buildAdditionalFolders, buildRequestKey } from "./lib/ghostScanUtils";
+import { getRandomGhost, recordLaunch } from "./lib/ghostDatabase";
+import { invoke } from "@tauri-apps/api/core";
+import type { SortOrder } from "./types";
 
 const useStyles = makeStyles({
   app: {
@@ -75,6 +78,7 @@ function App() {
   } = useSettings();
   const { loading: ghostsLoading, error, refresh } = useGhosts(sspPath, ghostFolders);
   const [searchQuery, setSearchQuery] = useState("");
+  const [sortOrder, setSortOrder] = useState<SortOrder>("name");
   const deferredSearchQuery = useDeferredValue(searchQuery);
   const LIMIT = 500;
 
@@ -102,7 +106,8 @@ function App() {
     deferredSearchQuery,
     LIMIT,
     offset,
-    refreshTrigger
+    refreshTrigger,
+    sortOrder,
   );
 
   const handleLoadMore = useCallback((targetOffset: number) => {
@@ -114,6 +119,34 @@ function App() {
   const handleRefresh = useCallback(() => refresh({ forceFullScan: true }), [refresh]);
   const handleOpenSettings = openSettings;
   const handleCloseSettings = closeSettings;
+
+  const [randomLaunchError, setRandomLaunchError] = useState<string | null>(null);
+  const handleRandomLaunch = useCallback(async () => {
+    if (!searchRequestKey || !sspPath) return;
+    setRandomLaunchError(null);
+    try {
+      const ghost = await getRandomGhost(searchRequestKey);
+      if (!ghost) {
+        setRandomLaunchError(t("header.randomLaunch.empty"));
+        return;
+      }
+      await invoke("launch_ghost", {
+        sspPath,
+        ghostDirectoryName: ghost.directory_name,
+        ghostSource: ghost.source,
+      });
+      if (ghost.ghost_identity_key) {
+        void recordLaunch(ghost.ghost_identity_key).catch(() => {});
+      }
+    } catch (e) {
+      setRandomLaunchError(e instanceof Error ? e.message : String(e));
+    }
+  }, [searchRequestKey, sspPath, t]);
+
+  const handleSortChange = useCallback((value: SortOrder) => {
+    setSortOrder(value);
+    setOffset(0);
+  }, [setOffset]);
 
   if (settingsLoading) {
     return (
@@ -131,6 +164,7 @@ function App() {
           ghostsLoading={ghostsLoading}
           onRefresh={handleRefresh}
           onOpenSettings={handleOpenSettings}
+          onRandomLaunch={handleRandomLaunch}
         />
         <GhostContent
           ghosts={searchResultGhosts}
@@ -138,10 +172,12 @@ function App() {
           loadedStart={loadedStart}
           sspPath={sspPath}
           searchQuery={searchQuery}
+          sortOrder={sortOrder}
           loading={ghostsLoading}
           searchLoading={searchLoading}
-          error={error ?? dbError}
+          error={error ?? dbError ?? randomLaunchError}
           onSearchChange={setSearchQuery}
+          onSortChange={handleSortChange}
           onOpenSettings={handleOpenSettings}
           onLoadMore={handleLoadMore}
         />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -164,7 +164,6 @@ function App() {
           ghostsLoading={ghostsLoading}
           onRefresh={handleRefresh}
           onOpenSettings={handleOpenSettings}
-          onRandomLaunch={handleRandomLaunch}
         />
         <GhostContent
           ghosts={searchResultGhosts}
@@ -178,6 +177,7 @@ function App() {
           error={error ?? dbError ?? randomLaunchError}
           onSearchChange={setSearchQuery}
           onSortChange={handleSortChange}
+          onRandomLaunch={handleRandomLaunch}
           onOpenSettings={handleOpenSettings}
           onLoadMore={handleLoadMore}
         />

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -1,13 +1,14 @@
-import { memo } from "react";
+import { memo, useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Button, Text, makeStyles, tokens } from "@fluentui/react-components";
-import { ArrowClockwiseRegular, SettingsRegular } from "@fluentui/react-icons";
+import { Button, Text, Tooltip, makeStyles, tokens } from "@fluentui/react-components";
+import { ArrowClockwiseRegular, ArrowShuffleRegular, SettingsRegular } from "@fluentui/react-icons";
 
 interface Props {
   sspPath: string | null;
   ghostsLoading: boolean;
   onRefresh: () => void;
   onOpenSettings: () => void;
+  onRandomLaunch: () => Promise<void>;
 }
 
 const useStyles = makeStyles({
@@ -41,9 +42,19 @@ const useStyles = makeStyles({
   },
 });
 
-export const AppHeader = memo(function AppHeader({ sspPath, ghostsLoading, onRefresh, onOpenSettings }: Props) {
+export const AppHeader = memo(function AppHeader({ sspPath, ghostsLoading, onRefresh, onOpenSettings, onRandomLaunch }: Props) {
   const styles = useStyles();
   const { t } = useTranslation();
+  const [randomLaunching, setRandomLaunching] = useState(false);
+
+  const handleRandomLaunch = useCallback(async () => {
+    setRandomLaunching(true);
+    try {
+      await onRandomLaunch();
+    } finally {
+      setRandomLaunching(false);
+    }
+  }, [onRandomLaunch]);
 
   return (
     <header className={styles.header}>
@@ -54,14 +65,25 @@ export const AppHeader = memo(function AppHeader({ sspPath, ghostsLoading, onRef
       </div>
       <div className={styles.headerActions}>
         {sspPath && (
-          <Button
-            icon={<ArrowClockwiseRegular />}
-            appearance="secondary"
-            onClick={onRefresh}
-            disabled={ghostsLoading}
-          >
-            {t("header.refresh")}
-          </Button>
+          <>
+            <Tooltip content={t("header.randomLaunch")} relationship="label">
+              <Button
+                icon={<ArrowShuffleRegular />}
+                appearance="subtle"
+                onClick={handleRandomLaunch}
+                disabled={ghostsLoading || randomLaunching}
+                data-testid="random-launch-button"
+              />
+            </Tooltip>
+            <Button
+              icon={<ArrowClockwiseRegular />}
+              appearance="secondary"
+              onClick={onRefresh}
+              disabled={ghostsLoading}
+            >
+              {t("header.refresh")}
+            </Button>
+          </>
         )}
         <Button icon={<SettingsRegular />} appearance="secondary" onClick={onOpenSettings} data-testid="settings-button">
           {t("header.settings")}

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -1,14 +1,13 @@
-import { memo, useCallback, useState } from "react";
+import { memo } from "react";
 import { useTranslation } from "react-i18next";
-import { Button, Text, Tooltip, makeStyles, tokens } from "@fluentui/react-components";
-import { ArrowClockwiseRegular, ArrowShuffleRegular, SettingsRegular } from "@fluentui/react-icons";
+import { Button, Text, makeStyles, tokens } from "@fluentui/react-components";
+import { ArrowClockwiseRegular, SettingsRegular } from "@fluentui/react-icons";
 
 interface Props {
   sspPath: string | null;
   ghostsLoading: boolean;
   onRefresh: () => void;
   onOpenSettings: () => void;
-  onRandomLaunch: () => Promise<void>;
 }
 
 const useStyles = makeStyles({
@@ -42,19 +41,9 @@ const useStyles = makeStyles({
   },
 });
 
-export const AppHeader = memo(function AppHeader({ sspPath, ghostsLoading, onRefresh, onOpenSettings, onRandomLaunch }: Props) {
+export const AppHeader = memo(function AppHeader({ sspPath, ghostsLoading, onRefresh, onOpenSettings }: Props) {
   const styles = useStyles();
   const { t } = useTranslation();
-  const [randomLaunching, setRandomLaunching] = useState(false);
-
-  const handleRandomLaunch = useCallback(async () => {
-    setRandomLaunching(true);
-    try {
-      await onRandomLaunch();
-    } finally {
-      setRandomLaunching(false);
-    }
-  }, [onRandomLaunch]);
 
   return (
     <header className={styles.header}>
@@ -65,25 +54,14 @@ export const AppHeader = memo(function AppHeader({ sspPath, ghostsLoading, onRef
       </div>
       <div className={styles.headerActions}>
         {sspPath && (
-          <>
-            <Tooltip content={t("header.randomLaunch")} relationship="label">
-              <Button
-                icon={<ArrowShuffleRegular />}
-                appearance="subtle"
-                onClick={handleRandomLaunch}
-                disabled={ghostsLoading || randomLaunching}
-                data-testid="random-launch-button"
-              />
-            </Tooltip>
-            <Button
-              icon={<ArrowClockwiseRegular />}
-              appearance="secondary"
-              onClick={onRefresh}
-              disabled={ghostsLoading}
-            >
-              {t("header.refresh")}
-            </Button>
-          </>
+          <Button
+            icon={<ArrowClockwiseRegular />}
+            appearance="secondary"
+            onClick={onRefresh}
+            disabled={ghostsLoading}
+          >
+            {t("header.refresh")}
+          </Button>
         )}
         <Button icon={<SettingsRegular />} appearance="secondary" onClick={onOpenSettings} data-testid="settings-button">
           {t("header.settings")}

--- a/src/components/GhostCard.tsx
+++ b/src/components/GhostCard.tsx
@@ -14,6 +14,7 @@ import {
 import { PlayRegular } from "@fluentui/react-icons";
 import { getSourceFolderLabel } from "../lib/ghostLaunchUtils";
 import { formatErrorDetail } from "../lib/ghostScanUtils";
+import { recordLaunch } from "../lib/ghostDatabase";
 import type { GhostView } from "../types";
 
 interface Props {
@@ -226,6 +227,9 @@ export const GhostCard = memo(function GhostCard({ ghost, sspPath }: Props) {
         ghostDirectoryName: ghost.directory_name,
         ghostSource: ghost.source,
       });
+      if (ghost.ghost_identity_key) {
+        void recordLaunch(ghost.ghost_identity_key).catch(() => {});
+      }
     } catch (e) {
       setError(t("card.launchError", { detail: formatErrorDetail(e) }));
     } finally {

--- a/src/components/GhostContent.tsx
+++ b/src/components/GhostContent.tsx
@@ -1,7 +1,7 @@
-import { memo } from "react";
+import { memo, useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Button, Dropdown, Option, Text, makeStyles, tokens } from "@fluentui/react-components";
-import { SettingsRegular } from "@fluentui/react-icons";
+import { Button, Dropdown, Option, Text, Tooltip, makeStyles, tokens } from "@fluentui/react-components";
+import { ArrowShuffleRegular, SettingsRegular } from "@fluentui/react-icons";
 import { GhostList } from "./GhostList";
 import { SearchBox } from "./SearchBox";
 import type { GhostView, SortOrder } from "../types";
@@ -18,6 +18,7 @@ interface Props {
   error: string | null;
   onSearchChange: (value: string) => void;
   onSortChange: (value: SortOrder) => void;
+  onRandomLaunch: () => Promise<void>;
   onOpenSettings: () => void;
   onLoadMore: (targetOffset: number) => void;
 }
@@ -72,11 +73,22 @@ export const GhostContent = memo(function GhostContent({
   error,
   onSearchChange,
   onSortChange,
+  onRandomLaunch,
   onOpenSettings,
   onLoadMore,
 }: Props) {
   const styles = useStyles();
   const { t } = useTranslation();
+  const [randomLaunching, setRandomLaunching] = useState(false);
+
+  const handleRandomLaunch = useCallback(async () => {
+    setRandomLaunching(true);
+    try {
+      await onRandomLaunch();
+    } finally {
+      setRandomLaunching(false);
+    }
+  }, [onRandomLaunch]);
 
   if (!sspPath) {
     return (
@@ -109,6 +121,15 @@ export const GhostContent = memo(function GhostContent({
             ))}
           </Dropdown>
         </div>
+        <Tooltip content={t("header.randomLaunch")} relationship="label">
+          <Button
+            icon={<ArrowShuffleRegular />}
+            appearance="subtle"
+            onClick={handleRandomLaunch}
+            disabled={loading || randomLaunching}
+            data-testid="random-launch-button"
+          />
+        </Tooltip>
       </div>
       <div className={styles.content}>
         <GhostList

--- a/src/components/GhostContent.tsx
+++ b/src/components/GhostContent.tsx
@@ -1,10 +1,10 @@
 import { memo } from "react";
 import { useTranslation } from "react-i18next";
-import { Button, Text, makeStyles, tokens } from "@fluentui/react-components";
+import { Button, Dropdown, Option, Text, makeStyles, tokens } from "@fluentui/react-components";
 import { SettingsRegular } from "@fluentui/react-icons";
 import { GhostList } from "./GhostList";
 import { SearchBox } from "./SearchBox";
-import type { GhostView } from "../types";
+import type { GhostView, SortOrder } from "../types";
 
 interface Props {
   ghosts: GhostView[];
@@ -12,19 +12,33 @@ interface Props {
   loadedStart: number;
   sspPath: string | null;
   searchQuery: string;
+  sortOrder: SortOrder;
   loading: boolean;
   searchLoading: boolean;
   error: string | null;
   onSearchChange: (value: string) => void;
+  onSortChange: (value: SortOrder) => void;
   onOpenSettings: () => void;
   onLoadMore: (targetOffset: number) => void;
 }
 
+const SORT_OPTIONS: SortOrder[] = ["name", "recent", "frequency", "random"];
+
 const useStyles = makeStyles({
   toolbar: {
-    display: "block",
-    width: "min(480px, 100%)",
-    minWidth: 0,
+    display: "flex",
+    alignItems: "end",
+    gap: "12px",
+    flexWrap: "wrap",
+  },
+  searchWrapper: {
+    flex: "1 1 auto",
+    minWidth: "200px",
+    maxWidth: "480px",
+  },
+  sortWrapper: {
+    flex: "0 0 auto",
+    minWidth: "140px",
   },
   content: {
     flex: 1,
@@ -52,10 +66,12 @@ export const GhostContent = memo(function GhostContent({
   loadedStart,
   sspPath,
   searchQuery,
+  sortOrder,
   loading,
   searchLoading,
   error,
   onSearchChange,
+  onSortChange,
   onOpenSettings,
   onLoadMore,
 }: Props) {
@@ -76,7 +92,23 @@ export const GhostContent = memo(function GhostContent({
   return (
     <>
       <div className={styles.toolbar}>
-        <SearchBox value={searchQuery} onChange={onSearchChange} />
+        <div className={styles.searchWrapper}>
+          <SearchBox value={searchQuery} onChange={onSearchChange} />
+        </div>
+        <div className={styles.sortWrapper}>
+          <Dropdown
+            aria-label={t("sort.label")}
+            value={t(`sort.${sortOrder}`)}
+            selectedOptions={[sortOrder]}
+            onOptionSelect={(_, data) => {
+              if (data.optionValue) onSortChange(data.optionValue as SortOrder);
+            }}
+          >
+            {SORT_OPTIONS.map((opt) => (
+              <Option key={opt} value={opt}>{t(`sort.${opt}`)}</Option>
+            ))}
+          </Dropdown>
+        </div>
       </div>
       <div className={styles.content}>
         <GhostList

--- a/src/hooks/useSearch.test.ts
+++ b/src/hooks/useSearch.test.ts
@@ -57,7 +57,7 @@ describe("useSearch", () => {
       expect(result.current.ghosts).toHaveLength(2);
     });
 
-    expect(searchGhostsInitialPage).toHaveBeenCalledWith("rk1", 100);
+    expect(searchGhostsInitialPage).toHaveBeenCalledWith("rk1", 100, "name");
     expect(result.current.total).toBe(2);
   });
 
@@ -259,7 +259,7 @@ describe("useSearch", () => {
     });
 
     expect(searchGhostsInitialPage).toHaveBeenCalledTimes(1);
-    expect(searchGhostsInitialPage).toHaveBeenCalledWith("rk1", 100);
+    expect(searchGhostsInitialPage).toHaveBeenCalledWith("rk1", 100, "name");
   });
 
   it("検索でエラーが発生した場合は dbError にメッセージを設定する", async () => {

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -1,16 +1,27 @@
 import { useState, useEffect, useRef } from "react";
-import type { GhostView } from "../types";
+import type { GhostView, SortOrder } from "../types";
 import { countGhostsByQuery, searchGhosts, searchGhostsInitialPage } from "../lib/ghostDatabase";
 
 // バッファの最大サイズ。これを超えるマージは全置換にフォールバックする
 export const MAX_BUFFER_SIZE = 2000;
+
+// Fisher-Yates シャッフル（in-place）
+function shuffleArray<T>(arr: T[]): T[] {
+  const result = [...arr];
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [result[i], result[j]] = [result[j], result[i]];
+  }
+  return result;
+}
 
 export function useSearch(
   requestKey: string | null,
   query: string,
   limit: number,
   offset: number,
-  refreshTrigger: number
+  refreshTrigger: number,
+  sortOrder: SortOrder = "name",
 ): { ghosts: GhostView[]; total: number; loadedStart: number; loading: boolean; dbError: string | null } {
   const [ghosts, setGhosts] = useState<GhostView[]>([]);
   const [total, setTotal] = useState(0);
@@ -25,7 +36,7 @@ export function useSearch(
 
   useEffect(() => {
     let isActive = true;
-    const resetKey = `${requestKey}\0${query}\0${refreshTrigger}`;
+    const resetKey = `${requestKey}\0${query}\0${refreshTrigger}\0${sortOrder}`;
     const isReset = resetKey !== resetKeyRef.current;
 
     async function fetchGhosts() {
@@ -46,8 +57,9 @@ export function useSearch(
         const isInitialLoad = query === "" && offset === 0;
 
         if (isInitialLoad) {
-          const initialGhosts = await searchGhostsInitialPage(requestKey, limit);
+          let initialGhosts = await searchGhostsInitialPage(requestKey, limit, sortOrder);
           if (!isActive) return;
+          if (sortOrder === "random") initialGhosts = shuffleArray(initialGhosts);
 
           resetKeyRef.current = resetKey;
           setGhosts(initialGhosts);
@@ -68,7 +80,8 @@ export function useSearch(
           return;
         }
 
-        const result = await searchGhosts(requestKey, query, limit, offset);
+        const result = await searchGhosts(requestKey, query, limit, offset, sortOrder);
+        if (sortOrder === "random") result.ghosts = shuffleArray(result.ghosts);
         if (!isActive) return;
 
         resetKeyRef.current = resetKey;
@@ -124,7 +137,7 @@ export function useSearch(
     return () => {
       isActive = false;
     };
-  }, [requestKey, query, limit, offset, refreshTrigger]);
+  }, [requestKey, query, limit, offset, refreshTrigger, sortOrder]);
 
   return { ghosts, total, loadedStart, loading, dbError };
 }

--- a/src/lib/ghostDatabase.test.ts
+++ b/src/lib/ghostDatabase.test.ts
@@ -240,8 +240,8 @@ describe("ghostDatabase - searchGhostsInitialPage", () => {
       (c[0] as string).includes("SELECT"));
     expect(call).toBeDefined();
     const sql = call![0] as string;
-    expect(sql).toContain("WHERE request_key = ?");
-    expect(sql).toContain("ORDER BY name_lower ASC");
+    expect(sql).toContain("WHERE g.request_key = ?");
+    expect(sql).toContain("ORDER BY g.name_lower ASC");
     expect(sql).toContain("LIMIT ?");
     expect(sql).not.toContain("LIKE");
     expect(sql).not.toContain("OFFSET");

--- a/src/lib/ghostDatabase.ts
+++ b/src/lib/ghostDatabase.ts
@@ -1,6 +1,6 @@
 import Database from "@tauri-apps/plugin-sql";
 import { invoke } from "@tauri-apps/api/core";
-import { GhostView } from "../types";
+import { GhostView, SortOrder } from "../types";
 import { measureSearch, reportDbSize } from "./dbMonitor";
 
 let dbInitPromise: Promise<Database> | null = null;
@@ -148,7 +148,7 @@ export async function hasGhosts(requestKey: string): Promise<boolean> {
 }
 
 const GHOST_SELECT_COLUMNS =
-  "name, sakura_name, kero_name, craftman, craftmanw, directory_name, path, source, name_lower, sakura_name_lower, kero_name_lower, craftman_lower, craftmanw_lower, directory_name_lower, thumbnail_path, thumbnail_use_self_alpha, thumbnail_kind";
+  "name, sakura_name, kero_name, craftman, craftmanw, directory_name, path, source, name_lower, sakura_name_lower, kero_name_lower, craftman_lower, craftmanw_lower, directory_name_lower, thumbnail_path, thumbnail_use_self_alpha, thumbnail_kind, ghost_identity_key";
 
 const GHOST_SEARCH_LOWER_COLUMNS = [
   "name_lower",
@@ -162,15 +162,39 @@ const GHOST_SEARCH_LOWER_COLUMNS = [
 const GHOST_SEARCH_WHERE =
   GHOST_SEARCH_LOWER_COLUMNS.map((col) => `${col} LIKE ?`).join(" OR ");
 
-export async function searchGhostsInitialPage(requestKey: string, limit: number): Promise<GhostView[]> {
+const GHOST_SELECT_COLUMNS_PREFIXED =
+  GHOST_SELECT_COLUMNS.split(", ").map((c) => `g.${c}`).join(", ");
+
+function buildOrderBy(sortOrder: SortOrder): { orderBy: string; join: string } {
+  switch (sortOrder) {
+    case "recent":
+      return {
+        join: "LEFT JOIN (SELECT ghost_identity_key, MAX(launched_at) AS last_launched FROM ghost_launches GROUP BY ghost_identity_key) gl ON g.ghost_identity_key = gl.ghost_identity_key",
+        orderBy: "gl.last_launched DESC NULLS LAST, g.name_lower ASC",
+      };
+    case "frequency":
+      return {
+        join: "LEFT JOIN (SELECT ghost_identity_key, COUNT(*) AS launch_count FROM ghost_launches GROUP BY ghost_identity_key) gl ON g.ghost_identity_key = gl.ghost_identity_key",
+        orderBy: "gl.launch_count DESC NULLS LAST, g.name_lower ASC",
+      };
+    default:
+      return { join: "", orderBy: "g.name_lower ASC" };
+  }
+}
+
+export async function searchGhostsInitialPage(requestKey: string, limit: number, sortOrder: SortOrder = "name"): Promise<GhostView[]> {
   return measureSearch("searchGhostsInitialPage", async () => {
     const db = await getDb();
+    const { join, orderBy } = buildOrderBy(sortOrder);
+    const from = join
+      ? `ghosts g ${join}`
+      : "ghosts g";
     const rows = await db.select<GhostView[]>(
-      `SELECT ${GHOST_SELECT_COLUMNS} FROM ghosts WHERE request_key = ? ORDER BY name_lower ASC LIMIT ?`,
+      `SELECT ${GHOST_SELECT_COLUMNS_PREFIXED} FROM ${from} WHERE g.request_key = ? ORDER BY ${orderBy} LIMIT ?`,
       [requestKey, limit]
     );
 
-    console.log(`[ghostDatabase] searchGhostsInitialPage(requestKey=${requestKey}, limit=${limit}) → rows=${rows.length}`);
+    console.log(`[ghostDatabase] searchGhostsInitialPage(requestKey=${requestKey}, limit=${limit}, sort=${sortOrder}) → rows=${rows.length}`);
     return rows;
   });
 }
@@ -196,23 +220,43 @@ export async function countGhostsByQuery(requestKey: string, query: string): Pro
   return countResult.length > 0 ? countResult[0].count : 0;
 }
 
-export async function searchGhosts(requestKey: string, query: string, limit: number, offset: number): Promise<{ ghosts: GhostView[], total: number }> {
+export async function searchGhosts(requestKey: string, query: string, limit: number, offset: number, sortOrder: SortOrder = "name"): Promise<{ ghosts: GhostView[], total: number }> {
   return measureSearch("searchGhosts", async () => {
     const db = await getDb();
 
     const normalizedQuery = normalizeForKey(query);
     const likePattern = `%${normalizedQuery}%`;
+    const { join, orderBy } = buildOrderBy(sortOrder);
+    const from = join ? `ghosts g ${join}` : "ghosts g";
+    const searchWhere = GHOST_SEARCH_LOWER_COLUMNS.map((col) => `g.${col} LIKE ?`).join(" OR ");
 
     const [total, rows] = await Promise.all([
       countGhostsByQuery(requestKey, query),
       db.select<GhostView[]>(
-        `SELECT ${GHOST_SELECT_COLUMNS} FROM ghosts WHERE request_key = ? AND (${GHOST_SEARCH_WHERE}) ORDER BY name_lower ASC LIMIT ? OFFSET ?`,
+        `SELECT ${GHOST_SELECT_COLUMNS_PREFIXED} FROM ${from} WHERE g.request_key = ? AND (${searchWhere}) ORDER BY ${orderBy} LIMIT ? OFFSET ?`,
         [requestKey, ...GHOST_SEARCH_LOWER_COLUMNS.map(() => likePattern), limit, offset]
       ),
     ]);
 
-    console.log(`[ghostDatabase] searchGhosts(requestKey=${requestKey}, query="${query}", limit=${limit}, offset=${offset}) → total=${total}`);
+    console.log(`[ghostDatabase] searchGhosts(requestKey=${requestKey}, query="${query}", limit=${limit}, offset=${offset}, sort=${sortOrder}) → total=${total}`);
     console.log(`[ghostDatabase] Fetched ${rows.length} rows`);
     return { ghosts: rows, total };
   });
+}
+
+export async function recordLaunch(ghostIdentityKey: string): Promise<void> {
+  const db = await getDb();
+  await db.execute(
+    "INSERT INTO ghost_launches (ghost_identity_key, launched_at) VALUES (?, datetime('now'))",
+    [ghostIdentityKey]
+  );
+}
+
+export async function getRandomGhost(requestKey: string): Promise<GhostView | null> {
+  const db = await getDb();
+  const rows = await db.select<GhostView[]>(
+    `SELECT ${GHOST_SELECT_COLUMNS_PREFIXED} FROM ghosts g WHERE g.request_key = ? ORDER BY RANDOM() LIMIT 1`,
+    [requestKey]
+  );
+  return rows.length > 0 ? rows[0] : null;
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -36,5 +36,12 @@
   "card.launching": "Launching...",
   "card.launchError": "Failed to launch. Please check SSP folder settings and ghost information, then try again.{{detail}}",
   "search.label": "Search ghosts",
-  "search.placeholder": "Search by name or author"
+  "search.placeholder": "Search by name or author",
+  "sort.label": "Sort by",
+  "sort.name": "Name",
+  "sort.recent": "Recently launched",
+  "sort.frequency": "Most launched",
+  "sort.random": "Random",
+  "header.randomLaunch": "Random launch",
+  "header.randomLaunch.empty": "No ghosts available to launch"
 }

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -35,5 +35,12 @@
   "card.launching": "起動中...",
   "card.launchError": "起動に失敗しました。SSPフォルダ設定とゴースト情報を確認して、再度お試しください。{{detail}}",
   "search.label": "ゴースト検索",
-  "search.placeholder": "ゴースト名・作者名で検索"
+  "search.placeholder": "ゴースト名・作者名で検索",
+  "sort.label": "並び替え",
+  "sort.name": "名前順",
+  "sort.recent": "最近起動した順",
+  "sort.frequency": "起動回数順",
+  "sort.random": "ランダム",
+  "header.randomLaunch": "ランダム起動",
+  "header.randomLaunch.empty": "起動できるゴーストがありません"
 }

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -35,5 +35,12 @@
   "card.launching": "실행 중...",
   "card.launchError": "실행에 실패했습니다. SSP 폴더 설정과 고스트 정보를 확인하고 다시 시도해주세요.{{detail}}",
   "search.label": "고스트 검색",
-  "search.placeholder": "고스트 이름·작가명으로 검색"
+  "search.placeholder": "고스트 이름·작가명으로 검색",
+  "sort.label": "정렬",
+  "sort.name": "이름순",
+  "sort.recent": "최근 실행순",
+  "sort.frequency": "실행 횟수순",
+  "sort.random": "랜덤",
+  "header.randomLaunch": "랜덤 실행",
+  "header.randomLaunch.empty": "실행할 수 있는 고스트가 없습니다"
 }

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -35,5 +35,12 @@
   "card.launching": "Запуск...",
   "card.launchError": "Не удалось запустить. Проверьте настройки папки SSP и информацию о духе, затем попробуйте снова.{{detail}}",
   "search.label": "Поиск духов",
-  "search.placeholder": "Поиск по имени духа или автора"
+  "search.placeholder": "Поиск по имени духа или автора",
+  "sort.label": "Сортировка",
+  "sort.name": "По имени",
+  "sort.recent": "Недавно запущенные",
+  "sort.frequency": "По частоте запуска",
+  "sort.random": "Случайно",
+  "header.randomLaunch": "Случайный запуск",
+  "header.randomLaunch.empty": "Нет доступных духов для запуска"
 }

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -35,5 +35,12 @@
   "card.launching": "启动中...",
   "card.launchError": "启动失败。请检查SSP文件夹设置和幽灵信息后重试。{{detail}}",
   "search.label": "搜索幽灵",
-  "search.placeholder": "按名称或作者搜索"
+  "search.placeholder": "按名称或作者搜索",
+  "sort.label": "排序方式",
+  "sort.name": "名称",
+  "sort.recent": "最近启动",
+  "sort.frequency": "启动次数",
+  "sort.random": "随机",
+  "header.randomLaunch": "随机启动",
+  "header.randomLaunch.empty": "没有可启动的幽灵"
 }

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -35,5 +35,12 @@
   "card.launching": "啟動中...",
   "card.launchError": "啟動失敗。請確認SSP資料夾設定與幽靈資訊後再試一次。{{detail}}",
   "search.label": "搜尋幽靈",
-  "search.placeholder": "以名稱或作者搜尋"
+  "search.placeholder": "以名稱或作者搜尋",
+  "sort.label": "排序方式",
+  "sort.name": "名稱",
+  "sort.recent": "最近啟動",
+  "sort.frequency": "啟動次數",
+  "sort.random": "隨機",
+  "header.randomLaunch": "隨機啟動",
+  "header.randomLaunch.empty": "沒有可啟動的幽靈"
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,8 @@
 
 export type ThumbnailKind = "surface" | "thumbnail" | "";
 
+export type SortOrder = "name" | "recent" | "frequency" | "random";
+
 /** DB クエリ結果。_lower カラムを含み、diff_fingerprint は SELECT 対象外 */
 export interface GhostView {
   name: string;
@@ -21,4 +23,5 @@ export interface GhostView {
   craftman_lower: string;
   craftmanw_lower: string;
   directory_name_lower: string;
+  ghost_identity_key: string;
 }


### PR DESCRIPTION
## Summary

- `ghost_launches` テーブル（migration 11）で起動履歴を記録
- ソートドロップダウン（名前順/最近起動した順/起動回数順/ランダム）を SearchBox 横に配置
- ランダム起動ボタンを AppHeader に追加（`ORDER BY RANDOM() LIMIT 1` で1件取得→即起動）
- GhostCard の起動成功時に `recordLaunch` で履歴を自動記録
- 6言語の翻訳キー追加、CLAUDE.md / e2e/CLAUDE.md のドキュメント更新

Closes #49

## Test plan

- [x] `npm run build` — ビルド成功
- [x] `npm test` — 107/107 通過
- [x] `cargo test --manifest-path src-tauri/Cargo.toml` — 36/36 通過
- [x] `npm run check:ui-guidelines` — 6/6 通過
- [x] `npm run test:ui-guidelines-check` — 6/6 通過
- [ ] `recordLaunch` / `getRandomGhost` / ソートUI の単体テストは別 PR で追加予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)