### PR TITLE
docs: CLAUDE.md の実体整合と依存更新からの学びを反映

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,19 +63,23 @@ ghost_launcher/
 │   └── src/
 │       ├── commands/
 │       │   ├── ghost/          # ゴーストスキャン・フィンガープリント
-│       │   └── ssp.rs          # ゴースト起動コマンド
+│       │   ├── ssp.rs          # ゴースト起動コマンド
+│       │   ├── db.rs           # DB リセット（マイグレーション失敗時の自動回復）
+│       │   └── locale.rs       # ユーザー言語ファイル読込
 │       └── lib.rs              # Tauri アプリビルダー
 ├── crates/ghost-meta/          # ゴーストメタデータ解析クレート
 │   └── src/                    # descript.txt パーサー・ゴースト走査・サムネイル解決
 ├── e2e/                        # E2E テスト → e2e/CLAUDE.md
 │   ├── helpers/
-│   │   └── harness.ts          # tauri-driver 起動・WebDriver セッション管理
+│   │   ├── harness.ts          # tauri-driver 起動・WebDriver セッション管理
+│   │   └── ui.ts               # 共通 UI ヘルパー（waitForAppReady など）
 │   ├── ghost-list.e2e.ts       # ゴースト一覧・検索・スクロールの E2E テスト
 │   └── i18n.e2e.ts             # 言語切り替え・NFKC 正規化の E2E テスト
 ├── docs/
-│   └── ui-guidelines.md        # UI デザインガイドライン
-├── workspace/
-│   └── retrospective.md        # 過去の振り返り
+│   ├── ui-guidelines.md        # UI デザインガイドライン
+│   └── locale-customization.md # ユーザー言語カスタマイズ仕様
+├── Cargo.toml                  # workspace ルート（src-tauri + crates/ghost-meta）
+├── RETROSPECTIVE.md            # 過去の振り返り（サイクル毎に上書き）
 └── SPEC.md                     # 機能仕様書
 ```
 
@@ -190,6 +194,7 @@ GitHub Flow に準拠する。
 
 - `SPEC.md` — 機能仕様書。振る舞いを変更する場合は実装と同期させる
 - `docs/ui-guidelines.md` — UI デザインガイドライン
+- `docs/locale-customization.md` — ユーザー言語カスタマイズ仕様
 - `RETROSPECTIVE.md` — 過去の振り返り（デバッグ教訓・アーキテクチャ上の学び）
   - **更新タイミング**: サイクル終了後（実装・レビュー・追加修正まで完了したとき）
   - **更新方法**: 上書き（追記しない）。前回サイクルの内容を新サイクルの振り返りで置き換える

--- a/e2e/CLAUDE.md
+++ b/e2e/CLAUDE.md
@@ -7,6 +7,7 @@
 - `e2e/helpers/harness.ts` が tauri-driver の起動・WebDriver セッション確立・後片付けを担当
 - E2E テストはリリースビルドが前提（`npm run tauri build` 後に実行）
 - **CI には含まれないため、UI 操作・言語表示・フォーム入力に関わる変更をした場合はローカルで手動実行が必須**
+- **既知の失敗テスト（依存更新と独立した既存問題）**: issue #69（SearchBox placeholder 反映）、#70（スクロール追加読込）。これらの失敗は環境/実装側の課題であり、依存更新後に再発しても deps 起因と即断しないこと
 
 ## 実行方法
 
@@ -18,7 +19,7 @@ npm run e2e:setup
 npm run e2e
 ```
 
-**EdgeDriver と WebView2 Runtime のバージョン整合**: `edgedriver` パッケージは既定でシステム Edge から版を判定する。システム Edge と WebView2 Runtime の版が乖離している環境（Edge 148 だが WebView2 Runtime 147 など）では `SessionNotCreatedError` で全テストが失敗する。WebView2 Runtime の版は次のレジストリから取得できる: `HKLM\SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\ClientState\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}` の `pv` 値。乖離時は `$env:EDGEDRIVER_VERSION = "147.0.3912.98"` のように WebView2 Runtime の版を環境変数で指定してから実行する。
+**EdgeDriver と WebView2 Runtime のバージョン整合**: `edgedriver` パッケージは既定でシステム Edge から版を判定する。システム Edge と WebView2 Runtime の版が乖離している環境（Edge 148 だが WebView2 Runtime 147 など）では `SessionNotCreatedError` で全テストが失敗する。WebView2 Runtime の版は次のレジストリから取得できる: `HKLM\SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\ClientState\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}` の `pv` 値。乖離時は `$env:EDGEDRIVER_VERSION = "147.0.3912.98"` のように WebView2 Runtime の版を環境変数で指定してから実行する。なお `edgedriver` の `download()` は cacheDir 内バイナリを版に関係なく返すため、harness は版指定時のみ `os.tmpdir()/edgedriver-{version}/` をバージョン別 cacheDir として渡す（`harness.ts` 参照）。
 
 ## 記述パターン
 

--- a/src-tauri/CLAUDE.md
+++ b/src-tauri/CLAUDE.md
@@ -30,6 +30,8 @@
 
 ## その他
 
+**rusqlite と sqlx-sqlite の libsqlite3-sys 共有制約**: `rusqlite` と `sqlx-sqlite`（`tauri-plugin-sql` 経由）は両方とも `links = "sqlite3"` を宣言するため、`libsqlite3-sys` を必ず同一バージョンで共有しなければならない（cargo の links 制約）。`tauri-plugin-sql` 2.4.0 系は `sqlx-sqlite 0.8.x`（libsqlite3-sys ^0.30）に固定されているため、`rusqlite` の上限は **0.32**（libsqlite3-sys 0.30）。`rusqlite` の major bump は `tauri-plugin-sql` が新 `sqlx`（libsqlite3-sys 0.37+）系に追従するまで待機する。
+
 **descript.txt 文字コード判定**: UTF-8 BOM → `charset` フィールド → Shift_JIS フォールバックの順で判定します（`crates/ghost-meta/src/descript.rs`）。
 
 **ファイルシステム操作の OS 差異**: macOS と Windows の挙動差に注意。`entry.metadata()` は Windows FindNextFile キャッシュを参照し陳腐化する場合がある。`fs::metadata(path)` は常に最新値を返す。


### PR DESCRIPTION
## Summary

CLAUDE.md 監査で見つかった実体との乖離を修正し、本日の依存更新（PR #71）で得た非自明な制約を記録。

### 変更ファイル

- **`CLAUDE.md`**（ルート）: ディレクトリツリーが実体と乖離していた箇所を修正
  - `src-tauri/src/commands/` 配下に `db.rs` / `locale.rs` を追記
  - `e2e/helpers/ui.ts` を追記
  - `docs/locale-customization.md` を追記
  - `workspace/retrospective.md`（存在しない）→ ルートの `RETROSPECTIVE.md` へ修正
  - `Cargo.toml`（workspace ルート）への言及を追加
  - 参照ドキュメント節にも `docs/locale-customization.md` を追加

- **`src-tauri/CLAUDE.md`**: rusqlite と sqlx-sqlite が共に `links = "sqlite3"` を宣言する cargo 制約を追記。`tauri-plugin-sql` 2.4.0 系では `rusqlite` の上限が **0.32**（libsqlite3-sys 0.30）であることを明文化

- **`e2e/CLAUDE.md`**: 既知の失敗テスト（#69 SearchBox placeholder、#70 スクロール追加読込）への参照。`edgedriver` の cacheDir 挙動と版別ディレクトリ分離の理由を補足

## Test plan

ドキュメントのみのため `npm run build` / `npm test` / `cargo test` への影響なし。

- [x] CLAUDE.md 内のファイルパスが実体と一致することを `Glob` で確認
- [x] 参照リンク先（`docs/locale-customization.md`、`RETROSPECTIVE.md`）が存在することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)