### PR TITLE
chore: 依存パッケージの更新（npm semver 内・cargo lock）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,9 +122,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base64"
@@ -167,9 +167,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 dependencies = [
  "serde_core",
 ]
@@ -230,9 +230,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "8.0.2"
+version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+checksum = "8119e4516436f5708bbc474a9d395bf12f1b5395e93a92a56e647ac3388c8610"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -241,19 +241,28 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.0"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+checksum = "5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.20.2"
+name = "bs58"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytecheck"
@@ -310,7 +319,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "cairo-sys-rs",
  "glib",
  "libc",
@@ -373,9 +382,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -489,7 +498,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "core-foundation",
  "core-graphics-types",
  "foreign-types",
@@ -502,7 +511,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "core-foundation",
  "libc",
 ]
@@ -758,7 +767,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "block2",
  "libc",
  "objc2",
@@ -766,9 +775,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -872,9 +881,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 dependencies = [
  "serde",
 ]
@@ -1368,7 +1377,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -1588,9 +1597,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1633,9 +1642,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1949,9 +1958,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1987,7 +1996,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "serde",
  "unicode-segmentation",
 ]
@@ -2064,14 +2073,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "libc",
  "plain",
- "redox_syscall 0.7.5",
+ "redox_syscall 0.8.1",
 ]
 
 [[package]]
@@ -2102,9 +2111,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
 
 [[package]]
 name = "markup5ever"
@@ -2129,9 +2138,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memoffset"
@@ -2160,9 +2169,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -2181,9 +2190,9 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ae8844f63b5b118e334e205585b8c5c17b984121dbdb179d44aeb087ffad3cb"
+checksum = "47a2e3dff89cd322c66647942668faee0a2b1f88ea6cbb4d374b4a8d7e92528c"
 dependencies = [
  "crossbeam-channel",
  "dpi",
@@ -2206,7 +2215,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "jni-sys 0.3.1",
  "log",
  "ndk-sys",
@@ -2248,9 +2257,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -2320,7 +2329,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "block2",
  "objc2",
  "objc2-core-foundation",
@@ -2333,7 +2342,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -2354,7 +2363,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "dispatch2",
  "objc2",
 ]
@@ -2365,7 +2374,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -2398,7 +2407,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -2425,7 +2434,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "block2",
  "libc",
  "objc2",
@@ -2438,7 +2447,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2449,7 +2458,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
@@ -2461,7 +2470,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "block2",
  "objc2",
  "objc2-cloud-kit",
@@ -2492,7 +2501,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "block2",
  "objc2",
  "objc2-app-kit",
@@ -2705,7 +2714,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -2778,7 +2787,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.11+spec-1.1.0",
+ "toml_edit 0.25.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -2938,16 +2947,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.5"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
+checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
 ]
 
 [[package]]
@@ -3021,9 +3030,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3132,7 +3141,7 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink 0.9.1",
@@ -3262,7 +3271,7 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "cssparser",
  "derive_more",
  "log",
@@ -3340,9 +3349,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -3394,11 +3403,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.19.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "base64 0.22.1",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -3413,9 +3423,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.19.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3478,9 +3488,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signature"
@@ -3527,9 +3537,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -3698,7 +3708,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "byteorder",
  "bytes",
  "crc",
@@ -3743,7 +3753,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "byteorder",
  "crc",
  "dotenvy",
@@ -3922,11 +3932,11 @@ dependencies = [
 
 [[package]]
 name = "tao"
-version = "0.35.2"
+version = "0.35.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33f7f9e486ade65fcf1e45c440f9236c904f5c1002cdc7fc6ae582777345ce4"
+checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "block2",
  "core-foundation",
  "core-graphics",
@@ -3985,9 +3995,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tauri"
-version = "2.11.1"
+version = "2.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b93bd86d231f0a8138f11a02a584769fe4b703dc36ae133d783228dbc4801405"
+checksum = "437404997acf375d85f1177afa7e11bb971f274ed6a7b83a2a3e339015f4cc28"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4037,9 +4047,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "2.6.1"
+version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a318b234cc2dea65f575467bafcfb76286bce228ebc3778e337d61d03213007"
+checksum = "4aa1f9055fc23919a54e4e125052bed16ed04aef0487086e758fe01a67b451c7"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -4058,9 +4068,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-codegen"
-version = "2.6.1"
+version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd11644962add2549a60b7e7c6800f17d7020156e02f516021d8103e80cc528"
+checksum = "e4a0319528a025a38c4078e7dae2c446f4e63620ddb0659a643ede1cb38f90e9"
 dependencies = [
  "base64 0.22.1",
  "brotli",
@@ -4085,9 +4095,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.6.1"
+version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed9d3742a37a355d2e47c9af924e9fbc112abb76f9835d35d4780e318419502"
+checksum = "ae6cb4e3896c21d2f6da5b31251d2faea0153bba56ed0e970f918115dbee4924"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -4099,9 +4109,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin"
-version = "2.6.1"
+version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eefb2c18e8a605c23edb48fc56bb77381199e1a1e7f6ff0c9b970afe7b3cb8ee"
+checksum = "e126abc9e84e35cdfd01596140a73a1850cdb0df0a23acf0185776c30b469a6e"
 dependencies = [
  "anyhow",
  "glob",
@@ -4198,7 +4208,7 @@ version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "log",
  "serde",
  "serde_json",
@@ -4209,9 +4219,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "2.11.1"
+version = "2.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fef478ba1d2ac21c2d528740b24d0cb315e1e8b1111aae53fafac34804371fc"
+checksum = "48222d7116c8807eaa6fe2f372e023fae125084e61e6eca6d70b7961cdf129ef"
 dependencies = [
  "cookie",
  "dpi",
@@ -4234,9 +4244,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.11.1"
+version = "2.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3989df2ae1c476404fe0a2e8ffc4cfbde97e51efd613c2bb5355fbc9ab52cf0"
+checksum = "b83849ee63ecb27a8e8d0fe51915ca215076914aca43f96db1179f0f415f6cd9"
 dependencies = [
  "gtk",
  "http",
@@ -4260,9 +4270,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.9.1"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d57200389a2f82b4b0a40ae29ca19b6978116e8f4d4e974c3234ce40c0ffbdec"
+checksum = "092379df9a707631978e6c56b1bc2401d387f01e2d4a3c123360d167bbb9aa95"
 dependencies = [
  "anyhow",
  "brotli",
@@ -4511,7 +4521,7 @@ dependencies = [
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -4567,14 +4577,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -4583,7 +4593,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -4609,11 +4619,11 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "bytes",
  "futures-util",
  "http",
@@ -4727,9 +4737,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unic-char-property"
@@ -4801,9 +4811,9 @@ checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-xid"
@@ -4850,9 +4860,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -4949,9 +4959,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4963,9 +4973,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.71"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4973,9 +4983,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4983,9 +4993,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4996,9 +5006,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -5044,7 +5054,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
@@ -5052,9 +5062,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5670,9 +5680,9 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -5751,7 +5761,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "indexmap 2.14.0",
  "log",
  "serde",
@@ -5886,18 +5896,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5906,9 +5916,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,37 +8,37 @@
       "name": "ghost-launcher",
       "version": "0.1.0",
       "dependencies": {
-        "@fluentui/react-components": "^9.73.8",
-        "@fluentui/react-icons": "^2.0.326",
+        "@fluentui/react-components": "^9.74.1",
+        "@fluentui/react-icons": "^2.0.328",
         "@tauri-apps/api": "^2.11.0",
         "@tauri-apps/plugin-dialog": "^2.7.1",
         "@tauri-apps/plugin-sql": "^2.4.0",
         "@tauri-apps/plugin-store": "^2.4.3",
-        "i18next": "^26.0.10",
-        "react": "^19.2.6",
-        "react-dom": "^19.2.6",
-        "react-i18next": "^17.0.7"
+        "i18next": "^26.3.0",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
+        "react-i18next": "^17.0.8"
       },
       "devDependencies": {
-        "@playwright/test": "^1.59.1",
-        "@tauri-apps/cli": "^2.11.1",
+        "@playwright/test": "^1.60.0",
+        "@tauri-apps/cli": "^2.11.2",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
-        "@types/react": "^19.2.14",
+        "@types/react": "^19.2.16",
         "@types/react-dom": "^19.2.3",
-        "@vitejs/plugin-react": "^6.0.1",
+        "@vitejs/plugin-react": "^6.0.2",
         "edgedriver": "^6.3.0",
         "jsdom": "^29.1.1",
-        "selenium-webdriver": "^4.43.0",
+        "selenium-webdriver": "^4.44.0",
         "typescript": "^6.0.3",
-        "vite": "^8.0.11",
-        "vitest": "^4.1.5"
+        "vite": "^8.0.16",
+        "vitest": "^4.1.8"
       }
     },
     "node_modules/@adobe/css-tools": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
-      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -94,14 +94,14 @@
       "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -110,9 +110,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -121,9 +121,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -170,9 +170,9 @@
       }
     },
     "node_modules/@csstools/css-calc": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
-      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
       "dev": true,
       "funding": [
         {
@@ -194,9 +194,9 @@
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
-      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
       "dev": true,
       "funding": [
         {
@@ -211,7 +211,7 @@
       "license": "MIT",
       "dependencies": {
         "@csstools/color-helpers": "^6.0.2",
-        "@csstools/css-calc": "^3.2.0"
+        "@csstools/css-calc": "^3.2.1"
       },
       "engines": {
         "node": ">=20.19.0"
@@ -245,9 +245,9 @@
       }
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
-      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.4.tgz",
+      "integrity": "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==",
       "dev": true,
       "funding": [
         {
@@ -339,9 +339,9 @@
       "license": "MIT"
     },
     "node_modules/@exodus/bytes": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
-      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -409,21 +409,21 @@
       }
     },
     "node_modules/@fluentui/react-accordion": {
-      "version": "9.11.0",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-accordion/-/react-accordion-9.11.0.tgz",
-      "integrity": "sha512-mEy73hbJM53tMj3MWqm3ajbBxj48uubnJjumVKI8Z/eXHS8L3GzUy5rf/gUH26xSR2Tl+edpFhYB8PFbJDIKKw==",
+      "version": "9.12.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-accordion/-/react-accordion-9.12.0.tgz",
+      "integrity": "sha512-Ay1Cet3qTdpcHQErelG/6tSAhaNCkCojZzNzhpET25ukiMNFeJVK/j/kQbrcjbdClYdz35+8/3hI8q6hSIPD/Q==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-aria": "^9.17.11",
-        "@fluentui/react-context-selector": "^9.2.16",
+        "@fluentui/react-aria": "^9.17.12",
+        "@fluentui/react-context-selector": "^9.2.17",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-motion": "^9.15.0",
-        "@fluentui/react-motion-components-preview": "^0.15.4",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-motion": "^9.16.0",
+        "@fluentui/react-motion-components-preview": "^0.15.5",
         "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
+        "@fluentui/react-tabster": "^9.26.15",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -435,18 +435,18 @@
       }
     },
     "node_modules/@fluentui/react-alert": {
-      "version": "9.0.0-beta.139",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-alert/-/react-alert-9.0.0-beta.139.tgz",
-      "integrity": "sha512-R9r4dwwpWpgFmB8wVeWqipjUh/e6lyacnerX39HtVdgcG/PE+kpdHjKGiy8MAD+BGYCzrUxKNhXTQDlpXasJ1Q==",
+      "version": "9.0.0-beta.140",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-alert/-/react-alert-9.0.0-beta.140.tgz",
+      "integrity": "sha512-IYrS7qNyN6FFya+FBdyHZU3jA+6xcU7SD1FjFbthZMx2QTYN7wnZGUdIRQQc3BQRRwRNWtH2BEF4RZY20TvfWQ==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-avatar": "^9.11.1",
-        "@fluentui/react-button": "^9.9.1",
+        "@fluentui/react-avatar": "^9.11.2",
+        "@fluentui/react-button": "^9.9.2",
         "@fluentui/react-icons": "^2.0.239",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-tabster": "^9.26.14",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-tabster": "^9.26.15",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -458,16 +458,16 @@
       }
     },
     "node_modules/@fluentui/react-aria": {
-      "version": "9.17.11",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-aria/-/react-aria-9.17.11.tgz",
-      "integrity": "sha512-K9nz+Wn5JliCpG6bIYYPXvKmpOql+w9uyzmYNYkYQ6QHgoCpph7XUFx1HCtsJm2PPNi8WO8g0ZV9jojdGKl1Tg==",
+      "version": "9.17.12",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-aria/-/react-aria-9.17.12.tgz",
+      "integrity": "sha512-Nrgj9ND3nqtr33w0ICXs3/VrtSBZNBoFl9FkeWz3SCUeUcC8A9eFIH2HpHjbgwENs9BV+aUPi2J2vZhX1+yqQg==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
         "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-tabster": "^9.26.15",
+        "@fluentui/react-utilities": "^9.26.4",
         "@swc/helpers": "^0.5.1"
       },
       "peerDependencies": {
@@ -478,21 +478,21 @@
       }
     },
     "node_modules/@fluentui/react-avatar": {
-      "version": "9.11.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-avatar/-/react-avatar-9.11.1.tgz",
-      "integrity": "sha512-y1T67rVQQ/D4FAod8F4crXo9funaptscRIiW81LAsbN82fFVexMPQ9GmXooQQvn6ILvjJtf9IyvSJ195qDsyag==",
+      "version": "9.11.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-avatar/-/react-avatar-9.11.2.tgz",
+      "integrity": "sha512-OGGrpQBKbIfbX5ZDfZezCR2i1TErNopam0rUowuUl/etaiXv6Q8+1qdDPisJUR3OJJkSIXmiDhjdgJ+z/f7nFA==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-badge": "^9.5.2",
-        "@fluentui/react-context-selector": "^9.2.16",
+        "@fluentui/react-badge": "^9.5.3",
+        "@fluentui/react-context-selector": "^9.2.17",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-popover": "^9.14.2",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-popover": "^9.14.3",
         "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
+        "@fluentui/react-tabster": "^9.26.15",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-tooltip": "^9.10.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-tooltip": "^9.10.2",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -504,16 +504,16 @@
       }
     },
     "node_modules/@fluentui/react-badge": {
-      "version": "9.5.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-badge/-/react-badge-9.5.2.tgz",
-      "integrity": "sha512-+UPAK9dCD6Gx+LWr6vqKMIbYOPf7oXX+GXRtCJ5fekCTHD0VgIWuIMuEtxVrHpJQdb2VNaZadY8/dMomk2JaXw==",
+      "version": "9.5.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-badge/-/react-badge-9.5.3.tgz",
+      "integrity": "sha512-pMvzFTrMP/CvgDzne281pXyrBjSeiFwKRYuAa9Y1NkqK+H5wI0U/SsZu81mAuUA7vRxxqHkqtp5J2/huVK1yEQ==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
         "@fluentui/react-shared-contexts": "^9.26.2",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -525,20 +525,20 @@
       }
     },
     "node_modules/@fluentui/react-breadcrumb": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-breadcrumb/-/react-breadcrumb-9.4.1.tgz",
-      "integrity": "sha512-XgUB1yv04GdcL/6kUo6kh+BaN4df1A/Ds/fL1QxNrm5E26Vmvvlc0LN0WV/qb5qhKx0NwhtIXgOZHjfzyt7iCA==",
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-breadcrumb/-/react-breadcrumb-9.4.2.tgz",
+      "integrity": "sha512-IpLlrQkvFnQ7kMzRaVn6lmfb6gDUwRtnMDfhLTfUiJkisvuqdZGeilGTH1Yx4JLqBzCQGnRHMjcYm1DcrwX4aQ==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-aria": "^9.17.11",
-        "@fluentui/react-button": "^9.9.1",
+        "@fluentui/react-aria": "^9.17.12",
+        "@fluentui/react-button": "^9.9.2",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-link": "^9.8.1",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-link": "^9.8.2",
         "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
+        "@fluentui/react-tabster": "^9.26.15",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -550,19 +550,19 @@
       }
     },
     "node_modules/@fluentui/react-button": {
-      "version": "9.9.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-button/-/react-button-9.9.1.tgz",
-      "integrity": "sha512-WNzpseiVbqEKKevTkAnyHNoK/8ktYPE6rvf31gGvSDnBBclqfrn4PSYG2ppi+Z7abmClnaNFxpp1OHuOoVQ8Bg==",
+      "version": "9.9.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-button/-/react-button-9.9.2.tgz",
+      "integrity": "sha512-zQ6EuJCb3hQ7d62lrn+wI3C9ugbi3M1d98SjOmj4WW/xG9gOKIZ+xjg6AYtAm7L94I/6JZbe5al2NvtejQWsHw==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-aria": "^9.17.11",
+        "@fluentui/react-aria": "^9.17.12",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
         "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
+        "@fluentui/react-tabster": "^9.26.15",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -574,18 +574,18 @@
       }
     },
     "node_modules/@fluentui/react-card": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-card/-/react-card-9.6.1.tgz",
-      "integrity": "sha512-KBijjAxi0mBDSgnA1OCglqAVWc+Q0L7A2wCokszX/53oqfJPSvWxWFma7esz9b5MF/kdRrAR0vmy7MiosepNLQ==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-card/-/react-card-9.7.0.tgz",
+      "integrity": "sha512-OWfkDlCNbxbap5W5TIc+fpSEWnArug2+47yYx2DnSiUkJ+/bSdqBvGAPlQjlONV/fuA/HPWBpsni4Ao9nZicqg==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
         "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-text": "^9.6.16",
+        "@fluentui/react-tabster": "^9.26.15",
+        "@fluentui/react-text": "^9.6.17",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -597,21 +597,21 @@
       }
     },
     "node_modules/@fluentui/react-carousel": {
-      "version": "9.9.7",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-carousel/-/react-carousel-9.9.7.tgz",
-      "integrity": "sha512-lummYk+tASL/rM/SXWruoqhUAyJjTiOMgiCz55ncE3q2pSZe/EbsV5WfRw5B3y7pHX8xLusN831TBgUthj/sUw==",
+      "version": "9.9.8",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-carousel/-/react-carousel-9.9.8.tgz",
+      "integrity": "sha512-NaC7SVZF+dk1xV9FU9hsqQvoXrAzP6KMEcbzW7HLrQfM/qDyA2ERyYPZXeho24mvg4KXDalzEBwHxctASsA8iw==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-aria": "^9.17.11",
-        "@fluentui/react-button": "^9.9.1",
-        "@fluentui/react-context-selector": "^9.2.16",
+        "@fluentui/react-aria": "^9.17.12",
+        "@fluentui/react-button": "^9.9.2",
+        "@fluentui/react-context-selector": "^9.2.17",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
         "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
+        "@fluentui/react-tabster": "^9.26.15",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-tooltip": "^9.10.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-tooltip": "^9.10.2",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1",
         "embla-carousel": "^8.5.1",
@@ -626,19 +626,19 @@
       }
     },
     "node_modules/@fluentui/react-checkbox": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-checkbox/-/react-checkbox-9.6.1.tgz",
-      "integrity": "sha512-Rsf3TmcNrzLuHan9lyUFUmMZnNyvS7DV8C4Vc9lZnZTFRBo94GRMGzu0BcWKFbr3cCDT/r5RmIyQYz0kc7Jd2w==",
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-checkbox/-/react-checkbox-9.6.2.tgz",
+      "integrity": "sha512-ONIvYhhIdwAuPD4V5CZYXXjeq0lAtpiwU0PSFP5JAabYrmPVnBALe8km1QFTSnz2pN70AfQsOm92n6PCUFbyrg==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-field": "^9.5.1",
+        "@fluentui/react-field": "^9.5.2",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-label": "^9.4.1",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-label": "^9.4.2",
         "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
+        "@fluentui/react-tabster": "^9.26.15",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -650,18 +650,18 @@
       }
     },
     "node_modules/@fluentui/react-color-picker": {
-      "version": "9.2.16",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-color-picker/-/react-color-picker-9.2.16.tgz",
-      "integrity": "sha512-+H8Ea8dwoSeUCTLRpUiGLrRsNvBnlHplnwJPU0isp8jdAfrIM/savZTLj6o4rqNFpNHQqAXxGwNuUV9YfHoJuQ==",
+      "version": "9.2.17",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-color-picker/-/react-color-picker-9.2.17.tgz",
+      "integrity": "sha512-cp9WdlrP2miMVNn5s1vjNqJCumezP/OWwGI0TV9tRMO0DvGQ8R1xwbVxxTH/C/wsMYrVIHiJaagQ5U6nzk6XLw==",
       "license": "MIT",
       "dependencies": {
         "@ctrl/tinycolor": "^3.3.4",
-        "@fluentui/react-context-selector": "^9.2.16",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
+        "@fluentui/react-context-selector": "^9.2.17",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
         "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
+        "@fluentui/react-tabster": "^9.26.15",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -673,23 +673,23 @@
       }
     },
     "node_modules/@fluentui/react-combobox": {
-      "version": "9.17.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-combobox/-/react-combobox-9.17.1.tgz",
-      "integrity": "sha512-ezgt6tfOKd3wlG6IHvWl0TPNPpfHRtnEwC2kuqHYH/r1nMNp9edFi8Ya3+1eM7oxai19XW0swt69GPwRu51FVQ==",
+      "version": "9.17.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-combobox/-/react-combobox-9.17.2.tgz",
+      "integrity": "sha512-uYFelRhb+3BOwAIm4lvCfvrIBBi2Q5A66jzTXwZaH4rg5wrTWkpv+eSVkHF5gfcxzoEYRy1Ze2Tf1B2DtYYJyQ==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-aria": "^9.17.11",
-        "@fluentui/react-context-selector": "^9.2.16",
-        "@fluentui/react-field": "^9.5.1",
+        "@fluentui/react-aria": "^9.17.12",
+        "@fluentui/react-context-selector": "^9.2.17",
+        "@fluentui/react-field": "^9.5.2",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-portal": "^9.8.12",
-        "@fluentui/react-positioning": "^9.22.1",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-portal": "^9.8.13",
+        "@fluentui/react-positioning": "^9.22.2",
         "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
+        "@fluentui/react-tabster": "^9.26.15",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -701,71 +701,71 @@
       }
     },
     "node_modules/@fluentui/react-components": {
-      "version": "9.73.8",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-components/-/react-components-9.73.8.tgz",
-      "integrity": "sha512-JG4KQjEvRRfPlh4yt6Rv1/k87ydM2y49r5XPNCnuYHahA7kEM+dY8JdOI7n7FW8bdcvZ7qt4smDrQ2XcPfmxlA==",
+      "version": "9.74.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-components/-/react-components-9.74.1.tgz",
+      "integrity": "sha512-N7BDd3g3A/ngxq8LKLD9ovd+3eHlOgo6R6QFPxA5pVYvznGSQlg00zQ2WxMz7jxQ8ADdPZYIsc7cfg80og3ckw==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-accordion": "^9.11.0",
-        "@fluentui/react-alert": "9.0.0-beta.139",
-        "@fluentui/react-aria": "^9.17.11",
-        "@fluentui/react-avatar": "^9.11.1",
-        "@fluentui/react-badge": "^9.5.2",
-        "@fluentui/react-breadcrumb": "^9.4.1",
-        "@fluentui/react-button": "^9.9.1",
-        "@fluentui/react-card": "^9.6.1",
-        "@fluentui/react-carousel": "^9.9.7",
-        "@fluentui/react-checkbox": "^9.6.1",
-        "@fluentui/react-color-picker": "^9.2.16",
-        "@fluentui/react-combobox": "^9.17.1",
-        "@fluentui/react-dialog": "^9.18.0",
-        "@fluentui/react-divider": "^9.7.1",
-        "@fluentui/react-drawer": "^9.12.0",
-        "@fluentui/react-field": "^9.5.1",
-        "@fluentui/react-image": "^9.4.1",
-        "@fluentui/react-infobutton": "9.0.0-beta.115",
-        "@fluentui/react-infolabel": "^9.4.20",
-        "@fluentui/react-input": "^9.8.2",
-        "@fluentui/react-label": "^9.4.1",
-        "@fluentui/react-link": "^9.8.1",
-        "@fluentui/react-list": "^9.6.14",
-        "@fluentui/react-menu": "^9.24.1",
-        "@fluentui/react-message-bar": "^9.7.0",
-        "@fluentui/react-motion": "^9.15.0",
-        "@fluentui/react-nav": "^9.3.24",
-        "@fluentui/react-overflow": "^9.7.2",
-        "@fluentui/react-persona": "^9.7.3",
-        "@fluentui/react-popover": "^9.14.2",
-        "@fluentui/react-portal": "^9.8.12",
-        "@fluentui/react-positioning": "^9.22.1",
-        "@fluentui/react-progress": "^9.5.1",
-        "@fluentui/react-provider": "^9.22.16",
-        "@fluentui/react-radio": "^9.6.2",
-        "@fluentui/react-rating": "^9.4.1",
-        "@fluentui/react-search": "^9.4.2",
-        "@fluentui/react-select": "^9.5.1",
+        "@fluentui/react-accordion": "^9.12.0",
+        "@fluentui/react-alert": "9.0.0-beta.140",
+        "@fluentui/react-aria": "^9.17.12",
+        "@fluentui/react-avatar": "^9.11.2",
+        "@fluentui/react-badge": "^9.5.3",
+        "@fluentui/react-breadcrumb": "^9.4.2",
+        "@fluentui/react-button": "^9.9.2",
+        "@fluentui/react-card": "^9.7.0",
+        "@fluentui/react-carousel": "^9.9.8",
+        "@fluentui/react-checkbox": "^9.6.2",
+        "@fluentui/react-color-picker": "^9.2.17",
+        "@fluentui/react-combobox": "^9.17.2",
+        "@fluentui/react-dialog": "^9.18.1",
+        "@fluentui/react-divider": "^9.7.2",
+        "@fluentui/react-drawer": "^9.13.0",
+        "@fluentui/react-field": "^9.5.2",
+        "@fluentui/react-image": "^9.4.2",
+        "@fluentui/react-infobutton": "9.0.0-beta.116",
+        "@fluentui/react-infolabel": "^9.4.21",
+        "@fluentui/react-input": "^9.8.3",
+        "@fluentui/react-label": "^9.4.2",
+        "@fluentui/react-link": "^9.8.2",
+        "@fluentui/react-list": "^9.6.15",
+        "@fluentui/react-menu": "^9.25.0",
+        "@fluentui/react-message-bar": "^9.7.1",
+        "@fluentui/react-motion": "^9.16.0",
+        "@fluentui/react-nav": "^9.4.0",
+        "@fluentui/react-overflow": "^9.8.0",
+        "@fluentui/react-persona": "^9.7.4",
+        "@fluentui/react-popover": "^9.14.3",
+        "@fluentui/react-portal": "^9.8.13",
+        "@fluentui/react-positioning": "^9.22.2",
+        "@fluentui/react-progress": "^9.5.2",
+        "@fluentui/react-provider": "^9.22.17",
+        "@fluentui/react-radio": "^9.6.3",
+        "@fluentui/react-rating": "^9.4.2",
+        "@fluentui/react-search": "^9.4.3",
+        "@fluentui/react-select": "^9.5.2",
         "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-skeleton": "^9.7.2",
-        "@fluentui/react-slider": "^9.6.2",
-        "@fluentui/react-spinbutton": "^9.6.2",
-        "@fluentui/react-spinner": "^9.8.2",
-        "@fluentui/react-swatch-picker": "^9.5.2",
-        "@fluentui/react-switch": "^9.7.2",
-        "@fluentui/react-table": "^9.19.15",
-        "@fluentui/react-tabs": "^9.12.1",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-tag-picker": "^9.8.6",
-        "@fluentui/react-tags": "^9.8.1",
-        "@fluentui/react-teaching-popover": "^9.6.21",
-        "@fluentui/react-text": "^9.6.16",
-        "@fluentui/react-textarea": "^9.7.2",
+        "@fluentui/react-skeleton": "^9.7.3",
+        "@fluentui/react-slider": "^9.6.3",
+        "@fluentui/react-spinbutton": "^9.6.3",
+        "@fluentui/react-spinner": "^9.8.3",
+        "@fluentui/react-swatch-picker": "^9.5.3",
+        "@fluentui/react-switch": "^9.7.3",
+        "@fluentui/react-table": "^9.19.16",
+        "@fluentui/react-tabs": "^9.12.2",
+        "@fluentui/react-tabster": "^9.26.15",
+        "@fluentui/react-tag-picker": "^9.8.8",
+        "@fluentui/react-tags": "^9.9.1",
+        "@fluentui/react-teaching-popover": "^9.7.0",
+        "@fluentui/react-text": "^9.6.17",
+        "@fluentui/react-textarea": "^9.7.3",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-toast": "^9.7.17",
-        "@fluentui/react-toolbar": "^9.8.0",
-        "@fluentui/react-tooltip": "^9.10.1",
-        "@fluentui/react-tree": "^9.16.0",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@fluentui/react-virtualizer": "9.0.0-alpha.112",
+        "@fluentui/react-toast": "^9.8.0",
+        "@fluentui/react-toolbar": "^9.8.1",
+        "@fluentui/react-tooltip": "^9.10.2",
+        "@fluentui/react-tree": "^9.16.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@fluentui/react-virtualizer": "9.0.0-alpha.113",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -777,12 +777,12 @@
       }
     },
     "node_modules/@fluentui/react-context-selector": {
-      "version": "9.2.16",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.16.tgz",
-      "integrity": "sha512-D+/X2liT+eZe0rzXbwddPH333ml2SXz71biR13aeyGJQr8+W+icMAIsYhpwk0CC3KtJ3f1/CLTm7vcIrvqsJ4g==",
+      "version": "9.2.17",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.17.tgz",
+      "integrity": "sha512-pZGIz8vjK9nxHKmztV7y5T8yHseoTjm3a43TdPN6fhup0tlrGE/JUmVFEwulI3j4fMWqa0P2OhJoe+HrDMs44Q==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@swc/helpers": "^0.5.1"
       },
       "peerDependencies": {
@@ -794,23 +794,23 @@
       }
     },
     "node_modules/@fluentui/react-dialog": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-dialog/-/react-dialog-9.18.0.tgz",
-      "integrity": "sha512-i+V2o0NJ1itjVADJFov5AR/JetpD2hCMiLye0vfi3/XsFMgEPZnGzILVxPCO/ovULTiCyThcL1UvY0d/PYrZfA==",
+      "version": "9.18.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-dialog/-/react-dialog-9.18.1.tgz",
+      "integrity": "sha512-tvi5MgUXY6yOySfKSEJobeBNwK3BOXVjRInxDz3ZM7g7FMMyzuf9HrXK/7caqMNRA9uQEQKFXKI9zD03L0kyPA==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-aria": "^9.17.11",
-        "@fluentui/react-context-selector": "^9.2.16",
+        "@fluentui/react-aria": "^9.17.12",
+        "@fluentui/react-context-selector": "^9.2.17",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-motion": "^9.15.0",
-        "@fluentui/react-motion-components-preview": "^0.15.4",
-        "@fluentui/react-portal": "^9.8.12",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-motion": "^9.16.0",
+        "@fluentui/react-motion-components-preview": "^0.15.5",
+        "@fluentui/react-portal": "^9.8.13",
         "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
+        "@fluentui/react-tabster": "^9.26.15",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -822,15 +822,15 @@
       }
     },
     "node_modules/@fluentui/react-divider": {
-      "version": "9.7.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-divider/-/react-divider-9.7.1.tgz",
-      "integrity": "sha512-ptymE6iADb/ugezulaMeoAfGxKSwOjHEHBh8N1ydOR3AoOxsSUPkvoPC0mReO/yV5Nas7pz5s5VuJTspmFz0hA==",
+      "version": "9.7.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-divider/-/react-divider-9.7.2.tgz",
+      "integrity": "sha512-rfzGQoGKtLBF5vxiJH2KhRiJGosozdql3d6eS7j11oRczgc5W/h38iLhiXuQzZHpkGaAOd3sY6sq4uGHJheOjA==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-jsx-runtime": "^9.4.2",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
         "@fluentui/react-shared-contexts": "^9.26.2",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -842,20 +842,20 @@
       }
     },
     "node_modules/@fluentui/react-drawer": {
-      "version": "9.12.0",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-drawer/-/react-drawer-9.12.0.tgz",
-      "integrity": "sha512-PUXeXUH6JqwpjqYphHesHl75UAFSvxQJQqrevMFHE78ZF0Cqn59Xpa+8hGwRSuoRcYa90jjfHzJOOjN0iNM2iA==",
+      "version": "9.13.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-drawer/-/react-drawer-9.13.0.tgz",
+      "integrity": "sha512-Xeh9kW8SiNXobx+5AUb4UVYsaqpE9uqrqFwsb5Z47oupX3zRLw7UCh5rVbJoXowZRc7z6K1FViyORqpsOXnzJw==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-dialog": "^9.18.0",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-motion": "^9.15.0",
-        "@fluentui/react-motion-components-preview": "^0.15.4",
-        "@fluentui/react-portal": "^9.8.12",
+        "@fluentui/react-dialog": "^9.18.1",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-motion": "^9.16.0",
+        "@fluentui/react-motion-components-preview": "^0.15.5",
+        "@fluentui/react-portal": "^9.8.13",
         "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
+        "@fluentui/react-tabster": "^9.26.15",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -867,18 +867,18 @@
       }
     },
     "node_modules/@fluentui/react-field": {
-      "version": "9.5.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-field/-/react-field-9.5.1.tgz",
-      "integrity": "sha512-u8J2d3AWb4yZXvy/mQd95y2lTon890RfybBTCbeBUzApGMI/77WqT5pRJ+zTM3lOMToPHVKylchNFusMpJaX9w==",
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-field/-/react-field-9.5.2.tgz",
+      "integrity": "sha512-5pZXGtDVXCkoL3/sRMyhCcPd6+TDR9/wYG7/mK82BDuX4viuoSr5llcQ1PkdcXMixFFU+nXa39l7/BLP3f6W8g==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-context-selector": "^9.2.16",
+        "@fluentui/react-context-selector": "^9.2.17",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-label": "^9.4.1",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-label": "^9.4.2",
         "@fluentui/react-shared-contexts": "^9.26.2",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -890,9 +890,9 @@
       }
     },
     "node_modules/@fluentui/react-icons": {
-      "version": "2.0.326",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.326.tgz",
-      "integrity": "sha512-iSN6YggrrQyZ46Jxk998Umm9jehWs6mrqCsrAvr7+uZWY6IwfYcoz94NCJ2SDiMO8Jompl4Y4Yu73SwljuUULQ==",
+      "version": "2.0.328",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.328.tgz",
+      "integrity": "sha512-HAotR2QQjff1WJmm+QeSIU+3m1SOiz9D2M+u8M+8FWyRsyHjbOpBV9QUrABBH9z9JxyYYOvzLamjHEkIgGKLUA==",
       "license": "MIT",
       "dependencies": {
         "@griffel/react": "^1.6.1",
@@ -903,15 +903,15 @@
       }
     },
     "node_modules/@fluentui/react-image": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-image/-/react-image-9.4.1.tgz",
-      "integrity": "sha512-yNd2Wq2xq952UUEVBkWeEmM7bTKdWx6BnsHPYRf0kdTADox2PquApYXsI1xw2pnAh3GSjARrGi9Eto0qxouLqA==",
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-image/-/react-image-9.4.2.tgz",
+      "integrity": "sha512-E7bOTFds8qoMiT/YDe2+ZL5h13u7M1bm8yoGFfeTw0fmE9Q0gtrx2WzJB/1ZV/4MTmjnaO9Dgx7ysTYxc3RWRw==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-jsx-runtime": "^9.4.2",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
         "@fluentui/react-shared-contexts": "^9.26.2",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -923,18 +923,18 @@
       }
     },
     "node_modules/@fluentui/react-infobutton": {
-      "version": "9.0.0-beta.115",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-infobutton/-/react-infobutton-9.0.0-beta.115.tgz",
-      "integrity": "sha512-b+4B0ODzPEb4jNaW9HdT6VVt3CL5FgPL2yuKzALBsYVl3udJdFpyxHsZEPf3JrVTBL/rgF2fRI1iAioX6Fl7DA==",
+      "version": "9.0.0-beta.116",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-infobutton/-/react-infobutton-9.0.0-beta.116.tgz",
+      "integrity": "sha512-bnL8hRs9K8xCKvJU49F0UxcRankGb2sr+KYezdrcrgfbePrh8kyJTFGmxKQSgka8P+SySE5DxFwb2RbfpTjmnw==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-icons": "^2.0.237",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-label": "^9.4.1",
-        "@fluentui/react-popover": "^9.14.2",
-        "@fluentui/react-tabster": "^9.26.14",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-label": "^9.4.2",
+        "@fluentui/react-popover": "^9.14.3",
+        "@fluentui/react-tabster": "^9.26.15",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -946,19 +946,19 @@
       }
     },
     "node_modules/@fluentui/react-infolabel": {
-      "version": "9.4.20",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-infolabel/-/react-infolabel-9.4.20.tgz",
-      "integrity": "sha512-w4FOnNP+CtbVdKBEO6wXAcmOuPZWvmB/BJj+7J/8cLAQm7+4kQgitFHncU6rtFhPdGbikVoBf707/0R1mA4aIg==",
+      "version": "9.4.21",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-infolabel/-/react-infolabel-9.4.21.tgz",
+      "integrity": "sha512-FDpbxwdEztarJ63NmHCQP5n2XXKvyVgkdIVQIbkVslYqfooy2kql8Q0+5brRN2IsjQJRZ0MpSFRoJSNVT8rJEg==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-label": "^9.4.1",
-        "@fluentui/react-popover": "^9.14.2",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-label": "^9.4.2",
+        "@fluentui/react-popover": "^9.14.3",
         "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
+        "@fluentui/react-tabster": "^9.26.15",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -970,16 +970,16 @@
       }
     },
     "node_modules/@fluentui/react-input": {
-      "version": "9.8.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-input/-/react-input-9.8.2.tgz",
-      "integrity": "sha512-t9zmqZR4bqeRjpWuCGfI4yrtPoCXFiK2XO4BoV5nNwAesglgz4+Vtso4YXst9QYEAazHtKI73YFJf1mn55hCuA==",
+      "version": "9.8.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-input/-/react-input-9.8.3.tgz",
+      "integrity": "sha512-nnApEcsPXVXCZZl9qRpS9hc2hy18btUtbG188TYM1FAynqjx5zZC9Ww5/6IOrGT8d12nDxxTu9dp/xqMZtUbbw==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-field": "^9.5.1",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
+        "@fluentui/react-field": "^9.5.2",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
         "@fluentui/react-shared-contexts": "^9.26.2",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -991,12 +991,12 @@
       }
     },
     "node_modules/@fluentui/react-jsx-runtime": {
-      "version": "9.4.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.4.2.tgz",
-      "integrity": "sha512-y3o0PBg2qzSdvgxDm7rH9BWq7E1h/eUWS+IhjQhd9dRpme6Py01+OLOglHojM5Tc9QjIp2Rjy2mFWBHXOR+8mw==",
+      "version": "9.4.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.4.3.tgz",
+      "integrity": "sha512-1QwEgITME+X24lnS68pQlU/b4BBdeS7oPdApwwoYQuAGKvImDY2nLAJt8BoHYKs9VFeX5ySEKPRM0rKXGq3EWQ==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@swc/helpers": "^0.5.1"
       },
       "peerDependencies": {
@@ -1005,15 +1005,15 @@
       }
     },
     "node_modules/@fluentui/react-label": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-label/-/react-label-9.4.1.tgz",
-      "integrity": "sha512-4O3cPX6dSJVBKlIEbznjJ08utEc98lKbZz/6MZTTQfFgYl0TxAhxEDsIIIyNjj0Xy9eJpqubJsaswucWXTG/qg==",
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-label/-/react-label-9.4.2.tgz",
+      "integrity": "sha512-FfbOQf5caDA3yc/wukbKY0p6Pv8wkzre7E480VxqTgKrMm12KUoT+0+2S7vi0eCQJCW3pL8XjzVTbGIn8KDE8A==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-jsx-runtime": "^9.4.2",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
         "@fluentui/react-shared-contexts": "^9.26.2",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -1025,17 +1025,17 @@
       }
     },
     "node_modules/@fluentui/react-link": {
-      "version": "9.8.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-link/-/react-link-9.8.1.tgz",
-      "integrity": "sha512-ZxrCeX4pMWHujdmYV8b0QW0ztLtu0rHHvRNx67Y3WqSijVyij8QtNNiZ/nab+UDNlz9t8QIXKdWQgYj1uKDpMg==",
+      "version": "9.8.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-link/-/react-link-9.8.2.tgz",
+      "integrity": "sha512-PDziHdvp717LFc7BgxXDVldnq8UFtyqWM4ZWr0772XtuEc08jVU3MxKMUEsGOclqLRKGyjd0nG7IWKREuSETcg==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
         "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
+        "@fluentui/react-tabster": "^9.26.15",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -1047,19 +1047,19 @@
       }
     },
     "node_modules/@fluentui/react-list": {
-      "version": "9.6.14",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-list/-/react-list-9.6.14.tgz",
-      "integrity": "sha512-B1mUQFvJOUlZysSduVnATNZggrGpgEWnW9ZSJAZ17LM0+9nWEQRi40jpUGI/d3PGKHt5O2df78s+1nEPAk0L6A==",
+      "version": "9.6.15",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-list/-/react-list-9.6.15.tgz",
+      "integrity": "sha512-mb2yVQC2gfILLFOZAxsYwo70YgoyacR52Qy2EGuB4wZOQtZ9KMZIOUFlQIztJBSxNIfo869/bF8EUWsVDaTeYg==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-checkbox": "^9.6.1",
-        "@fluentui/react-context-selector": "^9.2.16",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
+        "@fluentui/react-checkbox": "^9.6.2",
+        "@fluentui/react-context-selector": "^9.2.17",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
         "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
+        "@fluentui/react-tabster": "^9.26.15",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -1071,24 +1071,24 @@
       }
     },
     "node_modules/@fluentui/react-menu": {
-      "version": "9.24.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-menu/-/react-menu-9.24.1.tgz",
-      "integrity": "sha512-NLB5EhzKFiwax3O5JTRTtsqdEFDGEXzEuP/suyxNAaaQsIuXygo//Rmdq6dSn7GybTpEOZHKxYDyyG7dj+a4YA==",
+      "version": "9.25.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-menu/-/react-menu-9.25.0.tgz",
+      "integrity": "sha512-aoBlNLv8Ngr9wBiOEhvYVOSLfeen2vvdAdZM10OjJ+mo9uhdRxF4m0Uqd8mcp0bpGf5/Cnz9FIZjdgc5krdwyA==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-aria": "^9.17.11",
-        "@fluentui/react-context-selector": "^9.2.16",
+        "@fluentui/react-aria": "^9.17.12",
+        "@fluentui/react-context-selector": "^9.2.17",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-motion": "^9.15.0",
-        "@fluentui/react-motion-components-preview": "^0.15.4",
-        "@fluentui/react-portal": "^9.8.12",
-        "@fluentui/react-positioning": "^9.22.1",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-motion": "^9.16.0",
+        "@fluentui/react-motion-components-preview": "^0.15.5",
+        "@fluentui/react-portal": "^9.8.13",
+        "@fluentui/react-positioning": "^9.22.2",
         "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
+        "@fluentui/react-tabster": "^9.26.15",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -1100,20 +1100,20 @@
       }
     },
     "node_modules/@fluentui/react-message-bar": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-message-bar/-/react-message-bar-9.7.0.tgz",
-      "integrity": "sha512-ICFDxZ62r5OG97/FcfK1EfJPxGlyDNyFixLD/a3gOREvEcT/hyZgnlUM9Y30u92HjxChx2SwGWnv3iaQPsvToQ==",
+      "version": "9.7.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-message-bar/-/react-message-bar-9.7.1.tgz",
+      "integrity": "sha512-8ImzffgVF/DJacOCiP1x75GQHE0wdB+3QoRkGKsgOZcqn6JOXzCEYvM0JplietUsNczmXRtXx9ZE+Otl6HPOHQ==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-button": "^9.9.1",
+        "@fluentui/react-button": "^9.9.2",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-link": "^9.8.1",
-        "@fluentui/react-motion": "^9.15.0",
-        "@fluentui/react-motion-components-preview": "^0.15.4",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-link": "^9.8.2",
+        "@fluentui/react-motion": "^9.16.0",
+        "@fluentui/react-motion-components-preview": "^0.15.5",
         "@fluentui/react-shared-contexts": "^9.26.2",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -1125,13 +1125,13 @@
       }
     },
     "node_modules/@fluentui/react-motion": {
-      "version": "9.15.0",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-motion/-/react-motion-9.15.0.tgz",
-      "integrity": "sha512-ZNQHYzE6MRbLQFT08/mrcqQ9k7F5niktRP93X1v/kmwKfPjvdDofySfbhQXQs3zQw600690C9rfJTKUd3h+zlg==",
+      "version": "9.16.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-motion/-/react-motion-9.16.0.tgz",
+      "integrity": "sha512-ZhbeRfir3V6+2kQjRqF2Bp8jwZd6TfmA9y1c6IlglsB8aNAbhnewYJsYXLrbZ+gwloiDdf46cVDqWYv5VFAgpg==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@swc/helpers": "^0.5.1"
       },
       "peerDependencies": {
@@ -1142,9 +1142,9 @@
       }
     },
     "node_modules/@fluentui/react-motion-components-preview": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-motion-components-preview/-/react-motion-components-preview-0.15.4.tgz",
-      "integrity": "sha512-gAHPlyEYylZzUSGwc68VaB+vO8CTX6tgIA3d2+jFrpcwvXZjsdCpF1w1zK1+hTuiipmEaZLZyBz0e0CKH2+3XQ==",
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-motion-components-preview/-/react-motion-components-preview-0.15.5.tgz",
+      "integrity": "sha512-AhDw4/6fjIDWPwx8L1vNDYu3GBJYkyAazNHNrowoRsuxZHn0vK5TMUacT4UW6/QbByCk1x76TLv+CxmwU75FPA==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-motion": "*",
@@ -1159,25 +1159,25 @@
       }
     },
     "node_modules/@fluentui/react-nav": {
-      "version": "9.3.24",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-nav/-/react-nav-9.3.24.tgz",
-      "integrity": "sha512-OlB5k5Zev5VNjSRfJvJLO09Hjcv2UHAjLpSVa6gKHx+1NqqSJWZeDLSF7r+/nyZ4CWP5jWZYq7whEu3WvzdVZw==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-nav/-/react-nav-9.4.0.tgz",
+      "integrity": "sha512-gyrXwT1NFfRT4WoVXrz7656tuFOmhFgCw1OBmb+0igftXmSxz6XMIj8MlwfUv2/VUymAU4Hs0p3rZwE4l81KKA==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-aria": "^9.17.11",
-        "@fluentui/react-button": "^9.9.1",
-        "@fluentui/react-context-selector": "^9.2.16",
-        "@fluentui/react-divider": "^9.7.1",
-        "@fluentui/react-drawer": "^9.12.0",
+        "@fluentui/react-aria": "^9.17.12",
+        "@fluentui/react-button": "^9.9.2",
+        "@fluentui/react-context-selector": "^9.2.17",
+        "@fluentui/react-divider": "^9.7.2",
+        "@fluentui/react-drawer": "^9.13.0",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-motion": "^9.15.0",
-        "@fluentui/react-motion-components-preview": "^0.15.4",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-motion": "^9.16.0",
+        "@fluentui/react-motion-components-preview": "^0.15.5",
         "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
+        "@fluentui/react-tabster": "^9.26.15",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-tooltip": "^9.10.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-tooltip": "^9.10.2",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -1189,15 +1189,16 @@
       }
     },
     "node_modules/@fluentui/react-overflow": {
-      "version": "9.7.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-overflow/-/react-overflow-9.7.2.tgz",
-      "integrity": "sha512-5PA67LgnVmbbOzBN2H5gH3OvSVy1373VJfsHq2+6TLCfm+LXAkWBoFwvBuFI7HsMYae9A0FVlgX7gTsKVfMddw==",
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-overflow/-/react-overflow-9.8.0.tgz",
+      "integrity": "sha512-6lHvfcRNFSnOIrKHUzWc/WCKvSp5ivH8QP/stzyCUyzJpDde8uAbRMfg2iDFgJ8wlySP29BoPiepaH9bHgVLdQ==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/priority-overflow": "^9.3.0",
-        "@fluentui/react-context-selector": "^9.2.16",
+        "@fluentui/react-context-selector": "^9.2.17",
+        "@fluentui/react-shared-contexts": "^9.26.2",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -1209,17 +1210,17 @@
       }
     },
     "node_modules/@fluentui/react-persona": {
-      "version": "9.7.3",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-persona/-/react-persona-9.7.3.tgz",
-      "integrity": "sha512-OY3xpSD6l4NDdeKihriC+H0q6P1CA2xyZ+pe/WwfKPnatxs2BALoRFtDQduMO7AK/j0w7UAxnaZrvEeftLen2g==",
+      "version": "9.7.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-persona/-/react-persona-9.7.4.tgz",
+      "integrity": "sha512-CtYA3aElMwTrhZcvdtrSIHWOzZqFcpJlfjchNNFTtvvFvrLGw65/1UPzLf/IUVBD1JO0XLGyQFRLUg/g+rtBfg==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-avatar": "^9.11.1",
-        "@fluentui/react-badge": "^9.5.2",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
+        "@fluentui/react-avatar": "^9.11.2",
+        "@fluentui/react-badge": "^9.5.3",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
         "@fluentui/react-shared-contexts": "^9.26.2",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -1231,23 +1232,23 @@
       }
     },
     "node_modules/@fluentui/react-popover": {
-      "version": "9.14.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-popover/-/react-popover-9.14.2.tgz",
-      "integrity": "sha512-EDvzLkT98/vcCSGrcZWUACGsvLjrHin0Xf9eowMQKiiHFWbu8HNRmr7W2XB9Eja1W5HSIK6+mV8ro9zrLibG4w==",
+      "version": "9.14.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-popover/-/react-popover-9.14.3.tgz",
+      "integrity": "sha512-wR73yLdMm3/pJ92xJEeRnBAJ8tNvNv0LTSmaZvwbTgdcMT1zqfSyNO37qE7a8z+4bcp8kjyM8FR9NRqkr8OYdA==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-aria": "^9.17.11",
-        "@fluentui/react-context-selector": "^9.2.16",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-motion": "^9.15.0",
-        "@fluentui/react-motion-components-preview": "^0.15.4",
-        "@fluentui/react-portal": "^9.8.12",
-        "@fluentui/react-positioning": "^9.22.1",
+        "@fluentui/react-aria": "^9.17.12",
+        "@fluentui/react-context-selector": "^9.2.17",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-motion": "^9.16.0",
+        "@fluentui/react-motion-components-preview": "^0.15.5",
+        "@fluentui/react-portal": "^9.8.13",
+        "@fluentui/react-positioning": "^9.22.2",
         "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
+        "@fluentui/react-tabster": "^9.26.15",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -1259,14 +1260,14 @@
       }
     },
     "node_modules/@fluentui/react-portal": {
-      "version": "9.8.12",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-portal/-/react-portal-9.8.12.tgz",
-      "integrity": "sha512-+WH0wH/5lsodGP6Mam1alHXpkMCYA5uMcnF98RVOs7/GR69KiFcza1mCnvPJUaJ55AfwLuz/xLxuWdWgQnUdMQ==",
+      "version": "9.8.13",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-portal/-/react-portal-9.8.13.tgz",
+      "integrity": "sha512-a4EEt3KMzvW6qMk97K/8TQegmO8Ba4C2TdR7ke7g1SsEDmJGwwOD34hCwVxGi8LtxLcpAEdOx++brXnPsk5+Zw==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-tabster": "^9.26.15",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -1278,16 +1279,16 @@
       }
     },
     "node_modules/@fluentui/react-positioning": {
-      "version": "9.22.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-positioning/-/react-positioning-9.22.1.tgz",
-      "integrity": "sha512-/r1BHQKr/WCjEM8UGloiq7bWWBSYB/Uqt7D1sAF9EHd968VH07cAN3RMVKmWWjeJO31rstOZHdgcz0WHhFF+2Q==",
+      "version": "9.22.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-positioning/-/react-positioning-9.22.2.tgz",
+      "integrity": "sha512-Pmio9+lDN+rF4k0mHVXqX6W0+A0ym0dje92UVfXeuassuIuJpKfvQg1xLpgQPrGRbgERr8KgA04xQVoJKaZQmA==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/devtools": "^0.2.3",
         "@floating-ui/dom": "^1.6.12",
         "@fluentui/react-shared-contexts": "^9.26.2",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1",
         "use-sync-external-store": "^1.2.0"
@@ -1300,17 +1301,17 @@
       }
     },
     "node_modules/@fluentui/react-progress": {
-      "version": "9.5.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-progress/-/react-progress-9.5.1.tgz",
-      "integrity": "sha512-EXJ/Bp67d5+bXPNpPabxdtXUgCMTtvYrBoKtIS6wE5KeUzaek/rgQ3v5wnGfbuLnJ4J/kj+n7XQEc9fhoFPy9w==",
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-progress/-/react-progress-9.5.2.tgz",
+      "integrity": "sha512-H2t9Q9qYPm5gGb68RiIukFAZn/IxgoxcpKwZ+AjXKCly0C8x8EWCpyQSdfvswaGbcx7H6fe3SpKytBAAuvOOtA==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-field": "^9.5.1",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-motion": "^9.15.0",
+        "@fluentui/react-field": "^9.5.2",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-motion": "^9.16.0",
         "@fluentui/react-shared-contexts": "^9.26.2",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -1322,17 +1323,17 @@
       }
     },
     "node_modules/@fluentui/react-provider": {
-      "version": "9.22.16",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-provider/-/react-provider-9.22.16.tgz",
-      "integrity": "sha512-S77n5ASUWE/V1I6lX09CrHm4TAKSGENhIrKz9qMKDv2Vrq44/j3eGBLz12k8IW4TJVu9nwGwst9kBpCT+3WHpA==",
+      "version": "9.22.17",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-provider/-/react-provider-9.22.17.tgz",
+      "integrity": "sha512-VIguLw2Ez9qxYCzrwKe3ttIcIbRdi7qpafImLNdpIAWRacIHw1AXSiDKcL6VFfE1+NxfQEy655wqYABi+7pJfw==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
         "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
+        "@fluentui/react-tabster": "^9.26.15",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/core": "^1.16.0",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
@@ -1345,18 +1346,18 @@
       }
     },
     "node_modules/@fluentui/react-radio": {
-      "version": "9.6.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-radio/-/react-radio-9.6.2.tgz",
-      "integrity": "sha512-Sp2us4eWRopUKOMCQw5/iks7euPKY6FeesBCCUIVGBg5VKZf2/CfEtbCa9hMjn4D4PCHGivnUTf23t238mvvnw==",
+      "version": "9.6.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-radio/-/react-radio-9.6.3.tgz",
+      "integrity": "sha512-U+funQQvlcOe3BQevUlkxsCoTQKFjw3Z/wnoAXNaNr1lTLIZnB+nesLA3ovZFWyOGTTJ2Mfa+vYpLbyyEpS8eA==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-field": "^9.5.1",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-label": "^9.4.1",
+        "@fluentui/react-field": "^9.5.2",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-label": "^9.4.2",
         "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
+        "@fluentui/react-tabster": "^9.26.15",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -1368,17 +1369,17 @@
       }
     },
     "node_modules/@fluentui/react-rating": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-rating/-/react-rating-9.4.1.tgz",
-      "integrity": "sha512-DfWipzrT44j+yaShtfHz96/vHEa5ut5IR1kobrO0bSqAcpetOn327gFeY+sG/W6xzork/STcy/T836yK8A2+DQ==",
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-rating/-/react-rating-9.4.2.tgz",
+      "integrity": "sha512-jVHv9GFKKhzH1fai4/1ArG1xjFAU/PFsY8UkBikt3LQDL5Cuw2S2uIBanso0AllNwmwaImsd5xb1Uo8mfMayBw==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
         "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
+        "@fluentui/react-tabster": "^9.26.15",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -1390,17 +1391,17 @@
       }
     },
     "node_modules/@fluentui/react-search": {
-      "version": "9.4.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-search/-/react-search-9.4.2.tgz",
-      "integrity": "sha512-PIb50euHoMsKWLqFymf8wo/+z1jrx1MB7uNuhjNT5DvwTP4VYAy5EtRCSwVRyxWNSaWSL6iy6dDy517EQE96mA==",
+      "version": "9.4.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-search/-/react-search-9.4.3.tgz",
+      "integrity": "sha512-wKRakuodG76MTu2v/8PZiXA3SUFaMJhdJ5OjoVh5TpFtoYnzwJmiyW2TlgDuod2rk2fpJ3v34C6wkdx6tW8oZw==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-input": "^9.8.2",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
+        "@fluentui/react-input": "^9.8.3",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
         "@fluentui/react-shared-contexts": "^9.26.2",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -1412,17 +1413,17 @@
       }
     },
     "node_modules/@fluentui/react-select": {
-      "version": "9.5.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-select/-/react-select-9.5.1.tgz",
-      "integrity": "sha512-8GocQKiUHEUlAks6zA0HbGGSF2lpjuSZuxPzIBqTyuWof8vFiK6eFAcSXb0hTYIVH3RsTihhfc6G3NRnHoBrzg==",
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-select/-/react-select-9.5.2.tgz",
+      "integrity": "sha512-kbLbF8DAXsbb2UwJxVzV5tS9fpSX2RZdFPZYosvQly6+h5kTojVFeZRrSkyMPYRCkTMVENdAeyahdx4ESa5qHw==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-field": "^9.5.1",
+        "@fluentui/react-field": "^9.5.2",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
         "@fluentui/react-shared-contexts": "^9.26.2",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -1448,16 +1449,16 @@
       }
     },
     "node_modules/@fluentui/react-skeleton": {
-      "version": "9.7.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-skeleton/-/react-skeleton-9.7.2.tgz",
-      "integrity": "sha512-PrUgdSGDAZw9FIP5NyvPoPfHDe2N9VxMyBfyTwWfZVg03dzRfnE3vEqr7N5xyfv4JsRs6u1xSqVn/0jdS0IEMQ==",
+      "version": "9.7.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-skeleton/-/react-skeleton-9.7.3.tgz",
+      "integrity": "sha512-4YhAux0OaYs/91xz/K25pNQxFbdQ2FcDRnwTpgsCDFH4XGQtA+rxBsLA5il3chIf++bNWr/78c5PHp6tZQuCDw==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-field": "^9.5.1",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
+        "@fluentui/react-field": "^9.5.2",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
         "@fluentui/react-shared-contexts": "^9.26.2",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -1469,17 +1470,17 @@
       }
     },
     "node_modules/@fluentui/react-slider": {
-      "version": "9.6.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-slider/-/react-slider-9.6.2.tgz",
-      "integrity": "sha512-lVavtTg8eqovfRokeYDk4popwCi8nuicacJ/HZdF3ni5e3y/2WT/bVP0eErS/GvC7+90ACQQ8uxdr4sjjY/HWA==",
+      "version": "9.6.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-slider/-/react-slider-9.6.3.tgz",
+      "integrity": "sha512-r0AP/ZqyMpVEEniIMjQ6AH5DZeCZ/XypBw+21D6mtjiy9vCg0A9lU8U+ay2Y1RyQY4PCShsUVSOb3bNTSTVUxQ==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-field": "^9.5.1",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
+        "@fluentui/react-field": "^9.5.2",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
         "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
+        "@fluentui/react-tabster": "^9.26.15",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -1491,18 +1492,18 @@
       }
     },
     "node_modules/@fluentui/react-spinbutton": {
-      "version": "9.6.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-spinbutton/-/react-spinbutton-9.6.2.tgz",
-      "integrity": "sha512-P4vvJH7P5yHPFAv6aSo3dZxtErN62DiRJN+nEKS+/XBoRGsOGQdqyyx5Q/PQKOmyQrtwuZdXNHUjcyv8b50T2w==",
+      "version": "9.6.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-spinbutton/-/react-spinbutton-9.6.3.tgz",
+      "integrity": "sha512-wc3GjEB3vBz8uO+Jmdch9gk5effGz6ld2SrfmpHjfTGgww9qIj5S+WbSPZjAKgtqZw/f597DMpiplRE1kvqn/A==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-field": "^9.5.1",
+        "@fluentui/react-field": "^9.5.2",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
         "@fluentui/react-shared-contexts": "^9.26.2",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -1514,16 +1515,16 @@
       }
     },
     "node_modules/@fluentui/react-spinner": {
-      "version": "9.8.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-spinner/-/react-spinner-9.8.2.tgz",
-      "integrity": "sha512-0LxykLJGUD/I3XEeIXAWznwdg9XRe0piaByR0nLFOOV3UPwkVc2w5UdPhy2Y0NZDvtPHbNaMCuQAq82+bxg/0w==",
+      "version": "9.8.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-spinner/-/react-spinner-9.8.3.tgz",
+      "integrity": "sha512-knnL3Yx/qC+YoYPLCQLE5iHeNMwj3bLBQrksk85lQK0AFy1rOs8rTQuxUtjg9icn5BOFExhSDOYVwp3diSt1ug==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-label": "^9.4.1",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-label": "^9.4.2",
         "@fluentui/react-shared-contexts": "^9.26.2",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -1535,19 +1536,19 @@
       }
     },
     "node_modules/@fluentui/react-swatch-picker": {
-      "version": "9.5.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-swatch-picker/-/react-swatch-picker-9.5.2.tgz",
-      "integrity": "sha512-DK6UU9OJY9XaGBPU2ROx+B5/7XdwVtHBdVthOAptyKSsYGOdQt5AQqg3ZOXH6r5WYbMRQDuP2OZ2iKtwidFCVQ==",
+      "version": "9.5.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-swatch-picker/-/react-swatch-picker-9.5.3.tgz",
+      "integrity": "sha512-AiybFcvA6in1piIsPn83Wm+w5bOnLlWmqrHiTDFnt6bYb8j2MJZ+dratJVZRtidqlEyfcMS3SByLooaVzwLRLQ==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-context-selector": "^9.2.16",
-        "@fluentui/react-field": "^9.5.1",
+        "@fluentui/react-context-selector": "^9.2.17",
+        "@fluentui/react-field": "^9.5.2",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
         "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
+        "@fluentui/react-tabster": "^9.26.15",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -1559,19 +1560,19 @@
       }
     },
     "node_modules/@fluentui/react-switch": {
-      "version": "9.7.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-switch/-/react-switch-9.7.2.tgz",
-      "integrity": "sha512-j3e5se+3d+befV9MytkxxvJ9nHZOeZ7thKDTF4YVSYf6kcNx9eOlLvPgDjhGO08gzngO4B7aaprhDN7DJc3W1g==",
+      "version": "9.7.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-switch/-/react-switch-9.7.3.tgz",
+      "integrity": "sha512-/eCYAtaoyUF//6F/OdOGj+GhLtkeJMXJUxaRPiDa6d18DX2eyoGaQ10175ysOjv4CbzIg8xH15flgpB4qUUstQ==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-field": "^9.5.1",
+        "@fluentui/react-field": "^9.5.2",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-label": "^9.4.1",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-label": "^9.4.2",
         "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
+        "@fluentui/react-tabster": "^9.26.15",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -1583,23 +1584,23 @@
       }
     },
     "node_modules/@fluentui/react-table": {
-      "version": "9.19.15",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-table/-/react-table-9.19.15.tgz",
-      "integrity": "sha512-OdQ2Nwx2nAlPMlJeyAFrKa3Zy5Ya/H87OU8MvtFJhabM/FkHiZoli/DO1mavVI+jqavOlJuQWmJ55D6jjuGa7g==",
+      "version": "9.19.16",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-table/-/react-table-9.19.16.tgz",
+      "integrity": "sha512-SdwpJIHwCGg+ALOhZRvixkQhWSakXDgpDGe/OWwv1PiLDPxnBh+gUd+MtveryFaX+WvJvLWzx3u9O1ogQXKx3g==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-aria": "^9.17.11",
-        "@fluentui/react-avatar": "^9.11.1",
-        "@fluentui/react-checkbox": "^9.6.1",
-        "@fluentui/react-context-selector": "^9.2.16",
+        "@fluentui/react-aria": "^9.17.12",
+        "@fluentui/react-avatar": "^9.11.2",
+        "@fluentui/react-checkbox": "^9.6.2",
+        "@fluentui/react-context-selector": "^9.2.17",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-radio": "^9.6.2",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-radio": "^9.6.3",
         "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
+        "@fluentui/react-tabster": "^9.26.15",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -1611,17 +1612,17 @@
       }
     },
     "node_modules/@fluentui/react-tabs": {
-      "version": "9.12.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-tabs/-/react-tabs-9.12.1.tgz",
-      "integrity": "sha512-WvzOtpC6C/7Mo5X+xmE+3stpCbx2iH9BqrEN5KuGrsHJ78DjMDeabYeL90vlrHBdP4VlTpwdORBui/jtWkxnmQ==",
+      "version": "9.12.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tabs/-/react-tabs-9.12.2.tgz",
+      "integrity": "sha512-k2WsKmNQvFtNSywAb/VxXXlFdLC9fjRaRV4Ha7qDXucXuTCI1eKJuaAteePZiMAByv+AbRqRHevv5k2KMabxrw==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-context-selector": "^9.2.16",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
+        "@fluentui/react-context-selector": "^9.2.17",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
         "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
+        "@fluentui/react-tabster": "^9.26.15",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -1633,18 +1634,18 @@
       }
     },
     "node_modules/@fluentui/react-tabster": {
-      "version": "9.26.14",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-tabster/-/react-tabster-9.26.14.tgz",
-      "integrity": "sha512-WibgoF67hl6BXfmsY6RSIWSHadeMP/6EDG9gAacfHlwKvK0+FiHp5ernwuXTPAmu2kiHicn2qUZ8EteCFiFryg==",
+      "version": "9.26.15",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tabster/-/react-tabster-9.26.15.tgz",
+      "integrity": "sha512-SugQlqXsMueTojtvPU/RIoZg6WaV4bw++NhLjnF7dFvD61/w5pPsVSLCPsLJBD+oU5Kbgx2x3KFbI69kb+kNmQ==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-shared-contexts": "^9.26.2",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1",
-        "keyborg": "^2.6.0",
-        "tabster": "^8.5.5"
+        "keyborg": "^2.14.1",
+        "tabster": "^8.8.0"
       },
       "peerDependencies": {
         "@types/react": ">=16.14.0 <20.0.0",
@@ -1654,25 +1655,25 @@
       }
     },
     "node_modules/@fluentui/react-tag-picker": {
-      "version": "9.8.6",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-tag-picker/-/react-tag-picker-9.8.6.tgz",
-      "integrity": "sha512-sOZ+wBA3hgGhKrOP7wbjB2yRvAxjcRXtcj1jDTrtSkaDPXb3K0nGmjiqp2mve995ps3wvCGnNKK4EurX842ZbA==",
+      "version": "9.8.8",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tag-picker/-/react-tag-picker-9.8.8.tgz",
+      "integrity": "sha512-GkBqUMAxJtOGRNFmkoi6Js4jxvQEc3JScUok1/UKThPHZeMfk4vAKT8aGVx9Sa/Ab4Akr5LhcjOt4TXHPQ2IvQ==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-aria": "^9.17.11",
-        "@fluentui/react-combobox": "^9.17.1",
-        "@fluentui/react-context-selector": "^9.2.16",
-        "@fluentui/react-field": "^9.5.1",
+        "@fluentui/react-aria": "^9.17.12",
+        "@fluentui/react-combobox": "^9.17.2",
+        "@fluentui/react-context-selector": "^9.2.17",
+        "@fluentui/react-field": "^9.5.2",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-portal": "^9.8.12",
-        "@fluentui/react-positioning": "^9.22.1",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-portal": "^9.8.13",
+        "@fluentui/react-positioning": "^9.22.2",
         "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-tags": "^9.8.1",
+        "@fluentui/react-tabster": "^9.26.15",
+        "@fluentui/react-tags": "^9.9.1",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -1684,20 +1685,20 @@
       }
     },
     "node_modules/@fluentui/react-tags": {
-      "version": "9.8.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-tags/-/react-tags-9.8.1.tgz",
-      "integrity": "sha512-6ZTW78fu5eWByKHIM3i+raDrX3hwfZ67ONfZ8wEUXfZHowskxqpMHI8Gw7IAMWkC1scgLqEnht8TnHvZgjo7Ug==",
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tags/-/react-tags-9.9.1.tgz",
+      "integrity": "sha512-WY6Ye5TblwHnMIlRd0DgnPTCH+UyJBafr8bIOszi13KOkN3HFswY5syb4lbQUzP+EslAC5M5cPnJXe89TUXV+Q==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-aria": "^9.17.11",
-        "@fluentui/react-avatar": "^9.11.1",
+        "@fluentui/react-aria": "^9.17.12",
+        "@fluentui/react-avatar": "^9.11.2",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
         "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
+        "@fluentui/react-tabster": "^9.26.15",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -1709,21 +1710,21 @@
       }
     },
     "node_modules/@fluentui/react-teaching-popover": {
-      "version": "9.6.21",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-teaching-popover/-/react-teaching-popover-9.6.21.tgz",
-      "integrity": "sha512-V86zLB1B8xu3U/02FvvMdsJP+ZC9l3vT9bQ2Gr7hZHxJ4/0NLpVcrYSBFHpON9e/WK3p+A5b5V96p86b5Pavlg==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-teaching-popover/-/react-teaching-popover-9.7.0.tgz",
+      "integrity": "sha512-8oKts1w33JbLAgVNt7Ad5vidXsIpXyVkrPwo5aZW6oqEASJGEooAOx1od+bKgwZb2wyjq5/RXxdV22r13nqajg==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-aria": "^9.17.11",
-        "@fluentui/react-button": "^9.9.1",
-        "@fluentui/react-context-selector": "^9.2.16",
+        "@fluentui/react-aria": "^9.17.12",
+        "@fluentui/react-button": "^9.9.2",
+        "@fluentui/react-context-selector": "^9.2.17",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-popover": "^9.14.2",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-popover": "^9.14.3",
         "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
+        "@fluentui/react-tabster": "^9.26.15",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1",
         "use-sync-external-store": "^1.2.0"
@@ -1736,15 +1737,15 @@
       }
     },
     "node_modules/@fluentui/react-text": {
-      "version": "9.6.16",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-text/-/react-text-9.6.16.tgz",
-      "integrity": "sha512-ZzCSJWQ6LrVuPqA6sqNEZaXbLvhi2NxBOtlMudWlqYzidLQp038d7mMGSzNnhyeblg+gj+bOVE2eOgWFuVHGYw==",
+      "version": "9.6.17",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-text/-/react-text-9.6.17.tgz",
+      "integrity": "sha512-SqWXOKJNF6EgG4/vZeurl7MqO9OckRwK6tvk9JJVs7kbqOky+d+t1gITaqk9yIOw6LJtb76vm8cZUvKUb0WSqA==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-jsx-runtime": "^9.4.2",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
         "@fluentui/react-shared-contexts": "^9.26.2",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -1756,16 +1757,16 @@
       }
     },
     "node_modules/@fluentui/react-textarea": {
-      "version": "9.7.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-textarea/-/react-textarea-9.7.2.tgz",
-      "integrity": "sha512-awlkZoW81WaOqSoXTT9rZs3mTAzCCHnC9eAm6J8ZxI5+ASX07BTolBfZ82it5wxOHI5GMDfbFOl+xIy8uAMdzA==",
+      "version": "9.7.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-textarea/-/react-textarea-9.7.3.tgz",
+      "integrity": "sha512-BNStqBKO2fe3h5VAIPs33/7xj8EAr5msmb9krq02XAmvDndt3aLrQdz25vVEMvbcuUCNQoFsPtN/PrR6nXTIHw==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-field": "^9.5.1",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
+        "@fluentui/react-field": "^9.5.2",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
         "@fluentui/react-shared-contexts": "^9.26.2",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -1787,22 +1788,22 @@
       }
     },
     "node_modules/@fluentui/react-toast": {
-      "version": "9.7.17",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-toast/-/react-toast-9.7.17.tgz",
-      "integrity": "sha512-DWA5EARWSo1k19iWAulLpKrcUHT+Dq/Bw9zfdpoQEWWybrAZwyN7WiYFkBjKCQRxSp10OjLASSQK91CXfb1wJA==",
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-toast/-/react-toast-9.8.0.tgz",
+      "integrity": "sha512-GsLeEjLCLZ+SM2yL4G/hsypecXPn4FK73sH3KXer7Q0MST+ldulcaW8nsppCwqBB6Zf5pwcRU4qnkWwFMQd66Q==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-aria": "^9.17.11",
+        "@fluentui/react-aria": "^9.17.12",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-motion": "^9.15.0",
-        "@fluentui/react-motion-components-preview": "^0.15.4",
-        "@fluentui/react-portal": "^9.8.12",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-motion": "^9.16.0",
+        "@fluentui/react-motion-components-preview": "^0.15.5",
+        "@fluentui/react-portal": "^9.8.13",
         "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
+        "@fluentui/react-tabster": "^9.26.15",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -1814,20 +1815,20 @@
       }
     },
     "node_modules/@fluentui/react-toolbar": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-toolbar/-/react-toolbar-9.8.0.tgz",
-      "integrity": "sha512-EIe+QWOaFR1pZzENefsFTmjxGa2yJb4A/by3kGuGqSjx7isqPUllPq0/kFQzfoUYgPDJbJtQ+KyuRDekTL0QpQ==",
+      "version": "9.8.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-toolbar/-/react-toolbar-9.8.1.tgz",
+      "integrity": "sha512-ZzjFwFElF3bCsHXgl6YfmHzfZn2gUDe7NoYl4qloHhGacrSStvOt0h94WRz0a5ur/VIG2PDROeBLkcI2MIZQJQ==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-button": "^9.9.1",
-        "@fluentui/react-context-selector": "^9.2.16",
-        "@fluentui/react-divider": "^9.7.1",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-radio": "^9.6.2",
+        "@fluentui/react-button": "^9.9.2",
+        "@fluentui/react-context-selector": "^9.2.17",
+        "@fluentui/react-divider": "^9.7.2",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-radio": "^9.6.3",
         "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
+        "@fluentui/react-tabster": "^9.26.15",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -1839,19 +1840,19 @@
       }
     },
     "node_modules/@fluentui/react-tooltip": {
-      "version": "9.10.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-tooltip/-/react-tooltip-9.10.1.tgz",
-      "integrity": "sha512-IPHBFjqGhaaMDhLt5NSNOE9LEpDOpT7qgEqNz+Mlflo0A4qI2LW/EnkNop7IRmX/bC88A+wUtEONTjjR87dNBw==",
+      "version": "9.10.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tooltip/-/react-tooltip-9.10.2.tgz",
+      "integrity": "sha512-1qewqiTNKpbRuoINhytyaMoUsBLE4TRPXf9ilJnvN3UtN5TYtS/8Oe6zMocHEnCLETsFOyCn8sAlufWOo5efpQ==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-portal": "^9.8.12",
-        "@fluentui/react-positioning": "^9.22.1",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-portal": "^9.8.13",
+        "@fluentui/react-positioning": "^9.22.2",
         "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
+        "@fluentui/react-tabster": "^9.26.15",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -1863,26 +1864,26 @@
       }
     },
     "node_modules/@fluentui/react-tree": {
-      "version": "9.16.0",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-tree/-/react-tree-9.16.0.tgz",
-      "integrity": "sha512-c+Q4AVaYk9U69aGDgmJVNne+CtWKS75YIfGoxs6+9+wE2Wqz4T0E+gE1ng7ARCQQgI7E2NEJlot6DuI6nYYrRw==",
+      "version": "9.16.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tree/-/react-tree-9.16.1.tgz",
+      "integrity": "sha512-e87Fa+8ttbYh0XY4qxJ9NcmIWSfYouw8Rc68c10UczK2TcsWSII84cV9fHrbL7FtX8DlyncZuSjukoJYm5LD7w==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-aria": "^9.17.11",
-        "@fluentui/react-avatar": "^9.11.1",
-        "@fluentui/react-button": "^9.9.1",
-        "@fluentui/react-checkbox": "^9.6.1",
-        "@fluentui/react-context-selector": "^9.2.16",
+        "@fluentui/react-aria": "^9.17.12",
+        "@fluentui/react-avatar": "^9.11.2",
+        "@fluentui/react-button": "^9.9.2",
+        "@fluentui/react-checkbox": "^9.6.2",
+        "@fluentui/react-context-selector": "^9.2.17",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-motion": "^9.15.0",
-        "@fluentui/react-motion-components-preview": "^0.15.4",
-        "@fluentui/react-radio": "^9.6.2",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-motion": "^9.16.0",
+        "@fluentui/react-motion-components-preview": "^0.15.5",
+        "@fluentui/react-radio": "^9.6.3",
         "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
+        "@fluentui/react-tabster": "^9.26.15",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -1894,9 +1895,9 @@
       }
     },
     "node_modules/@fluentui/react-utilities": {
-      "version": "9.26.3",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-utilities/-/react-utilities-9.26.3.tgz",
-      "integrity": "sha512-bXB3jMm/RroT8c5eGZkijkPbLd4MqMI6biBHjavo0e7OkZHv9IPfH2nDkGhSn5Sh8e6kRcX0IjYhbM10WUK2iQ==",
+      "version": "9.26.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-utilities/-/react-utilities-9.26.4.tgz",
+      "integrity": "sha512-Rg1kg0ZPFOBi6VtQNkgV+K3z3O7PY5QFJQ4Y+qkZv7a8fUSNkEK151coaGOLps4P77fY2DiHhqKqeOehN7vFOA==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
@@ -1909,14 +1910,14 @@
       }
     },
     "node_modules/@fluentui/react-virtualizer": {
-      "version": "9.0.0-alpha.112",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-virtualizer/-/react-virtualizer-9.0.0-alpha.112.tgz",
-      "integrity": "sha512-dao/mQssaPFxCXMx7K+G/DrRoZg28kXcE1NGbJ1RPtbkVCzJgwrEEeDhM5/wyOXO/Z5EZ31FIerDDVOyr6FAaw==",
+      "version": "9.0.0-alpha.113",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-virtualizer/-/react-virtualizer-9.0.0-alpha.113.tgz",
+      "integrity": "sha512-MGmdlm+0HwwMypCpUCpddQjgKvZkL9oGvjXNcoIHYhMVy4WSc5ha8XqOxAo2cfWvKGN0jMiW3H3IebLdcFpd7Q==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-jsx-runtime": "^9.4.2",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
         "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-utilities": "^9.26.3",
+        "@fluentui/react-utilities": "^9.26.4",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
       },
@@ -1937,26 +1938,26 @@
       }
     },
     "node_modules/@griffel/core": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@griffel/core/-/core-1.21.0.tgz",
-      "integrity": "sha512-QqMoewiNTT0DmLM7OY607c7yhg18SuKfzovTO3hPXGQvtdu/StnjvuBAs+1B1kYSVGReAo6s/dJVeLnPuHjE7Q==",
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/@griffel/core/-/core-1.21.2.tgz",
+      "integrity": "sha512-vDvEdbIe7OhU15UkvUHe+Ut2sgCZ5PBj/RYLFwjUtkXS4ewNK9P6b4YRFNI2zgaNYI7GOuZqG7DLyaQbUP3+jg==",
       "license": "MIT",
       "dependencies": {
         "@emotion/hash": "^0.9.0",
-        "@griffel/style-types": "^1.4.0",
-        "csstype": "^3.1.3",
+        "@griffel/style-types": "^1.4.2",
+        "csstype": "^3.2.3",
         "rtl-css-js": "^1.16.1",
         "stylis": "^4.4.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@griffel/react": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@griffel/react/-/react-1.7.2.tgz",
-      "integrity": "sha512-/+N+81e9ibNsh2wNlhGf2PcimEFrx8VbtWiLCmI6lsrTV5eBcQrIIDVQq737KPIJFtD4v6Txu9n0PXbN3hedNg==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@griffel/react/-/react-1.7.4.tgz",
+      "integrity": "sha512-XsB+YOC4MOBg6GF5CJWJLf8ZI2AtXE8EvQdwJEmFNKX0cQu/An0azl3v9+sjA73zsIG2Wayo2pkT0JANYnKauA==",
       "license": "MIT",
       "dependencies": {
-        "@griffel/core": "^1.21.0",
+        "@griffel/core": "^1.21.2",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -1964,12 +1965,12 @@
       }
     },
     "node_modules/@griffel/style-types": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@griffel/style-types/-/style-types-1.4.0.tgz",
-      "integrity": "sha512-vNDfOGV7RN/XkA7vxgf7Z5HgW8eiBm5cHT9wQPhsKB4pxWom5u6eQ9CkYE5mCCTSPl9H6Nd1NBai04d4P6BD7Q==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@griffel/style-types/-/style-types-1.4.2.tgz",
+      "integrity": "sha512-MsSghfpyxR2MpTrYdcCozISsSLkmFjNw94wNPi4bDBRLW8W43718W/ZjmUdVkoM0KXMtJPYuEkx8Mzibqb03qA==",
       "license": "MIT",
       "dependencies": {
-        "csstype": "^3.1.3"
+        "csstype": "^3.2.3"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -1999,9 +2000,9 @@
       }
     },
     "node_modules/@nodable/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
       "dev": true,
       "funding": [
         {
@@ -2012,9 +2013,9 @@
       "license": "MIT"
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.128.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.128.0.tgz",
-      "integrity": "sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==",
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2022,13 +2023,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.59.1"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -2038,9 +2039,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.18.tgz",
-      "integrity": "sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
       ],
@@ -2055,9 +2056,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.18.tgz",
-      "integrity": "sha512-apJq2ktnGp27nSInMR5Vcj8kY6xJzDAvfdIFlpDcAK/w4cDO58qVoi1YQsES/SKiFNge/6e4CUzgjfHduYqWpQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
       ],
@@ -2072,9 +2073,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.18.tgz",
-      "integrity": "sha512-5Ofot8xbs+pxRHJqm9/9N/4sTQOvdrwEsmPE9pdLEEoAbdZtG6F2LMDfO1sp6ZAtXJuJV/21ew2srq3W8NXB5g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
       ],
@@ -2089,9 +2090,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.18.tgz",
-      "integrity": "sha512-7h8eeOTT1eyqJyx64BFCnWZpNm486hGWt2sqeLLgDxA0xI1oGZ9H7gK1S85uNGmBhkdPwa/6reTxfFFKvIsebw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
       ],
@@ -2106,9 +2107,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.18.tgz",
-      "integrity": "sha512-eRcm/HVt9U/JFu5RKAEKwGQYtDCKWLiaH6wOnsSEp6NMBb/3Os8LgHZlNyzMpFVNmiiMFlfb2zEnebfzJrHFmg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
       ],
@@ -2123,9 +2124,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.18.tgz",
-      "integrity": "sha512-SOrT/cT4ukTmgnrEz/Hg3m7LBnuCLW9psDeMKrimRWY4I8DmnO7Lco8W2vtqPmMkbVu8iJ+g4GFLVLLOVjJ9DQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
       ],
@@ -2143,9 +2144,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.18.tgz",
-      "integrity": "sha512-QWjdxN1HJCpBTAcZ5N5F7wju3gVPzRzSpmGzx7na0c/1qpN9CFil+xt+l9lV/1M6/gqHSNXCiqPfwhVJPeLnug==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
       ],
@@ -2163,9 +2164,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.18.tgz",
-      "integrity": "sha512-ugCOyj7a4d9h3q9B+wXmf6g3a68UsjGh6dob5DHevHGMwDUbhsYNbSPxJsENcIttJZ9jv7qGM2UesLw5jqIhdg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
       ],
@@ -2183,9 +2184,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.18.tgz",
-      "integrity": "sha512-kKWRhbsotpXkGbcd5dllUWg5gEXcDAa8u5YnP9AV5DYNbvJHGzzuwv7dpmhc8NqKMJldl0a+x76IHbspEpEmdA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
       ],
@@ -2203,9 +2204,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.18.tgz",
-      "integrity": "sha512-uCo8ElcCIAMyYAZyuIZ81oFkhTSIllNvUCHCAlbhlN4ji3uC28h7IIdlXyIvGO7HsuqnV9p3rD/bpH7XhIyhRw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
       "cpu": [
         "x64"
       ],
@@ -2223,9 +2224,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.18.tgz",
-      "integrity": "sha512-XNOQZtuE6yUIvx4rwGemwh8kpL1xvU41FXy/s9K7T/3JVcqGzo3NfKM2HrbrGgfPYGFW42f07Wk++aOC6B9NWA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
       ],
@@ -2243,9 +2244,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.18.tgz",
-      "integrity": "sha512-tSn/kzrfa7tNOXr7sEacDBN4YsIqTyLqh45IO0nHDwtpKIDNDJr+VFojt+4klSpChxB29JLyduSsE0MKEwa65A==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "cpu": [
         "arm64"
       ],
@@ -2260,9 +2261,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.18.tgz",
-      "integrity": "sha512-+J9YGmc+czgqlhYmwun3S3O0FIZhsH8ep2456xwjAdIOmuJxM7xz4P4PtrxU+Bz17a/5bqPA8o3HAAoX0teUdg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
       "cpu": [
         "wasm32"
       ],
@@ -2279,9 +2280,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.18.tgz",
-      "integrity": "sha512-zsu47DgU0FQzSwi6sU9dZoEdUv7pc1AptSEz/Z8HBg54sV0Pbs3N0+CrIbTsgiu6EyoaNN9CHboqbLaz9lhOyQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "cpu": [
         "arm64"
       ],
@@ -2296,9 +2297,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.18.tgz",
-      "integrity": "sha512-7H+3yqGgmnlDTRRhw/xpYY9J1kf4GC681nVc4GqKhExZTDrVVrV2tsOR9kso0fvgBdcTCcQShx4SLLoHgaLwhg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "cpu": [
         "x64"
       ],
@@ -2313,9 +2314,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.7",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.7.tgz",
-      "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2327,9 +2328,9 @@
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
-      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
@@ -2346,9 +2347,9 @@
       }
     },
     "node_modules/@tauri-apps/cli": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.11.1.tgz",
-      "integrity": "sha512-rpEbaJ/HzNb6fwsquwoAbq29/Vt4gADhS423A8fdkwL4edJ0wZmoB8ar7O6JPDL834MUKOCm/rrJ7c9oAaEaYQ==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.11.2.tgz",
+      "integrity": "sha512-bk3HemqvGRoy+5D/dVMUQHKMYLglD0jVnMm/0iGMH6ufZ+p8r14m6BpIixwij3PBvZdvORUp1YifTD8QxVZ1Nw==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "bin": {
@@ -2362,23 +2363,23 @@
         "url": "https://opencollective.com/tauri"
       },
       "optionalDependencies": {
-        "@tauri-apps/cli-darwin-arm64": "2.11.1",
-        "@tauri-apps/cli-darwin-x64": "2.11.1",
-        "@tauri-apps/cli-linux-arm-gnueabihf": "2.11.1",
-        "@tauri-apps/cli-linux-arm64-gnu": "2.11.1",
-        "@tauri-apps/cli-linux-arm64-musl": "2.11.1",
-        "@tauri-apps/cli-linux-riscv64-gnu": "2.11.1",
-        "@tauri-apps/cli-linux-x64-gnu": "2.11.1",
-        "@tauri-apps/cli-linux-x64-musl": "2.11.1",
-        "@tauri-apps/cli-win32-arm64-msvc": "2.11.1",
-        "@tauri-apps/cli-win32-ia32-msvc": "2.11.1",
-        "@tauri-apps/cli-win32-x64-msvc": "2.11.1"
+        "@tauri-apps/cli-darwin-arm64": "2.11.2",
+        "@tauri-apps/cli-darwin-x64": "2.11.2",
+        "@tauri-apps/cli-linux-arm-gnueabihf": "2.11.2",
+        "@tauri-apps/cli-linux-arm64-gnu": "2.11.2",
+        "@tauri-apps/cli-linux-arm64-musl": "2.11.2",
+        "@tauri-apps/cli-linux-riscv64-gnu": "2.11.2",
+        "@tauri-apps/cli-linux-x64-gnu": "2.11.2",
+        "@tauri-apps/cli-linux-x64-musl": "2.11.2",
+        "@tauri-apps/cli-win32-arm64-msvc": "2.11.2",
+        "@tauri-apps/cli-win32-ia32-msvc": "2.11.2",
+        "@tauri-apps/cli-win32-x64-msvc": "2.11.2"
       }
     },
     "node_modules/@tauri-apps/cli-darwin-arm64": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.11.1.tgz",
-      "integrity": "sha512-6eEKMBXsQPCuM1EmvrjT2+aBuxWQuFdKdW8pzNuNQtpq45nEEpBlD5gr8pUeAyOU1DQKlkFaEc/MPBxb/Pfjtg==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.11.2.tgz",
+      "integrity": "sha512-+4UZzLt+eOAEQCwgd+TqKgyUJMrvx+BgdXLLaqJYmPqzP+nE6YZr/hY6CWLYGQb8jFn99jEkmC6uA3tNvamA1w==",
       "cpu": [
         "arm64"
       ],
@@ -2393,9 +2394,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-darwin-x64": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.11.1.tgz",
-      "integrity": "sha512-LQUO7exfRWjWALNhetph5guWpMeHphRpokOLk0OIbTTExaNwJNFu3I4vb+CCM/4G/QGoZe/5XikZOJdNEFP1ig==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.11.2.tgz",
+      "integrity": "sha512-VjYYtZUPqDMLutSfJEyxFE3Bz+DPi7c8wC3imckgvciLDZLq4qwKJxBicg0BXGhXjJsl8vKWgWRFNMPELQ+Xyg==",
       "cpu": [
         "x64"
       ],
@@ -2410,9 +2411,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm-gnueabihf": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.11.1.tgz",
-      "integrity": "sha512-5i/awiBCRRhOUG8yjn0fMHXIWD5Ez8eEk5LtvOxyQrKuJkRaZDvnbIjZbE183blAwkoA4xN3aO/prJiqscl02Q==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.11.2.tgz",
+      "integrity": "sha512-yMemD6f4i95AQriS8EazyOFzbE34yjnP16i3IOzpHGQvBoy2DjypFMFBq0NtPuITURv/cOGguRtHR5d79/9CSA==",
       "cpu": [
         "arm"
       ],
@@ -2427,9 +2428,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm64-gnu": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.11.1.tgz",
-      "integrity": "sha512-9LrwDw3S9Fygtw/Q6WDhOP+3svJRGAsejeE+GKrc0eO1ThMVhwi2LL6hw4dlKw93IfS7VY1G19sWGxJ/NcU4nA==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.11.2.tgz",
+      "integrity": "sha512-cgI91D2wL8GSgoWwZXDqt+DwnuZCP2/bz03QAE4TrhgAKIsrB4hX26W/H1EONPUUNkqrsgeCD0wU6pcNjV/5kw==",
       "cpu": [
         "arm64"
       ],
@@ -2447,9 +2448,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm64-musl": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.11.1.tgz",
-      "integrity": "sha512-mNA5dbbqPqDUdTIwdUYYuhO2GvIe9UnB2r0VU2njxBOS3Opbx4gKNC5yP0Iu4rYmEmqdlwry9VzGZQ3wq9dyFg==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.11.2.tgz",
+      "integrity": "sha512-X1rm0BERqAAggtYTESSgXrS3sz4Sb/OiPiz54UqISlXW+GkR3vNIGnsy/lejNmoXGVqri3Q53BCfQiclOIyRPw==",
       "cpu": [
         "arm64"
       ],
@@ -2467,9 +2468,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-riscv64-gnu": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.11.1.tgz",
-      "integrity": "sha512-fZj3Gwq+6fUs305T5WQiD5iSGJw+j/4w/HGmk4sHDAcy+rp9zU5eaxB7nOyz5/I/nkNAuKPqfp6uIbiUBXkBCw==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.11.2.tgz",
+      "integrity": "sha512-usbMLJbT3KtkOrBMDVeGYNM35aTHXx38SJSzTMSqqjeUIOQ+iVPjb2yAGNAE+KqmBbAx4FOFIyMeKXx2M/JKGQ==",
       "cpu": [
         "riscv64"
       ],
@@ -2487,9 +2488,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-x64-gnu": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.11.1.tgz",
-      "integrity": "sha512-XFxGxOvHM7jjeD6ozCKdGfhzJ7lERYDGZl1/Kb4fsvchaJsfLJ981TlyTG8Qy/gFq+f5GitH3bfrX9JAkjPEyw==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.11.2.tgz",
+      "integrity": "sha512-Ru4gwJKPG0ctVGchRGpRup4Y4lW2SSfFnrbQcyHhCliKy4g8Qz97TrUgCur4CbWyAgKxvGh3SjrkA0LDYzDGiw==",
       "cpu": [
         "x64"
       ],
@@ -2507,9 +2508,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-x64-musl": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.11.1.tgz",
-      "integrity": "sha512-d5C2/Zm+68v7R9wTuTCjRQEVrWjcdMkJBZ1+rXse+QdMMlTB9+u9PDNDLw9PQflWxYLaYZ7tjxxL9Nb9II6PbA==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.11.2.tgz",
+      "integrity": "sha512-eUm7T6clN1MMmNSRQ9gaWsQdyehQx2Gmn5hht/QUlqZQI/qcP2OJK5dnaxqwFzCr2HdsEo9ydxaqcS1oJzMvUw==",
       "cpu": [
         "x64"
       ],
@@ -2527,9 +2528,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-arm64-msvc": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.11.1.tgz",
-      "integrity": "sha512-YdeVWFAR1pTXzUU6NLstPq4G6OLxuDrXCXEBdmBH+5EZIDXUx0D2kJlz3+YjpazkKvAzYpgziTsyRagls0OfRQ==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.11.2.tgz",
+      "integrity": "sha512-HeeZW80jU+gVTOEX4X/hC6NVSAdDVXajwP5fxIZ/3z9WvUC7qrudX2GMTilYq6Dg0e0sk0XgsAJD1hZ5wPBXUA==",
       "cpu": [
         "arm64"
       ],
@@ -2544,9 +2545,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-ia32-msvc": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.11.1.tgz",
-      "integrity": "sha512-VBGkuH0eB9K9LLSMv361Gzr5Ou72sCS4+ztpmkWEQ+wd/amhcYOsf3X6qn1RJZDzIhiOYHJEOysZUC3baD01rA==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.11.2.tgz",
+      "integrity": "sha512-YhjQNZcXfbkCLyazSv1nPnJ9iRFE1wm6kc51FDbU10/Dk09io+6PAGMLjkxnX2GdM0qMnDmTjstY8mTDVvtKeA==",
       "cpu": [
         "ia32"
       ],
@@ -2561,9 +2562,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-x64-msvc": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.11.1.tgz",
-      "integrity": "sha512-b3ORhIAKgp9ZYY+zBt7b7r0kLU2kjvyGF0+MS2SBym3emsweGPybEqocJcmtMuxyBhkOKHP4CiuEJEDuAlTx6A==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.11.2.tgz",
+      "integrity": "sha512-d2JchlFIpZevZVReyqhQOekJmb1UH3rhZ5VX6sH3ty9ETE0TKQavpihvoScUXfKKpW6HZC0MrFGRU0ZtD+w3gA==",
       "cpu": [
         "x64"
       ],
@@ -2718,16 +2719,16 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "version": "19.2.16",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.16.tgz",
+      "integrity": "sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w==",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2750,13 +2751,13 @@
       "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
-      "integrity": "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.2.tgz",
+      "integrity": "sha512-DlSMqo4WhThw4vB8Mpn0Woe9J+Jfq1geJ61AKW0QEgLzGMNwtIMdxbDUzLxcun8W7NbJO0e2Jg/Nxm3cCSVzzg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@rolldown/pluginutils": "1.0.0-rc.7"
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
@@ -2776,16 +2777,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
-      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.5",
-        "@vitest/utils": "4.1.5",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -2794,13 +2795,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
-      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.5",
+        "@vitest/spy": "4.1.8",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -2821,9 +2822,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
-      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2834,13 +2835,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
-      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.5",
+        "@vitest/utils": "4.1.8",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -2848,14 +2849,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
-      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.5",
-        "@vitest/utils": "4.1.5",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/utils": "4.1.8",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -2864,9 +2865,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
-      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2874,13 +2875,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
-      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.5",
+        "@vitest/pretty-format": "4.1.8",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -3272,9 +3273,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
-      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
       "dev": true,
       "funding": [
         {
@@ -3285,9 +3286,10 @@
       "license": "MIT",
       "dependencies": {
         "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.7",
+        "fast-xml-builder": "^1.2.0",
         "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -3377,9 +3379,9 @@
       }
     },
     "node_modules/i18next": {
-      "version": "26.0.10",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.0.10.tgz",
-      "integrity": "sha512-k3yGPAlWR2RdMYoVXJoDZDT87qeHIWKH7gVksdZMpRty7QX/D9QZeYGvN08KGbKHke9wn01eYT+EEsrqX/YTlw==",
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.3.0.tgz",
+      "integrity": "sha512-gHSgGpUXVmuqE2El1W61DmxeyeTlFfZgdJRWMo9jScAn5pu7TuTuiccb1zh3E2J9hEBVGJ23+96x0ieBhfuIHA==",
       "funding": [
         {
           "type": "individual",
@@ -3499,16 +3501,6 @@
         "canvas": {
           "optional": true
         }
-      }
-    },
-    "node_modules/jsdom/node_modules/lru-cache": {
-      "version": "11.3.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
-      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/jszip": {
@@ -3834,6 +3826,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/lz-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -3973,13 +3975,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.1"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -3992,9 +3994,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4005,9 +4007,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -4025,7 +4027,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -4067,30 +4069,30 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
-      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
-      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.6"
+        "react": "^19.2.7"
       }
     },
     "node_modules/react-i18next": {
-      "version": "17.0.7",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.7.tgz",
-      "integrity": "sha512-rwtPXsb/zwzDafN+gytcjF5YnqGQQIRmCQ6DctBC1VSipRB8GD/MWEVrFP42vjMyuYydxWxM8CZRt+yiNuuoHg==",
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.8.tgz",
+      "integrity": "sha512-0ooKbGLU8JXhe1zwpQUWIeXSgLPOfwJmgheWRIUpcoA0CpyabpGhayjdG+/eA5esC1AQ8h2jWpXjJfzQzeDOCw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.2",
@@ -4098,7 +4100,7 @@
         "use-sync-external-store": "^1.6.0"
       },
       "peerDependencies": {
-        "i18next": ">= 26.0.10",
+        "i18next": ">= 26.2.0",
         "react": ">= 16.8.0",
         "typescript": "^5 || ^6"
       },
@@ -4173,14 +4175,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.18.tgz",
-      "integrity": "sha512-phmyKBpuBdRYDf4hgyynGAYn/rDDe+iZXKVJ7WX5b1zQzpLkP5oJRPGsfJuHdzPMlyyEO/4sPW6yfSx2gf7lVg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.128.0",
-        "@rolldown/pluginutils": "1.0.0-rc.18"
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -4189,29 +4191,22 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.18",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.18",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.18",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.18",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.18",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.18",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.18",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.18",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.18",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.18",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.18",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.18",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.18",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.18",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.18"
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
-    },
-    "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.18.tgz",
-      "integrity": "sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/rtl-css-js": {
       "version": "1.16.1",
@@ -4272,9 +4267,9 @@
       "license": "MIT"
     },
     "node_modules/selenium-webdriver": {
-      "version": "4.43.0",
-      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.43.0.tgz",
-      "integrity": "sha512-dV4zBTT37or3Z3/8uD6rS8zvd4ZxPuG4EJVlqYIbZCGZCYttZm7xb9rlFLSk4rrsQHAeDYvudl7cquo0vWpHjg==",
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.44.0.tgz",
+      "integrity": "sha512-7RbYoKK0zET+KMVak11UDCtKvNulOU6gFZp8HI5GN9K8+BhqrliIJU/FP6QADrvRAXFMr3wHxfE3JHOcAxO3GQ==",
       "dev": true,
       "funding": [
         {
@@ -4291,7 +4286,7 @@
         "@bazel/runfiles": "^6.5.0",
         "jszip": "^3.10.1",
         "tmp": "^0.2.5",
-        "ws": "^8.20.0"
+        "ws": "^8.20.1"
       },
       "engines": {
         "node": ">= 20.0.0"
@@ -4431,9 +4426,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
-      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4441,9 +4436,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4468,29 +4463,29 @@
       }
     },
     "node_modules/tldts": {
-      "version": "7.0.30",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
-      "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.2.tgz",
+      "integrity": "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.30"
+        "tldts-core": "^7.4.2"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.30",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
-      "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
+      "integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4544,9 +4539,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.0.tgz",
+      "integrity": "sha512-+t2Z/GwkZQDtu00813aP66ygViGtPHKhhoFZpQKpKrE+9jIgES+Zw+mFNaDWOVRKiuJjuqKHzD3B1sfGg8+ZOQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4570,17 +4565,17 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "8.0.11",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.11.tgz",
-      "integrity": "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.14",
-        "rolldown": "1.0.0-rc.18",
-        "tinyglobby": "^0.2.16"
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -4663,19 +4658,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
-      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.5",
-        "@vitest/mocker": "4.1.5",
-        "@vitest/pretty-format": "4.1.5",
-        "@vitest/runner": "4.1.5",
-        "@vitest/snapshot": "4.1.5",
-        "@vitest/spy": "4.1.5",
-        "@vitest/utils": "4.1.5",
+        "@vitest/expect": "4.1.8",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/runner": "4.1.8",
+        "@vitest/snapshot": "4.1.8",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -4703,12 +4698,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.5",
-        "@vitest/browser-preview": "4.1.5",
-        "@vitest/browser-webdriverio": "4.1.5",
-        "@vitest/coverage-istanbul": "4.1.5",
-        "@vitest/coverage-v8": "4.1.5",
-        "@vitest/ui": "4.1.5",
+        "@vitest/browser-playwright": "4.1.8",
+        "@vitest/browser-preview": "4.1.8",
+        "@vitest/browser-webdriverio": "4.1.8",
+        "@vitest/coverage-istanbul": "4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -4843,9 +4838,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -16,30 +16,30 @@
     "e2e": "playwright test -c playwright.tauri.config.ts"
   },
   "dependencies": {
-    "@fluentui/react-components": "^9.73.8",
-    "@fluentui/react-icons": "^2.0.326",
+    "@fluentui/react-components": "^9.74.1",
+    "@fluentui/react-icons": "^2.0.328",
     "@tauri-apps/api": "^2.11.0",
     "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-sql": "^2.4.0",
     "@tauri-apps/plugin-store": "^2.4.3",
-    "i18next": "^26.0.10",
-    "react": "^19.2.6",
-    "react-dom": "^19.2.6",
-    "react-i18next": "^17.0.7"
+    "i18next": "^26.3.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "react-i18next": "^17.0.8"
   },
   "devDependencies": {
-    "@playwright/test": "^1.59.1",
-    "@tauri-apps/cli": "^2.11.1",
+    "@playwright/test": "^1.60.0",
+    "@tauri-apps/cli": "^2.11.2",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
-    "@types/react": "^19.2.14",
+    "@types/react": "^19.2.16",
     "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react": "^6.0.1",
+    "@vitejs/plugin-react": "^6.0.2",
     "edgedriver": "^6.3.0",
     "jsdom": "^29.1.1",
-    "selenium-webdriver": "^4.43.0",
+    "selenium-webdriver": "^4.44.0",
     "typescript": "^6.0.3",
-    "vite": "^8.0.11",
-    "vitest": "^4.1.5"
+    "vite": "^8.0.16",
+    "vitest": "^4.1.8"
   }
 }


### PR DESCRIPTION
## Summary
- npm を semver 範囲内で更新し、`package.json` の下限と lockfile を同期（`@fluentui/*`, react / react-dom 19.2.7, i18next 26.3.0, vite 8.0.16, vitest 4.1.8, playwright 1.60.0 ほか）
- cargo は lockfile のみ更新（tauri 2.11.2, serde_json 1.0.150, reqwest 0.13.4, wasm-bindgen 0.2.122 ほか互換版）。`Cargo.toml` は不変
- `rusqlite` は 0.32 を維持（`sqlx-sqlite` と `libsqlite3-sys` の `links = "sqlite3"` 共有制約により major 更新は封印）

## Test plan
- [x] `npm run build`（vite 8.0.16）
- [x] `npm test`（vitest 107 件）
- [x] `npm run check:ui-guidelines`（6 件）
- [x] `npm run test:ui-guidelines-check`（6 件）
- [x] `cargo test --manifest-path src-tauri/Cargo.toml`（36 件）
- [x] `cargo test --manifest-path crates/ghost-meta/Cargo.toml`（35 件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)