### PR TITLE
fix: Claude Code フックを stdin JSON 入力・$CLAUDE_PROJECT_DIR 絶対パスへ修正

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,12 +6,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash scripts/hooks/check-ts-types.sh",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/hooks/check-ts-types.sh\"",
             "timeout": 30000
           },
           {
             "type": "command",
-            "command": "bash scripts/hooks/check-rust-clippy.sh",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/hooks/check-rust-clippy.sh\"",
             "timeout": 60000
           }
         ]
@@ -23,7 +23,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash scripts/hooks/warn-migration-edit.sh"
+            "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/hooks/warn-migration-edit.sh\""
           }
         ]
       }

--- a/scripts/hooks/check-rust-clippy.sh
+++ b/scripts/hooks/check-rust-clippy.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
-# PostToolUse hook: .rs ファイル編集後に cargo clippy を実行
-# Edit/Write の file_path が .rs で終わる場合のみ clippy を走らせる
+# PostToolUse hook (Edit|Write): .rs 編集後に cargo clippy を実行する。
+# tool 入力は stdin の JSON で渡る（.tool_input.file_path）。$TOOL_INPUT は存在しない。
 
-case "$TOOL_INPUT" in
-  *'.rs"'*)
-    output=$(cargo clippy --manifest-path src-tauri/Cargo.toml --quiet 2>&1)
-    exit_code=$?
-    if [ $exit_code -ne 0 ]; then
-      echo "$output" | tail -15
-    fi
-    ;;
+file_path=$(jq -r '.tool_input.file_path // empty' 2>/dev/null)
+case "$file_path" in
+  *.rs) ;;
+  *) exit 0 ;;
 esac
+
+# --manifest-path が相対指定のため、プロジェクトルートへ移動してから走らせる。
+cd "${CLAUDE_PROJECT_DIR:-.}" || exit 0
+if ! output=$(cargo clippy --manifest-path src-tauri/Cargo.toml --quiet 2>&1); then
+  echo "$output" | tail -15
+fi

--- a/scripts/hooks/check-ts-types.sh
+++ b/scripts/hooks/check-ts-types.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
-# PostToolUse hook: .ts/.tsx ファイル編集後に型チェックを実行
-# Edit/Write の file_path が .ts or .tsx で終わる場合のみ tsc を走らせる
+# PostToolUse hook (Edit|Write): .ts/.tsx 編集後に tsc --noEmit で型チェックする。
+# tool 入力は stdin の JSON で渡る（.tool_input.file_path）。$TOOL_INPUT は存在しない。
 
-case "$TOOL_INPUT" in
-  *'.ts"'*|*'.tsx"'*)
-    output=$(npx tsc --noEmit --pretty 2>&1)
-    exit_code=$?
-    if [ $exit_code -ne 0 ]; then
-      echo "$output" | tail -10
-    fi
-    ;;
+file_path=$(jq -r '.tool_input.file_path // empty' 2>/dev/null)
+case "$file_path" in
+  *.ts | *.tsx) ;;
+  *) exit 0 ;;
 esac
+
+# tsc は tsconfig.json をルートから解決するため、プロジェクトルートへ移動する。
+cd "${CLAUDE_PROJECT_DIR:-.}" || exit 0
+if ! output=$(npx tsc --noEmit --pretty 2>&1); then
+  echo "$output" | tail -10
+fi

--- a/scripts/hooks/warn-migration-edit.sh
+++ b/scripts/hooks/warn-migration-edit.sh
@@ -1,12 +1,17 @@
 #!/bin/bash
-# PreToolUse hook: lib.rs のマイグレーション SQL 編集時に警告（非ブロック）
+# PreToolUse hook (Edit): lib.rs のマイグレーション SQL 編集時に警告する（非ブロック）。
 # 既存マイグレーションの SQL を変更するとチェックサム不一致で起動クラッシュする。
-# 新規マイグレーション追加は安全。
+# 新規マイグレーション追加は安全。tool 入力は stdin の JSON で渡る。$TOOL_INPUT は存在しない。
 
-case "$TOOL_INPUT" in
-  *'lib.rs"'*)
-    if echo "$TOOL_INPUT" | grep -qiE 'ALTER TABLE|CREATE TABLE|CREATE INDEX|DROP TABLE|DROP INDEX'; then
-      echo "lib.rs のマイグレーション SQL を編集しようとしています。既存マイグレーションの変更はチェックサム不一致で起動クラッシュします（src-tauri/CLAUDE.md 参照）。新規マイグレーション追加のみ安全です。"
-    fi
-    ;;
+input=$(cat)
+file_path=$(echo "$input" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
+case "$file_path" in
+  *lib.rs) ;;
+  *) exit 0 ;;
 esac
+
+# old_string / new_string の双方を含む tool_input 全体を対象に SQL キーワードを探す。
+if echo "$input" | grep -qiE 'ALTER TABLE|CREATE TABLE|CREATE INDEX|DROP TABLE|DROP INDEX'; then
+  echo "lib.rs のマイグレーション SQL を編集しようとしています。既存マイグレーションの変更はチェックサム不一致で起動クラッシュします（src-tauri/CLAUDE.md 参照）。新規マイグレーション追加のみ安全です。"
+fi
+exit 0


### PR DESCRIPTION
## 背景
`.claude/settings.json` のフックが「`bash: scripts/hooks/check-rust-clippy.sh: No such file or directory`」と失敗していた。調査の結果、**2 つのバグ**でフックが導入以来まったく機能していなかったことが判明した。

## 根本原因
### ① 相対パス × cwd 漂流（＝表に出ていたエラー）
フックコマンドが相対パス `bash scripts/hooks/xxx.sh` を使用。Claude Code はフックの cwd を保証しないため、cwd がルート以外だと "No such file or directory" で失敗する。実証: ルートから実行 `exit 0` / `src-tauri` から実行 `exit 127`（再現）。

### ② `$TOOL_INPUT` は存在しない（沈黙の失敗）
各スクリプトが `case "$TOOL_INPUT"` で編集ファイルを判定していたが、現行フック API では tool 入力は **stdin の JSON** で渡る。`$TOOL_INPUT` は常に空文字で、clippy / tsc / マイグレーション警告が**一度も実行されていなかった**。

## 修正
- **settings.json**: 3 箇所のコマンドを `bash "$CLAUDE_PROJECT_DIR/scripts/hooks/xxx.sh"`（絶対パス）へ
- **3 スクリプト**: `$TOOL_INPUT` → `jq -r '.tool_input.file_path'`（stdin から抽出）へ書き換え
- 各スクリプトに `cd "${CLAUDE_PROJECT_DIR:-.}"` を追加し、cargo/tsc を正しいルートから走らせる

## Test plan
- [x] mock stdin JSON で Red→Green を確認（migration 警告/沈黙、`.tsx`→tsc 実走、`.rs`→clippy 実走、非対象拡張子は即 skip）
- [x] settings.json は valid JSON（`jq empty`）
- [x] tsc・clippy ともクリーン（フック有効化後も警告で溢れない）
- [x] `npm run build` / `npm test`（107）/ UI ガイドライン / `cargo test`（36）すべて緑
- 注: シェルフック用テスト基盤が無く、チェックフックは外部ツール(cargo/tsc)を起動するため、自動テストは追加せず手動検証とした

🤖 Generated with [Claude Code](https://claude.com/claude-code)