### PR TITLE
docs: 横断パターンに Claude Code フック作法を追記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,8 @@ ghost_launcher/
 
 **ゴーストのディレクトリ構造**: `{parent}/ghost/{ghost_name}/ghost/master/descript.txt`。`parent` は `{ssp_path}`（SSP ネイティブゴースト用）または、ゴーストサブディレクトリを直接含むユーザー指定の追加フォルダです。
 
+**Claude Code フック**: `.claude/settings.json` のフックは `scripts/hooks/*.sh` を `bash "$CLAUDE_PROJECT_DIR/..."`（絶対パス）で呼ぶ。tool 入力は **stdin の JSON** で渡り `jq -r '.tool_input.file_path'` で取り出す（`$TOOL_INPUT` は存在しない。フックの cwd も保証されないので相対パス厳禁）。
+
 ## 開発方針
 
 - **KISS**: シンプルさを最優先する。1つの関数は1つのことだけを行い、短く保つ。到達不能なフォールバックや使われない汎用化は書かない


### PR DESCRIPTION
## Summary
- `CLAUDE.md` の「横断パターン」節に、Claude Code フック作成時の作法を一行追記
- tool 入力は **stdin の JSON**（`jq -r '.tool_input.file_path'`）で受け取り、`$TOOL_INPUT` は存在しないこと
- スクリプト参照は `$CLAUDE_PROJECT_DIR` 絶対パスで書くこと（フックの cwd は保証されない）
- PR #75 でフックが両バグにより全機能していなかった教訓の再発防止メモ

## Test plan
- [x] ドキュメントのみの変更（コード・ビルドへの影響なし）につきテストは対象外

🤖 Generated with [Claude Code](https://claude.com/claude-code)