### PR TITLE
test: スクロール E2E を仮想化モデルに整合させる (#70)

### DIFF
--- a/e2e/ghost-list.e2e.ts
+++ b/e2e/ghost-list.e2e.ts
@@ -26,6 +26,12 @@ async function findEmptyStateText(driver: WebDriver): Promise<string | null> {
   }
 }
 
+/** 現在 DOM に描画されているゴースト名の一覧を取得する（仮想化の窓内のカードのみ） */
+async function visibleGhostNames(driver: WebDriver): Promise<string[]> {
+  const els = await driver.findElements(By.css("[data-testid='ghost-name']"));
+  return Promise.all(els.map((el) => el.getText()));
+}
+
 // --- テストケース ---
 
 test("起動テスト: アプリが起動しウィンドウが表示される", async ({ harness }) => {
@@ -117,7 +123,7 @@ test("検索: 検索ボックスに入力すると一覧がフィルタされる
   }, 10_000);
 });
 
-test("スクロール＆ページネーション: 下にスクロールすると追加読込がトリガーされる", async ({ harness }) => {
+test("スクロール＆ページネーション: 下にスクロールすると後続のゴーストが表示される", async ({ harness }) => {
   const { driver } = harness;
   await waitForAppReady(driver);
 
@@ -127,29 +133,34 @@ test("スクロール＆ページネーション: 下にスクロールすると
     test.skip();
     return;
   }
-  const countBefore = initialButtons.length;
 
-  // total 表示を取得して追加読込が可能か確認
+  // 仮想化は total >= 80 で有効化される（GhostList.tsx の shouldVirtualize）。
+  // 仮想化されない件数では全件が同時に描画され、スクロールしても描画内容が
+  // 変わらないためスキップする。
   const countText = await driver.findElement(By.css("[aria-live='polite']")).getText();
   const totalMatch = countText.match(/(\d+)/);
-  if (!totalMatch || parseInt(totalMatch[1], 10) <= countBefore) {
-    // 全件読み込み済みならスキップ
+  if (!totalMatch || parseInt(totalMatch[1], 10) < 80) {
     test.skip();
     return;
   }
 
-  // ビューポートの末尾までスクロール
+  // 仮想化リストは DOM のカード枚数を一定の窓に保つため「枚数の増加」では検証できない。
+  // 代わりに「窓が移動し、スクロール前に無かったゴーストが描画される」ことを検証する。
+  const namesBefore = new Set(await visibleGhostNames(driver));
+
+  // ビューポートの末尾までスクロール（scrollTop 代入は scroll イベントを発火する）
   await driver.executeScript(`
     const viewport = document.querySelector("[data-testid='ghost-list-viewport']");
     if (viewport) viewport.scrollTop = viewport.scrollHeight;
   `);
 
-  // 追加読み込みによってカード数が増えるのを待機
+  // 末尾行は当初 SkeletonCard（ghost-name を持たない）で、追加読込の完了後に
+  // GhostCard へ差し替わる。スクロール前に無かったゴースト名の出現を待機する。
   await driver.wait(async () => {
-    const elements = await driver.findElements(By.css("[data-testid='launch-button']"));
-    return elements.length > countBefore;
+    const namesNow = await visibleGhostNames(driver);
+    return namesNow.some((name) => name.length > 0 && !namesBefore.has(name));
   }, 15_000);
 
-  const cardsAfter = await driver.findElements(By.css("[data-testid='launch-button']"));
-  expect(cardsAfter.length).toBeGreaterThan(countBefore);
+  const namesAfter = await visibleGhostNames(driver);
+  expect(namesAfter.some((name) => name.length > 0 && !namesBefore.has(name))).toBe(true);
 });


### PR DESCRIPTION
## Summary
- #70 の根本原因は **テストの前提モデルの誤り**。旧テストは「スクロール＝ DOM カードが累積的に増える」という append 型ページネーションを前提にしていたが、`GhostList` は描画枚数を一定の窓に保つ**スライディングウィンドウ型仮想化**のため、`launch-button` 枚数が `countBefore` を超えることは構造上ありえず（末尾では下側 overscan がクランプされ枚数はむしろ減る）、15s タイムアウトしていた。
- アサーションを **「可視ゴースト名の集合がスクロール後に入れ替わる」** へ是正。窓が移動し末尾の `SkeletonCard` が `GhostCard` へ差し替われば、スクロール前に無かった名前が出現する。仮想化が有効化される `total >= 80` 未満ではスキップ（旧 `total <= countBefore` ガードも是正）。
- `visibleGhostNames` ヘルパーを追加。変更は `e2e/ghost-list.e2e.ts` の 1 ファイルに閉じる。

## Test plan
- [x] `npm run build`
- [x] `npm test`（107 passed）
- [x] `npm run check:ui-guidelines`
- [x] `npm run test:ui-guidelines-check`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml`（36 passed）
- [x] 手動 E2E（`npm run tauri build` → `playwright`）: `:126` の **15s タイムアウト失敗が消滅**し clean に skip。非ゴーストテスト（`:37`/`:45`/`:65`）は passed。
- [ ] `:126` の積極的 passed は**本環境では観測不能**（下記）

## E2E に関する注記
- 本環境ではゴースト依存テスト（**未変更の `:80`・`:94` を含む**）が一律 skip する。原因は #70 とは別で、`App.tsx` の `searchRequestKey` が `refreshTrigger > 0`（初回スキャン完了）まで `null` のため、**初回スキャンが完了するまで画面が空状態**になること。1193 件×クラウド含む複数フォルダの走査が harness 環境で 180s 内に完了せず、ゴーストが表示されないため検証の前提が成立しない。
- 修正の正しさは構造的論証で担保。ゴーストが表示される環境（CI 不対象のため要手動）では passed が観測できるはず。
- 派生所見（別 issue 候補）: 「初回スキャン完了まで一覧が空」かつ「大量＋クラウドフォルダで数分かかりうる」点は UX/E2E 双方の課題。

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)