### PR TITLE
fix: 起動時のキャッシュ即時表示とスキャンエラー時のキャッシュ保持（stale-while-revalidate）

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render } from "@testing-library/react";
 
 vi.mock("react-i18next", () => ({
@@ -22,25 +22,36 @@ vi.mock("./hooks/useSettings", () => ({
   }),
 }));
 
-// 初回スキャンが進行中（ghostsLoading=true のまま）= キャッシュ未活用バグの再現条件
-vi.mock("./hooks/useGhosts", () => ({
-  useGhosts: () => ({ loading: true, error: null, refresh: vi.fn() }),
-}));
-
-// useSearch の呼び出し引数（特に requestKey）を捕捉する
-const { useSearchSpy } = vi.hoisted(() => ({
-  useSearchSpy: vi.fn(() => ({
-    ghosts: [],
+// useGhosts / useSearch の戻り値はテストごとに差し替える。GhostContent が受け取る
+// props を捕捉し、App の合成ロジック（requestKey ゲート・エラー抑制）を検証する
+const mocks = vi.hoisted(() => ({
+  ghostsState: { loading: true, error: null as string | null, refresh: () => {} },
+  searchState: {
+    ghosts: [] as unknown[],
     total: 0,
     loadedStart: 0,
     loading: false,
-    dbError: null,
-  })),
-}));
-vi.mock("./hooks/useSearch", () => ({
-  useSearch: useSearchSpy,
+    dbError: null as string | null,
+  },
+  useSearchSpy: vi.fn(),
+  ghostContentSpy: vi.fn(),
 }));
 
+vi.mock("./hooks/useGhosts", () => ({
+  useGhosts: () => mocks.ghostsState,
+}));
+vi.mock("./hooks/useSearch", () => ({
+  useSearch: (...args: unknown[]) => {
+    mocks.useSearchSpy(...args);
+    return mocks.searchState;
+  },
+}));
+vi.mock("./components/GhostContent", () => ({
+  GhostContent: (props: Record<string, unknown>) => {
+    mocks.ghostContentSpy(props);
+    return null;
+  },
+}));
 // plugin-sql のロードを避けるため DB アクセス関数はモック化する
 vi.mock("./lib/ghostDatabase", () => ({
   getRandomGhost: vi.fn(),
@@ -49,13 +60,60 @@ vi.mock("./lib/ghostDatabase", () => ({
 
 import App from "./App";
 
+function makeGhost(name: string) {
+  return {
+    name,
+    directory_name: name.toLowerCase(),
+    path: `/${name}`,
+    source: "ssp",
+    name_lower: name.toLowerCase(),
+    directory_name_lower: name.toLowerCase(),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.ghostsState = { loading: true, error: null, refresh: () => {} };
+  mocks.searchState = { ghosts: [], total: 0, loadedStart: 0, loading: false, dbError: null };
+});
+
 describe("App - 起動時のキャッシュ即時表示", () => {
   it("初回スキャン中（ghostsLoading=true）でも sspPath が確定していればキャッシュを即時クエリする", () => {
+    mocks.ghostsState = { loading: true, error: null, refresh: () => {} };
+
     render(<App />);
 
     // useSearch の第1引数 requestKey が非 null = スキャン完了を待たずに DB を引く
-    const lastCall = useSearchSpy.mock.calls.at(-1);
+    const lastCall = mocks.useSearchSpy.mock.calls.at(-1);
     expect(lastCall?.[0]).not.toBeNull();
     expect(typeof lastCall?.[0]).toBe("string");
+  });
+});
+
+describe("App - スキャンエラー時のキャッシュ保持（SPEC 9 エラーハンドリング）", () => {
+  it("キャッシュ表示中（ゴーストあり）はスキャンエラーを抑制する", () => {
+    mocks.ghostsState = { loading: false, error: "scan failed", refresh: () => {} };
+    mocks.searchState = {
+      ghosts: [makeGhost("Reimu"), makeGhost("Marisa")],
+      total: 2,
+      loadedStart: 0,
+      loading: false,
+      dbError: null,
+    };
+
+    render(<App />);
+
+    const props = mocks.ghostContentSpy.mock.calls.at(-1)?.[0];
+    expect(props?.error).toBeNull();
+  });
+
+  it("キャッシュなし（ゴースト空）ではスキャンエラーを表示する", () => {
+    mocks.ghostsState = { loading: false, error: "scan failed", refresh: () => {} };
+    mocks.searchState = { ghosts: [], total: 0, loadedStart: 0, loading: false, dbError: null };
+
+    render(<App />);
+
+    const props = mocks.ghostContentSpy.mock.calls.at(-1)?.[0];
+    expect(props?.error).toBe("scan failed");
   });
 });

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+  // lib/i18n.ts が読込時に i18n.use(initReactI18next) を呼ぶためスタブを供給する
+  initReactI18next: { type: "3rdParty", init: () => {} },
+}));
+
+// 設定読込は完了済み・sspPath は確定している状態
+vi.mock("./hooks/useSettings", () => ({
+  useSettings: () => ({
+    sspPath: "C:/SSP",
+    saveSspPath: vi.fn(),
+    ghostFolders: [],
+    addGhostFolder: vi.fn(),
+    removeGhostFolder: vi.fn(),
+    language: "ja",
+    saveLanguage: vi.fn(),
+    loading: false,
+    languageApplying: false,
+  }),
+}));
+
+// 初回スキャンが進行中（ghostsLoading=true のまま）= キャッシュ未活用バグの再現条件
+vi.mock("./hooks/useGhosts", () => ({
+  useGhosts: () => ({ loading: true, error: null, refresh: vi.fn() }),
+}));
+
+// useSearch の呼び出し引数（特に requestKey）を捕捉する
+const { useSearchSpy } = vi.hoisted(() => ({
+  useSearchSpy: vi.fn(() => ({
+    ghosts: [],
+    total: 0,
+    loadedStart: 0,
+    loading: false,
+    dbError: null,
+  })),
+}));
+vi.mock("./hooks/useSearch", () => ({
+  useSearch: useSearchSpy,
+}));
+
+// plugin-sql のロードを避けるため DB アクセス関数はモック化する
+vi.mock("./lib/ghostDatabase", () => ({
+  getRandomGhost: vi.fn(),
+  recordLaunch: vi.fn(),
+}));
+
+import App from "./App";
+
+describe("App - 起動時のキャッシュ即時表示", () => {
+  it("初回スキャン中（ghostsLoading=true）でも sspPath が確定していればキャッシュを即時クエリする", () => {
+    render(<App />);
+
+    // useSearch の第1引数 requestKey が非 null = スキャン完了を待たずに DB を引く
+    const lastCall = useSearchSpy.mock.calls.at(-1);
+    expect(lastCall?.[0]).not.toBeNull();
+    expect(typeof lastCall?.[0]).toBe("string");
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -97,7 +97,9 @@ function App() {
     ghostsLoading,
   });
 
-  const searchRequestKey = (refreshTrigger > 0 && sspPath)
+  // キャッシュ即時表示（stale-while-revalidate）: sspPath 確定時点で DB を引き、
+  // 初回スキャン完了（refreshTrigger の増加）で再クエリして最新へ差し替える
+  const searchRequestKey = sspPath
     ? buildRequestKey(sspPath, buildAdditionalFolders(ghostFolders))
     : null;
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -150,6 +150,11 @@ function App() {
     setOffset(0);
   }, [setOffset]);
 
+  // キャッシュ表示中（ゴーストあり）はスキャンエラーを抑制し、表示を維持する。
+  // キャッシュが無い場合のみエラーを表示する（SPEC 9 エラーハンドリング）
+  const hasCachedDisplay = searchResultGhosts.length > 0 || searchTotal > 0;
+  const scanError = hasCachedDisplay ? null : error;
+
   if (settingsLoading) {
     return (
       <div className={styles.loading}>
@@ -176,7 +181,7 @@ function App() {
           sortOrder={sortOrder}
           loading={ghostsLoading}
           searchLoading={searchLoading}
-          error={error ?? dbError ?? randomLaunchError}
+          error={scanError ?? dbError ?? randomLaunchError}
           onSearchChange={setSearchQuery}
           onSortChange={handleSortChange}
           onRandomLaunch={handleRandomLaunch}

--- a/src/components/GhostList.test.tsx
+++ b/src/components/GhostList.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { GhostList } from "./GhostList";
+import type { GhostView } from "../types";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+// GhostCard はサムネイル解決等の依存を持つため、表示有無の検証用に最小モック化する
+vi.mock("./GhostCard", () => ({
+  GhostCard: ({ ghost }: { ghost: GhostView }) => (
+    <div data-testid="ghost-card">{ghost.name}</div>
+  ),
+}));
+
+function makeGhost(name: string): GhostView {
+  return {
+    name,
+    directory_name: name.toLowerCase(),
+    path: `/${name}`,
+    source: "ssp",
+    name_lower: name.toLowerCase(),
+    directory_name_lower: name.toLowerCase(),
+  };
+}
+
+const baseProps = {
+  sspPath: "C:/SSP",
+  searchQuery: "",
+  searchLoading: false,
+  error: null as string | null,
+  loadedStart: 0,
+  onLoadMore: vi.fn(),
+};
+
+describe("GhostList - スキャン中のキャッシュ表示（stale-while-revalidate）", () => {
+  it("スキャン中（loading=true）でもキャッシュ済みゴーストがあれば一覧を表示する", () => {
+    const ghosts = [makeGhost("Reimu"), makeGhost("Marisa")];
+    render(<GhostList {...baseProps} ghosts={ghosts} total={2} loading={true} />);
+
+    // スピナーではなく一覧（件数表示 + カード）を表示する
+    expect(screen.queryByText("list.loading")).not.toBeInTheDocument();
+    expect(screen.getByText("list.count")).toBeInTheDocument();
+    expect(screen.getAllByTestId("ghost-card")).toHaveLength(2);
+  });
+
+  it("スキャン中でキャッシュが空（total=0）のときはスピナーを表示する", () => {
+    render(<GhostList {...baseProps} ghosts={[]} total={0} loading={true} />);
+
+    expect(screen.getByText("list.loading")).toBeInTheDocument();
+    expect(screen.queryByTestId("empty-state")).not.toBeInTheDocument();
+  });
+
+  it("スキャン完了後（loading=false）にゴーストが無ければ空状態を表示する", () => {
+    render(<GhostList {...baseProps} ghosts={[]} total={0} loading={false} />);
+
+    expect(screen.getByTestId("empty-state")).toBeInTheDocument();
+    expect(screen.getByText("list.empty")).toBeInTheDocument();
+  });
+});

--- a/src/components/GhostList.tsx
+++ b/src/components/GhostList.tsx
@@ -112,7 +112,9 @@ export function GhostList({ ghosts, total, loadedStart, sspPath, searchQuery, lo
     return () => clearTimeout(timer);
   }, [startIndex, endIndex, loadedStart, loadedEnd, shouldVirtualize, total, searchLoading]);
 
-  if (loading) {
+  // スキャン中でも表示可能なキャッシュがあれば一覧を維持する（stale-while-revalidate）。
+  // 表示するゴーストが無いときのみスピナーを出す
+  if (loading && total === 0 && ghosts.length === 0) {
     return (
       <div className={styles.state}>
         <Spinner label={t("list.loading")} />


### PR DESCRIPTION
## 概要

Closes #78

起動時、`ghosts.db` にキャッシュ済みのゴーストがあっても初回スキャン完了まで一覧が空になる問題を修正し、あわせてキャッシュ表示中のスキャンエラー処理を `SPEC.md` 9 章に整合させる。`SPEC.md` 9.1 の状態遷移（`ShowCachedGhosts → ValidateFingerprint`）および 9 章のエラーハンドリング表が既に記述していた**意図された挙動**で、実装が仕様に追いついていなかった。

## 変更 1: 起動時のキャッシュ即時表示（stale-while-revalidate）

### 原因（二重ゲート）
1. **`App.tsx`**: `searchRequestKey = (refreshTrigger > 0 && sspPath) ? … : null` — `refreshTrigger` は初回スキャン完了で初めて 1 になるため、それまで `useSearch` が DB を一切クエリしない。
2. **`GhostList.tsx`**: `if (loading) return <Spinner>` — `loading`(=`ghostsLoading`) が true の間はキャッシュがあっても無条件でスピナー。

### 修正
- **`App.tsx`**: `searchRequestKey` を `sspPath` 確定時点で算出（`refreshTrigger` ゲート除去）。`refreshTrigger` は `useSearch` の第5引数として温存し、スキャン完了時（0→1）の再クエリ＝revalidate を駆動。
- **`GhostList.tsx`**: スピナー条件を `loading && total === 0 && ghosts.length === 0` に変更。表示できるキャッシュがあればスキャン中でも一覧を維持。

`useSearch` は初期ロード時に新データ到着まで `setGhosts` を呼ばないため、再検証中も旧キャッシュが残りちらつきなく差し替わる。

## 変更 2: スキャンエラー時のキャッシュ保持（SPEC 9 エラーハンドリング）

変更 1 でキャッシュが即時表示されるようになった結果、表示中に背景スキャンが失敗するとエラー画面がキャッシュ一覧を上書きしうる。SPEC のエラーハンドリング表に整合させる。

| 状況 | 期待挙動 |
|---|---|
| スキャンエラー（キャッシュ表示済み） | キャッシュ表示を維持しエラーを抑制 |
| スキャンエラー（キャッシュなし） | エラー表示 + 一覧クリア |

- **`App.tsx`**: `searchResultGhosts`/`searchTotal` で「キャッシュ表示中」を判定し、その場合のみスキャンエラー（`useGhosts` の `error`）を抑制。`dbError`/`randomLaunchError` は従来どおり流す。エラー種別を知る合成層で判断するため `GhostList` は無改変。

## テスト（TDD: Red → Green）

- `src/App.test.tsx`（新規→刷新）: ①初回スキャン中でも `useSearch` が非 null の `requestKey` で呼ばれる ②キャッシュ表示中はスキャンエラー抑制 ③キャッシュなしはエラー表示。
- `src/components/GhostList.test.tsx`（新規）: スキャン中のキャッシュ表示／空キャッシュ時のスピナー／スキャン完了後の空状態。

### コミット前チェックリスト
- [x] `npm test`（113 passed）
- [x] `npm run build`
- [x] `npm run check:ui-guidelines`
- [x] `npm run test:ui-guidelines-check`
- [x] `cargo test`: Rust ファイル未変更のため影響なし

## SPEC 整合

`SPEC.md` 9.1 状態遷移図および 9 章エラーハンドリング表は既に本挙動を記述済みのため、SPEC 編集は不要（実装を仕様へ寄せた）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)