### PR TITLE
chore: ドリフト防御フックと運用スキルを追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -26,6 +26,19 @@
             "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/hooks/warn-migration-edit.sh\""
           }
         ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/hooks/warn-generated-edit.sh\""
+          },
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/hooks/warn-protected-file-edit.sh\""
+          }
+        ]
       }
     ]
   }

--- a/.claude/skills/e2e/SKILL.md
+++ b/.claude/skills/e2e/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: e2e
+description: Playwright + tauri-driver の E2E テストを正しい環境変数で実行する。ユーザーが「E2E 回して」「e2e」と言ったときに使う。この環境固有の GHOST_LAUNCHER_E2E_APP / EDGEDRIVER_VERSION の指定と、ゴースト依存テストが skip する既知要因を踏まえる。
+disable-model-invocation: true
+---
+
+# E2E 実行ワークフロー
+
+`playwright.tauri.config.ts` の E2E を、この環境の勘所を踏まえて実行する。E2E は CI に含まれないため、これが唯一の統合テスト手段。
+
+## 前提
+
+- 初回のみ: `npm run e2e:setup`（tauri-driver と EdgeDriver を用意）。
+- 実行前に **`npm run tauri build`** が必要（E2E は release バイナリを検証する）。
+
+## ステップ 1: ビルド
+
+```bash
+npm run tauri build
+```
+
+## ステップ 2: 必須環境変数を添えて実行
+
+```bash
+GHOST_LAUNCHER_E2E_APP='C:\workspace\ghost_launcher\target\release\ghost-launcher.exe' \
+EDGEDRIVER_VERSION='<WebView2 Runtime の pv>' \
+npx playwright test -c playwright.tauri.config.ts
+```
+
+- **`GHOST_LAUNCHER_E2E_APP` は必ず指定**する。cargo workspace のため `tauri build` の出力は*ワークスペース直下* `target/release/` に集約されるが、harness の `getAppBinaryPath()` 既定は `src-tauri/target/release/`（化石）を指す。override しないと古いバイナリを検証してしまう。
+- **`EDGEDRIVER_VERSION`** は WebView2 Runtime の版（2026-06 時点 `149.0.4022.80`）に合わせる。レジストリの `pv` は `e2e/CLAUDE.md` 参照。
+- 特定テストのみ: `-g "<テスト名>"` を付ける。
+
+## ステップ 3: 既知の skip 要因を踏まえて結果を解釈
+
+- ゴースト依存テスト（一覧 / 検索 / スクロール）は **harness 環境で一律 skip** する。`App.tsx` の `searchRequestKey` は初回スキャン完了（`refreshTrigger > 0`）まで `null` で、画面が「ゴーストが見つかりません」の空状態。実環境の大規模走査（Dropbox 含む複数フォルダ・1000 件超）は harness 上で `waitForGhosts`(15s) までに完了せず skip になる。
+- **skip は失敗ではない**。ゴースト表示が前提のテストはこの環境では `passed` を観測できない。確実な検証はゴーストが少数で速く出る環境か、CI 外の別マシンで行う。
+
+## ステップ 4: 報告
+
+passed / skipped / failed の内訳を示し、skip が上記の既知要因によるものか（=失敗ではない）を明記する。

--- a/.claude/skills/post-merge-sync/SKILL.md
+++ b/.claude/skills/post-merge-sync/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: post-merge-sync
+description: PR マージ後に main をローカル同期し、作業ブランチを後始末する。ユーザーが「マージ後の同期」「post-merge-sync」「ブランチ片付けて」と言ったときに使う。この環境は SSH push/fetch が壊れているため gh-HTTPS 経由で行う。
+disable-model-invocation: true
+---
+
+# マージ後の同期・後始末ワークフロー
+
+GitHub 上で PR がマージされた後、ローカル `main` を最新化し、作業ブランチを安全に削除する。
+
+> **この環境固有の制約**: `origin`（`git@github.com:finelagusaz/ghost_launcher.git`、SSH）への `git push`/`fetch` は `~/.ssh/config` の ACL で失敗する。`gh` はトークン認証済みのため、HTTPS + gh 資格情報ヘルパーで迂回する。SSH remote にも永続 git config にも触れない。
+
+## 引数
+
+- `$ARGUMENTS` に PR 番号（例: `83`）またはブランチ名があれば使う。無ければ現在のブランチを対象とする。
+
+## ステップ 1: マージ済みの確認
+
+```bash
+gh pr view <PR番号 or ブランチ> --json number,state,headRefName,mergedAt
+```
+
+`state` が `MERGED` でなければ中断し「PR がまだマージされていません」と伝える。`headRefName` を対象ブランチ名として控える。
+
+## ステップ 2: リモートブランチの削除（API 経由）
+
+```bash
+gh api -X DELETE repos/finelagusaz/ghost_launcher/git/refs/heads/<branch>
+```
+
+（GitHub の自動削除設定で既に消えている場合は 404。無視してよい。）
+
+## ステップ 3: main をローカル同期（gh-HTTPS）
+
+```bash
+git switch main
+git -c credential.helper= -c credential.helper='!gh auth git-credential' \
+  pull https://github.com/finelagusaz/ghost_launcher.git main --ff-only
+```
+
+## ステップ 4: 追跡参照を整える
+
+URL 指定の pull は `refs/remotes/origin/main` を更新しないため、`status` が "ahead by N" と誤表示する。`update-ref` で揃える:
+
+```bash
+git update-ref refs/remotes/origin/main "$(git rev-parse main)"
+```
+
+> **禁止**: `git fetch <url> main:refs/remotes/origin/main` は `refs/remotes/origin/main` と `origin/HEAD` を壊して `[gone]` 化させる。追跡参照の同期は必ず `update-ref` で行う。
+
+## ステップ 5: ローカル作業ブランチの削除
+
+```bash
+git branch -D <branch>
+```
+
+（スカッシュマージでは元コミットが main の祖先に入らないため `-d` は「未マージ」と誤検知する。内容が取り込まれているかは `git diff main..<branch> --stat` がほぼゼロであることで確認済みなら `-D` で削除してよい。）
+
+## ステップ 6: 結果の報告
+
+`git log --oneline -3 main` と `git status` を示し、main が最新・作業ツリーが clean になったことを伝える。

--- a/scripts/hooks/warn-generated-edit.sh
+++ b/scripts/hooks/warn-generated-edit.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# PreToolUse hook (Edit|Write): src/types/generated/ の ts-rs 生成ファイル編集時に警告する（非ブロック）。
+# これらは Rust struct（commands/ghost/types.rs の #[ts(export)]）から cargo test 時に自動生成される。
+# 手編集はドリフトの元（生成物と Rust struct が乖離し、CI の生成型照合で落ちる）。
+# tool 入力は stdin の JSON で渡る（.tool_input.file_path）。$TOOL_INPUT は存在しない。
+
+file_path=$(jq -r '.tool_input.file_path // empty' 2>/dev/null)
+# Windows のバックスラッシュ区切りを正規化してからディレクトリ判定する。
+fp="${file_path//\\//}"
+case "$fp" in
+  */src/types/generated/*) ;;
+  *) exit 0 ;;
+esac
+
+echo "src/types/generated/ は ts-rs 生成ファイルです。手編集せず、Rust struct（src-tauri/src/commands/ghost/types.rs）を変更して 'cargo test --manifest-path src-tauri/Cargo.toml' で再生成してください（src-tauri/CLAUDE.md・docs/superpowers の drift-hardening 参照）。"
+exit 0

--- a/scripts/hooks/warn-protected-file-edit.sh
+++ b/scripts/hooks/warn-protected-file-edit.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# PreToolUse hook (Edit|Write): ロックファイル・.env の手編集時に警告する（非ブロック）。
+# Cargo.lock / package-lock.json はパッケージマネージャ（cargo/npm）が管理する生成物で、
+# 手編集すると依存解決が壊れる。.env 系は秘匿情報で手編集・コミットを避ける。
+# tool 入力は stdin の JSON で渡る（.tool_input.file_path）。$TOOL_INPUT は存在しない。
+
+file_path=$(jq -r '.tool_input.file_path // empty' 2>/dev/null)
+# Windows のバックスラッシュ区切りを正規化してからファイル名判定する。
+fp="${file_path//\\//}"
+case "$fp" in
+  */Cargo.lock | */package-lock.json | */.env | */.env.*) ;;
+  *) exit 0 ;;
+esac
+
+echo "保護対象ファイル（$fp）を編集しようとしています。ロックファイルは npm/cargo 経由で更新し、.env 系は手編集・コミットを避けてください。意図的な場合のみ続行してください。"
+exit 0


### PR DESCRIPTION
## Summary
ドリフト再発防止のフックと、この環境固有の運用スキルを追加（アプリコード無変更）。

- **PreToolUse 警告フック 2 本**（既存 `warn-migration-edit` と同じ非ブロック作法）
  - `warn-generated-edit.sh`: `src/types/generated/` の ts-rs 生成ファイル手編集を警告し再生成を促す
  - `warn-protected-file-edit.sh`: `Cargo.lock` / `package-lock.json` / `.env` の手編集を警告
- **user-only スキル 2 本**（`disable-model-invocation`）
  - `post-merge-sync`: SSH 不通環境向け gh-HTTPS の `main` 同期＋ブランチ後始末手順
  - `e2e`: `GHOST_LAUNCHER_E2E_APP` / `EDGEDRIVER_VERSION` 必須・skip 既知要因を踏まえた E2E 実行

## Test plan
- [x] フックを stdin JSON で直接実行（生成/ロック/.env パスで警告、それ以外は無反応、空 file_path もエラーなし、Windows バックスラッシュ正規化を確認）
- [x] `.claude/settings.json` が valid JSON（既存フック作法: stdin JSON・\$CLAUDE_PROJECT_DIR 絶対パス・jq を踏襲）
- アプリコード無変更のため build / test / cargo は対象外

🤖 Generated with [Claude Code](https://claude.com/claude-code)