### PR TITLE
fix: DB パス解決を単一権威化し GhostView 選択列の機械照合を追加

### DIFF
--- a/src-tauri/src/commands/db.rs
+++ b/src-tauri/src/commands/db.rs
@@ -1,15 +1,12 @@
-use tauri::Manager;
+use crate::db_path;
 
 /// ghosts.db と関連ファイル（WAL/SHM）を削除してマイグレーション競合を解消する
 #[tauri::command]
 pub fn reset_ghost_db(app_handle: tauri::AppHandle) -> Result<(), String> {
-    let app_data_dir = app_handle
-        .path()
-        .app_data_dir()
-        .map_err(|e| format!("アプリデータディレクトリの取得に失敗: {e}"))?;
+    let db_dir = db_path::ghost_db_dir(&app_handle)?;
 
-    for filename in ["ghosts.db", "ghosts.db-wal", "ghosts.db-shm"] {
-        let path = app_data_dir.join(filename);
+    for filename in db_path::GHOST_DB_FILES {
+        let path = db_dir.join(filename);
         if path.exists() {
             std::fs::remove_file(&path)
                 .map_err(|e| format!("{filename} の削除に失敗: {e}"))?;

--- a/src-tauri/src/commands/ghost/mod.rs
+++ b/src-tauri/src/commands/ghost/mod.rs
@@ -30,19 +30,13 @@ pub fn scan_and_store(
     request_key: String,
     cached_fingerprint: Option<String>,
 ) -> Result<ScanStoreResult, String> {
-    use tauri::Manager;
-
     ensure_request_key(&request_key)?;
 
     // 親ディレクトリ mtime を 1 回だけ収集（Layer 1 / Layer 2 hit / cache miss で共用）
     let current_mtimes = fingerprint::collect_parent_mtimes(&ssp_path, &additional_folders);
 
-    // DB パスを 1 回だけ解決
-    let db_path = app
-        .path()
-        .app_config_dir()
-        .map_err(|e| format!("app_config_dir 取得エラー: {e}"))?
-        .join("ghosts.db");
+    // DB パスを 1 回だけ解決（reset_ghost_db・sanitize_ghost_db と同一の単一権威を経由）
+    let db_path = crate::db_path::ghost_db_path(&app)?;
 
     // Layer 1: 親ディレクトリ mtime 高速チェック（< 1ms）
     // NTFS では親の mtime は直下のエントリ追加・削除でのみ変化する。

--- a/src-tauri/src/db_path.rs
+++ b/src-tauri/src/db_path.rs
@@ -1,0 +1,28 @@
+// ghosts.db パス解決の単一権威。
+// tauri-plugin-sql は "sqlite:ghosts.db" を app_config_dir 基準で解決するため、
+// 書込（scan_and_store）・削除（reset_ghost_db）・起動時検査（sanitize_ghost_db）も
+// 必ずここを経由して同じディレクトリを参照する。
+// app_config_dir と app_data_dir は Windows では同一パスに収束するが、
+// それはプラットフォームの偶然であり、別 API での解決を混在させてはならない。
+
+use tauri::Manager;
+
+/// ghosts.db 本体と WAL/SHM の関連ファイル名
+pub(crate) const GHOST_DB_FILES: [&str; 3] = ["ghosts.db", "ghosts.db-wal", "ghosts.db-shm"];
+
+/// ghosts.db を格納するディレクトリ（tauri-plugin-sql と同じ app_config_dir 基準）
+pub(crate) fn ghost_db_dir<R: tauri::Runtime>(
+    manager: &impl Manager<R>,
+) -> Result<std::path::PathBuf, String> {
+    manager
+        .path()
+        .app_config_dir()
+        .map_err(|e| format!("アプリ設定ディレクトリの取得に失敗: {e}"))
+}
+
+/// ghosts.db 本体のフルパス
+pub(crate) fn ghost_db_path<R: tauri::Runtime>(
+    manager: &impl Manager<R>,
+) -> Result<std::path::PathBuf, String> {
+    Ok(ghost_db_dir(manager)?.join(GHOST_DB_FILES[0]))
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,8 +1,7 @@
 mod commands;
+mod db_path;
 #[cfg(test)]
 pub(crate) mod testutil;
-
-use tauri::Manager;
 
 // マイグレーション追加時の注意:
 //   ALTER TABLE ... ADD COLUMN ... DEFAULT <値> の <値> はリテラルのみ許容される。
@@ -107,6 +106,40 @@ mod tests {
     }
 
     #[test]
+    fn ghost_viewの全選択列がghostsスキーマに存在する() {
+        // JS 側（ghostDatabase.ts の GHOST_VIEW_COLUMNS）と同じ fixture を参照し、
+        // GhostView 型・SELECT 列・SQLite スキーマの三者同期を縛る。
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../src/test/fixtures/ghost-view-columns.json"
+        );
+        let raw = std::fs::read_to_string(path).expect("fixture を読めること");
+        let expected_columns: Vec<String> = serde_json::from_str(&raw).unwrap();
+        assert!(!expected_columns.is_empty(), "fixture が空でないこと");
+
+        let conn = Connection::open_in_memory().unwrap();
+        let mut applied = migrations();
+        applied.sort_by_key(|m| m.version);
+        for m in applied {
+            conn.execute_batch(m.sql).unwrap();
+        }
+        let schema_columns: Vec<String> = conn
+            .prepare("PRAGMA table_info(ghosts)")
+            .unwrap()
+            .query_map([], |row| row.get::<_, String>(1))
+            .unwrap()
+            .filter_map(Result::ok)
+            .collect();
+
+        for column in &expected_columns {
+            assert!(
+                schema_columns.contains(column),
+                "GhostView の選択列 {column} が ghosts テーブルに存在しない（fixture: ghost-view-columns.json）"
+            );
+        }
+    }
+
+    #[test]
     fn マイグレーション7は既存の同一request_key行があっても適用できる() {
         // DELETE が CREATE UNIQUE INDEX より先に実行されることを確認するリグレッションテスト。
         // 修正前は同一 request_key の複数行が全て ghost_identity_key='' となり
@@ -204,10 +237,10 @@ mod tests {
 /// 未適用マイグレーションが ADD COLUMN しようとするカラムが既に存在する場合、
 /// DB ファイルを削除して再作成を促す。ghosts.db はキャッシュなので安全。
 fn sanitize_ghost_db(app: &tauri::App) {
-    let Ok(app_data_dir) = app.path().app_data_dir() else {
+    let Ok(db_dir) = db_path::ghost_db_dir(app) else {
         return;
     };
-    let db_path = app_data_dir.join("ghosts.db");
+    let db_path = db_dir.join(db_path::GHOST_DB_FILES[0]);
     if !db_path.exists() {
         return;
     }
@@ -218,8 +251,8 @@ fn sanitize_ghost_db(app: &tauri::App) {
     };
 
     if should_delete {
-        for filename in ["ghosts.db", "ghosts.db-wal", "ghosts.db-shm"] {
-            let _ = std::fs::remove_file(app_data_dir.join(filename));
+        for filename in db_path::GHOST_DB_FILES {
+            let _ = std::fs::remove_file(db_dir.join(filename));
         }
     }
 }

--- a/src/lib/ghostDatabase.test.ts
+++ b/src/lib/ghostDatabase.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import cases from "../test/fixtures/normalize-key-cases.json";
+import ghostViewColumns from "../test/fixtures/ghost-view-columns.json";
 
 const mockExecute = vi.fn().mockResolvedValue({ rowsAffected: 0 });
 const mockSelect = vi.fn().mockResolvedValue([]);
@@ -19,6 +20,15 @@ beforeEach(() => {
   mockExecute.mockClear();
   mockSelect.mockClear();
   mockLoad.mockClear();
+});
+
+describe("ghostDatabase - GhostView 列同期", () => {
+  it("GHOST_VIEW_COLUMNS が共有 fixture と一致する", async () => {
+    // Rust 側テスト（lib.rs）が同じ fixture を ghosts スキーマと照合することで、
+    // GhostView 型（コンパイル時検査）・SELECT 列・SQLite スキーマの三者同期を縛る
+    const { GHOST_VIEW_COLUMNS } = await import("./ghostDatabase");
+    expect([...GHOST_VIEW_COLUMNS]).toEqual(ghostViewColumns);
+  });
 });
 
 describe("ghostDatabase - getDb マイグレーションエラー回復", () => {

--- a/src/lib/ghostDatabase.ts
+++ b/src/lib/ghostDatabase.ts
@@ -147,8 +147,33 @@ export async function hasGhosts(requestKey: string): Promise<boolean> {
   return total > 0;
 }
 
-const GHOST_SELECT_COLUMNS =
-  "name, sakura_name, kero_name, craftman, craftmanw, directory_name, path, source, name_lower, sakura_name_lower, kero_name_lower, craftman_lower, craftmanw_lower, directory_name_lower, thumbnail_path, thumbnail_use_self_alpha, thumbnail_kind, ghost_identity_key";
+// SELECT 対象列の単一権威。satisfies が GhostView に無い列名（typo・削除漏れ）を弾く。
+// 列を増減するときは GhostView（src/types/index.ts）と
+// src/test/fixtures/ghost-view-columns.json も更新する（Rust 側テストがスキーマと照合）。
+export const GHOST_VIEW_COLUMNS = [
+  "name",
+  "sakura_name",
+  "kero_name",
+  "craftman",
+  "craftmanw",
+  "directory_name",
+  "path",
+  "source",
+  "name_lower",
+  "sakura_name_lower",
+  "kero_name_lower",
+  "craftman_lower",
+  "craftmanw_lower",
+  "directory_name_lower",
+  "thumbnail_path",
+  "thumbnail_use_self_alpha",
+  "thumbnail_kind",
+  "ghost_identity_key",
+] as const satisfies readonly (keyof GhostView)[];
+
+// GhostView のフィールドで GHOST_VIEW_COLUMNS に列挙されていないもの。
+// 列挙漏れがあると never でなくなり、下の型注釈が never に解決されて代入が型エラーになる。
+type MissingGhostViewColumns = Exclude<keyof GhostView, (typeof GHOST_VIEW_COLUMNS)[number]>;
 
 const GHOST_SEARCH_LOWER_COLUMNS = [
   "name_lower",
@@ -162,8 +187,8 @@ const GHOST_SEARCH_LOWER_COLUMNS = [
 const GHOST_SEARCH_WHERE =
   GHOST_SEARCH_LOWER_COLUMNS.map((col) => `${col} LIKE ?`).join(" OR ");
 
-const GHOST_SELECT_COLUMNS_PREFIXED =
-  GHOST_SELECT_COLUMNS.split(", ").map((c) => `g.${c}`).join(", ");
+const GHOST_SELECT_COLUMNS_PREFIXED: [MissingGhostViewColumns] extends [never] ? string : never =
+  GHOST_VIEW_COLUMNS.map((c) => `g.${c}`).join(", ");
 
 function buildOrderBy(sortOrder: SortOrder): { orderBy: string; join: string } {
   switch (sortOrder) {

--- a/src/test/fixtures/ghost-view-columns.json
+++ b/src/test/fixtures/ghost-view-columns.json
@@ -1,0 +1,20 @@
+[
+  "name",
+  "sakura_name",
+  "kero_name",
+  "craftman",
+  "craftmanw",
+  "directory_name",
+  "path",
+  "source",
+  "name_lower",
+  "sakura_name_lower",
+  "kero_name_lower",
+  "craftman_lower",
+  "craftmanw_lower",
+  "directory_name_lower",
+  "thumbnail_path",
+  "thumbnail_use_self_alpha",
+  "thumbnail_kind",
+  "ghost_identity_key"
+]


### PR DESCRIPTION
## Summary
- **DB パス解決の単一権威化**: `scan_and_store` は `app_config_dir`、`reset_ghost_db` / `sanitize_ghost_db` は `app_data_dir` と API が割れており、削除・復旧経路が書込先と同一ファイルを指すことが Windows のプラットフォーム偶然にのみ依存していた。`db_path.rs` を新設し、tauri-plugin-sql の `sqlite:ghosts.db` 解決基準（`app_config_dir`）に全経路を統一
- **GhostView 選択列の機械照合**: 18 フィールドの `GhostView` 型・`GHOST_SELECT_COLUMNS` 文字列・SQLite スキーマが照合機構のない三重手動同期だったため、`normalize-key-cases.json` と同じ共有 fixture 方式（`ghost-view-columns.json`）で三角形を閉じた
  - TS コンパイル時検査: `as const satisfies` + `[Exclude<...>] extends [never]` で `GhostView` との双方向一致を強制
  - vitest: 列配列 = fixture の一致を検証
  - cargo test: fixture の全列が migration 適用後の `ghosts` スキーマに存在することを検証

## Test plan
- [x] `npm run build`
- [x] `npm test`（127 件）
- [x] `npm run check:ui-guidelines`
- [x] `npm run test:ui-guidelines-check`
- [x] `cargo test --workspace`（73 件）
- [x] 変異テストで各ガードの発火を確認（列挙漏れ → TS2322、架空列 → cargo test 失敗）

**テストに関する注記**: DB パス統一（修正 1）は Windows 上で観測可能な挙動差がない構造的リファクタリングのため、先に失敗するテストを書くことができない（両 API が現状同一パスに収束するため）。回帰は既存の cargo test 全件で確認した。GhostView 照合（修正 2）は fixture・エクスポート不在の状態で Red を観測してから実装した。

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)