### PR TITLE
fix: random ソート安定シード化と SSP IPC ラッパー対称化・テスト補強

### DIFF
--- a/src-tauri/src/commands/ssp.rs
+++ b/src-tauri/src/commands/ssp.rs
@@ -1,6 +1,19 @@
 use std::path::Path;
 use std::process::Command;
 
+/// SSP へ渡すゴースト指定引数を構築する。
+/// SSP 内ゴースト（source == "ssp"）はディレクトリ名のみ、外部ゴーストはフルパス。
+fn build_ghost_arg(ghost_source: &str, ghost_directory_name: &str) -> String {
+    if ghost_source == "ssp" {
+        ghost_directory_name.to_string()
+    } else {
+        Path::new(ghost_source)
+            .join(ghost_directory_name)
+            .to_string_lossy()
+            .into_owned()
+    }
+}
+
 /// SSP フォルダのパスを検証する（ssp.exe の存在確認）
 #[tauri::command]
 pub fn validate_ssp_path(ssp_path: String) -> Result<(), String> {
@@ -24,13 +37,7 @@ pub fn launch_ghost(
         return Err(format!("ssp.exe が見つかりません: {}", ssp_exe.display()));
     }
 
-    // SSP 内ゴーストはディレクトリ名、外部ゴーストはフルパスで指定
-    let ghost_arg = if ghost_source == "ssp" {
-        ghost_directory_name
-    } else {
-        let full_path = Path::new(&ghost_source).join(&ghost_directory_name);
-        full_path.to_string_lossy().into_owned()
-    };
+    let ghost_arg = build_ghost_arg(&ghost_source, &ghost_directory_name);
 
     Command::new(&ssp_exe)
         .arg("/g")
@@ -40,4 +47,28 @@ pub fn launch_ghost(
         .map_err(|e| format!("SSP の起動に失敗しました: {}", e))?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_ghost_arg, validate_ssp_path};
+
+    #[test]
+    fn ssp内ゴーストはディレクトリ名のみを渡す() {
+        assert_eq!(build_ghost_arg("ssp", "my_ghost"), "my_ghost");
+    }
+
+    #[test]
+    fn 外部ゴーストはsourceと結合したフルパスを渡す() {
+        assert_eq!(
+            build_ghost_arg("C:\\Ghosts\\Extra", "my_ghost"),
+            "C:\\Ghosts\\Extra\\my_ghost"
+        );
+    }
+
+    #[test]
+    fn validate_ssp_path_はssp_exe不在でエラーを返す() {
+        let result = validate_ssp_path("C:\\__ghost_launcher_no_such_dir__".to_string());
+        assert!(result.is_err());
+    }
 }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -56,6 +56,7 @@ vi.mock("./components/GhostContent", () => ({
 vi.mock("./lib/ghostDatabase", () => ({
   getRandomGhost: vi.fn(),
   recordLaunch: vi.fn(),
+  reseedRandomSort: vi.fn(),
 }));
 
 import App from "./App";

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ import { AppHeader } from "./components/AppHeader";
 import { GhostContent } from "./components/GhostContent";
 import { SettingsPanel } from "./components/SettingsPanel";
 import { requestKeyFromSettings } from "./lib/ghostScanUtils";
-import { getRandomGhost } from "./lib/ghostDatabase";
+import { getRandomGhost, reseedRandomSort } from "./lib/ghostDatabase";
 import { launchGhost } from "./lib/sspClient";
 import type { SortOrder } from "./types";
 
@@ -139,6 +139,8 @@ function App() {
   }, [searchRequestKey, sspPath, t]);
 
   const handleSortChange = useCallback((value: SortOrder) => {
+    // 「ランダム」を選ぶたびに並びを引き直す（同値再選択は sortOrder が変わらないため次回 fetch から反映）
+    if (value === "random") reseedRandomSort();
     setSortOrder(value);
     setOffset(0);
   }, [setOffset]);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,6 +79,10 @@ function App() {
   const { loading: ghostsLoading, error, refresh } = useGhosts(sspPath, ghostFolders);
   const [searchQuery, setSearchQuery] = useState("");
   const [sortOrder, setSortOrder] = useState<SortOrder>("name");
+  // ランダム再選択でシードを引き直したことを useSearch に伝える epoch。
+  // reseedRandomSort() 自体はモジュール変数の変更のみで React から不可視のため、
+  // これを resetKey に含めて全置換フェッチを強制する（App.tsx#handleSortChange 参照）
+  const [sortEpoch, setSortEpoch] = useState(0);
   const deferredSearchQuery = useDeferredValue(searchQuery);
   const LIMIT = 500;
 
@@ -110,6 +114,7 @@ function App() {
     offset,
     refreshTrigger,
     sortOrder,
+    sortEpoch,
   );
 
   const handleLoadMore = useCallback((targetOffset: number) => {
@@ -139,8 +144,12 @@ function App() {
   }, [searchRequestKey, sspPath, t]);
 
   const handleSortChange = useCallback((value: SortOrder) => {
-    // 「ランダム」を選ぶたびに並びを引き直す（同値再選択は sortOrder が変わらないため次回 fetch から反映）
-    if (value === "random") reseedRandomSort();
+    // 「ランダム」を選ぶたびに並びを引き直す。同値再選択は sortOrder/offset が
+    // 変わらず effect が再実行されないため、sortEpoch を進めて可視状態として配線する
+    if (value === "random") {
+      reseedRandomSort();
+      setSortEpoch((e) => e + 1);
+    }
     setSortOrder(value);
     setOffset(0);
   }, [setOffset]);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,8 +20,8 @@ import { AppHeader } from "./components/AppHeader";
 import { GhostContent } from "./components/GhostContent";
 import { SettingsPanel } from "./components/SettingsPanel";
 import { requestKeyFromSettings } from "./lib/ghostScanUtils";
-import { getRandomGhost, recordLaunch } from "./lib/ghostDatabase";
-import { invoke } from "@tauri-apps/api/core";
+import { getRandomGhost } from "./lib/ghostDatabase";
+import { launchGhost } from "./lib/sspClient";
 import type { SortOrder } from "./types";
 
 const useStyles = makeStyles({
@@ -132,14 +132,7 @@ function App() {
         setRandomLaunchError(t("header.randomLaunch.empty"));
         return;
       }
-      await invoke("launch_ghost", {
-        sspPath,
-        ghostDirectoryName: ghost.directory_name,
-        ghostSource: ghost.source,
-      });
-      if (ghost.ghost_identity_key) {
-        void recordLaunch(ghost.ghost_identity_key).catch(() => {});
-      }
+      await launchGhost(sspPath, ghost);
     } catch (e) {
       setRandomLaunchError(e instanceof Error ? e.message : String(e));
     }

--- a/src/components/GhostCard.tsx
+++ b/src/components/GhostCard.tsx
@@ -1,7 +1,7 @@
 import { memo, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
-import { convertFileSrc, invoke } from "@tauri-apps/api/core";
+import { convertFileSrc } from "@tauri-apps/api/core";
 import {
   Badge,
   Button,
@@ -14,7 +14,7 @@ import {
 import { PlayRegular } from "@fluentui/react-icons";
 import { getSourceFolderLabel } from "../lib/ghostLaunchUtils";
 import { formatErrorDetail } from "../lib/ghostScanUtils";
-import { recordLaunch } from "../lib/ghostDatabase";
+import { launchGhost } from "../lib/sspClient";
 import type { GhostView } from "../types";
 
 interface Props {
@@ -222,14 +222,7 @@ export const GhostCard = memo(function GhostCard({ ghost, sspPath }: Props) {
     setLaunching(true);
     setError(null);
     try {
-      await invoke("launch_ghost", {
-        sspPath,
-        ghostDirectoryName: ghost.directory_name,
-        ghostSource: ghost.source,
-      });
-      if (ghost.ghost_identity_key) {
-        void recordLaunch(ghost.ghost_identity_key).catch(() => {});
-      }
+      await launchGhost(sspPath, ghost);
     } catch (e) {
       setError(t("card.launchError", { detail: formatErrorDetail(e) }));
     } finally {

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { invoke } from "@tauri-apps/api/core";
 import { confirm, open } from "@tauri-apps/plugin-dialog";
 import {
   Button,
@@ -14,6 +13,7 @@ import {
 } from "@fluentui/react-components";
 import { AddRegular, DeleteRegular, FolderOpenRegular } from "@fluentui/react-icons";
 import { SUPPORTED_LANGUAGES, type Language } from "../lib/i18n";
+import { validateSspPath } from "../lib/sspClient";
 
 interface Props {
   sspPath: string | null;
@@ -109,7 +109,7 @@ export function SettingsPanel({
 
     setValidating(true);
     try {
-      await invoke("validate_ssp_path", { sspPath: selected });
+      await validateSspPath(selected);
       onPathChange(selected);
       setValidationError(null);
     } catch (e) {

--- a/src/hooks/useGhosts.test.ts
+++ b/src/hooks/useGhosts.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+
+const { mockRefreshGhostCatalog } = vi.hoisted(() => ({ mockRefreshGhostCatalog: vi.fn() }));
+vi.mock("../lib/ghostCatalogService", () => ({ refreshGhostCatalog: mockRefreshGhostCatalog }));
+
+import { useGhosts } from "./useGhosts";
+
+beforeEach(() => {
+  mockRefreshGhostCatalog.mockReset();
+  mockRefreshGhostCatalog.mockResolvedValue({ skipped: false });
+});
+
+describe("useGhosts", () => {
+  it("マウント時に refresh が走り loading が収束する", async () => {
+    const { result } = renderHook(() => useGhosts("C:/ssp", []));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mockRefreshGhostCatalog).toHaveBeenCalledTimes(1);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("同一 inFlightKey の並行 refresh は 1 回に抑止される", async () => {
+    let resolveScan: ((v: { skipped: boolean }) => void) | undefined;
+    mockRefreshGhostCatalog.mockImplementation(
+      () => new Promise((resolve) => { resolveScan = resolve; }),
+    );
+    const { result } = renderHook(() => useGhosts("C:/ssp", []));
+    // マウント時の refresh が in-flight の間に同一キーで再度呼ぶ
+    await act(async () => {
+      void result.current.refresh();
+      void result.current.refresh();
+    });
+    expect(mockRefreshGhostCatalog).toHaveBeenCalledTimes(1);
+    await act(async () => { resolveScan?.({ skipped: false }); });
+  });
+
+  it("forceFullScan は別 inFlightKey なので抑止されない", async () => {
+    let resolveScan: ((v: { skipped: boolean }) => void) | undefined;
+    mockRefreshGhostCatalog.mockImplementation(
+      () => new Promise((resolve) => { resolveScan = resolve; }),
+    );
+    const { result } = renderHook(() => useGhosts("C:/ssp", []));
+    await act(async () => {
+      void result.current.refresh({ forceFullScan: true });
+    });
+    expect(mockRefreshGhostCatalog).toHaveBeenCalledTimes(2);
+    await act(async () => { resolveScan?.({ skipped: false }); });
+  });
+
+  it("スキャン失敗でエラーメッセージが設定される", async () => {
+    mockRefreshGhostCatalog.mockRejectedValue(new Error("boom"));
+    const { result } = renderHook(() => useGhosts("C:/ssp", []));
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.error).toContain("boom");
+  });
+
+  it("sspPath が null なら refresh せず loading が収束する", async () => {
+    const { result } = renderHook(() => useGhosts(null, []));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mockRefreshGhostCatalog).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useSearch.test.ts
+++ b/src/hooks/useSearch.test.ts
@@ -262,6 +262,35 @@ describe("useSearch", () => {
     expect(searchGhostsInitialPage).toHaveBeenCalledWith("rk1", 100, "name");
   });
 
+  it("sortEpoch の変化で全置換リフェッチが走る（マージ分岐に旧シードのバッファが混ざらない）", async () => {
+    vi.mocked(searchGhosts)
+      .mockResolvedValueOnce({ ghosts: [reimu, marisa], total: 5 })
+      .mockResolvedValueOnce({ ghosts: [alice], total: 5 });
+
+    const { result, rerender } = renderHook(
+      ({ sortEpoch }) => useSearch("rk1", "ki", 2, 3, 1, "random", sortEpoch),
+      { initialProps: { sortEpoch: 0 } }
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+      expect(result.current.ghosts).toHaveLength(2);
+    });
+    expect(result.current.loadedStart).toBe(3);
+
+    rerender({ sortEpoch: 1 });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+      expect(searchGhosts).toHaveBeenCalledTimes(2);
+    });
+
+    // マージ（[alice, marisa] 長さ2）ではなく全置換（[alice] 長さ1）であること
+    expect(result.current.ghosts).toHaveLength(1);
+    expect(result.current.ghosts[0].name).toBe("Alice");
+    expect(result.current.loadedStart).toBe(3);
+  });
+
   it("検索でエラーが発生した場合は dbError にメッセージを設定する", async () => {
     vi.mocked(searchGhostsInitialPage).mockRejectedValueOnce(
       new Error("database is locked")

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -12,6 +12,10 @@ export function useSearch(
   offset: number,
   refreshTrigger: number,
   sortOrder: SortOrder = "name",
+  // ランダム再選択によるシード変更を可視化する epoch。resetKey/deps に含めることで、
+  // モジュールスコープの reseedRandomSort() だけでは検知できない「同値再選択」でも
+  // 全置換フェッチを強制し、旧シードのバッファが新シードのページと縫合されるのを防ぐ
+  sortEpoch: number = 0,
 ): { ghosts: GhostView[]; total: number; loadedStart: number; loading: boolean; dbError: string | null } {
   const [ghosts, setGhosts] = useState<GhostView[]>([]);
   const [total, setTotal] = useState(0);
@@ -26,7 +30,7 @@ export function useSearch(
 
   useEffect(() => {
     let isActive = true;
-    const resetKey = `${requestKey}\0${query}\0${refreshTrigger}\0${sortOrder}`;
+    const resetKey = `${requestKey}\0${query}\0${refreshTrigger}\0${sortOrder}\0${sortEpoch}`;
     const isReset = resetKey !== resetKeyRef.current;
 
     async function fetchGhosts() {
@@ -125,7 +129,7 @@ export function useSearch(
     return () => {
       isActive = false;
     };
-  }, [requestKey, query, limit, offset, refreshTrigger, sortOrder]);
+  }, [requestKey, query, limit, offset, refreshTrigger, sortOrder, sortEpoch]);
 
   return { ghosts, total, loadedStart, loading, dbError };
 }

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -5,16 +5,6 @@ import { countGhostsByQuery, searchGhosts, searchGhostsInitialPage } from "../li
 // バッファの最大サイズ。これを超えるマージは全置換にフォールバックする
 export const MAX_BUFFER_SIZE = 2000;
 
-// Fisher-Yates シャッフル（in-place）
-function shuffleArray<T>(arr: T[]): T[] {
-  const result = [...arr];
-  for (let i = result.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [result[i], result[j]] = [result[j], result[i]];
-  }
-  return result;
-}
-
 export function useSearch(
   requestKey: string | null,
   query: string,
@@ -57,9 +47,8 @@ export function useSearch(
         const isInitialLoad = query === "" && offset === 0;
 
         if (isInitialLoad) {
-          let initialGhosts = await searchGhostsInitialPage(requestKey, limit, sortOrder);
+          const initialGhosts = await searchGhostsInitialPage(requestKey, limit, sortOrder);
           if (!isActive) return;
-          if (sortOrder === "random") initialGhosts = shuffleArray(initialGhosts);
 
           resetKeyRef.current = resetKey;
           setGhosts(initialGhosts);
@@ -81,7 +70,6 @@ export function useSearch(
         }
 
         const result = await searchGhosts(requestKey, query, limit, offset, sortOrder);
-        if (sortOrder === "random") result.ghosts = shuffleArray(result.ghosts);
         if (!isActive) return;
 
         resetKeyRef.current = resetKey;

--- a/src/hooks/useVirtualizedList.test.ts
+++ b/src/hooks/useVirtualizedList.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useVirtualizedList } from "./useVirtualizedList";
+
+// rowHeight = estimatedRowHeight + gap = 90 + 10 = 100
+// visibleRowCount = max(1, ceil(400 / 100)) = 4
+const options = { viewportHeight: 400, estimatedRowHeight: 90, overscanRows: 3, gap: 10, totalCount: 1000 };
+
+describe("useVirtualizedList", () => {
+  it("初期状態は先頭から可視行 + overscan*2 を返す", () => {
+    const { result } = renderHook(() => useVirtualizedList([], options));
+    expect(result.current.startIndex).toBe(0);
+    expect(result.current.endIndex).toBe(10); // 0 + 4 + 3*2
+    expect(result.current.topSpacer).toBe(0);
+    expect(result.current.bottomSpacer).toBe((1000 - 10) * 100);
+  });
+
+  it("totalCount 未指定なら items.length でスクロール空間を計算する", () => {
+    const { result } = renderHook(() =>
+      useVirtualizedList(new Array(6).fill(null), { ...options, totalCount: undefined }),
+    );
+    expect(result.current.endIndex).toBe(6); // itemCount=6 にクランプ
+    expect(result.current.bottomSpacer).toBe(0);
+  });
+
+  it("totalCount の減少でインデックスとスクロール空間を再計算する", () => {
+    const { result, rerender } = renderHook(
+      ({ total }: { total: number }) => useVirtualizedList([], { ...options, totalCount: total }),
+      { initialProps: { total: 1000 } },
+    );
+    rerender({ total: 5 });
+    expect(result.current.endIndex).toBe(5);
+    expect(result.current.bottomSpacer).toBe(0);
+  });
+
+  it("itemCount が 0 でも負のインデックスにならない", () => {
+    const { result } = renderHook(() => useVirtualizedList([], { ...options, totalCount: 0 }));
+    expect(result.current.startIndex).toBe(0);
+    expect(result.current.endIndex).toBe(0);
+    expect(result.current.bottomSpacer).toBe(0);
+  });
+});

--- a/src/lib/ghostDatabase.test.ts
+++ b/src/lib/ghostDatabase.test.ts
@@ -260,6 +260,45 @@ describe("ghostDatabase - searchGhostsInitialPage", () => {
   });
 });
 
+describe("ghostDatabase - random ソートの安定シード", () => {
+  it("searchGhosts が random でシード付き ORDER BY を発行する", async () => {
+    const { searchGhosts } = await import("./ghostDatabase");
+    await searchGhosts("rk", "", 10, 0, "random");
+    const sql = mockSelect.mock.calls
+      .map((c) => c[0] as string)
+      .find((q) => q.includes("ORDER BY"));
+    expect(sql).toMatch(/\(g\.id \* \d+\) % 1000003, g\.id/);
+  });
+
+  it("同一シード中は searchGhostsInitialPage も同じ ORDER BY 式を使う", async () => {
+    const { searchGhosts, searchGhostsInitialPage } = await import("./ghostDatabase");
+    await searchGhosts("rk", "", 10, 0, "random");
+    await searchGhostsInitialPage("rk", 10, "random");
+    const sqls = mockSelect.mock.calls
+      .map((c) => c[0] as string)
+      .filter((q) => q.includes("% 1000003"));
+    const seedOf = (q: string) => q.match(/g\.id \* (\d+)/)?.[1];
+    expect(sqls.length).toBeGreaterThanOrEqual(2);
+    expect(seedOf(sqls[0])).toBe(seedOf(sqls[1]));
+  });
+
+  it("reseedRandomSort でシードが変わる", async () => {
+    const randomSpy = vi
+      .spyOn(Math, "random")
+      .mockReturnValueOnce(0.1)
+      .mockReturnValueOnce(0.9);
+    const { searchGhosts, reseedRandomSort } = await import("./ghostDatabase");
+    await searchGhosts("rk", "", 10, 0, "random");
+    reseedRandomSort();
+    await searchGhosts("rk", "", 10, 0, "random");
+    const sqls = mockSelect.mock.calls
+      .map((c) => c[0] as string)
+      .filter((q) => q.includes("% 1000003"));
+    expect(sqls[0]).not.toEqual(sqls[1]);
+    randomSpy.mockRestore();
+  });
+});
+
 describe("ghostDatabase - countGhostsByQuery", () => {
   it("空クエリ時は LIKE なしで件数取得する", async () => {
     mockSelect.mockResolvedValue([{ count: 42 }]);

--- a/src/lib/ghostDatabase.ts
+++ b/src/lib/ghostDatabase.ts
@@ -190,8 +190,29 @@ const GHOST_SEARCH_WHERE =
 const GHOST_SELECT_COLUMNS_PREFIXED: [MissingGhostViewColumns] extends [never] ? string : never =
   GHOST_VIEW_COLUMNS.map((c) => `g.${c}`).join(", ");
 
+// random ソート用のセッションシード。ORDER BY 式を固定することで、
+// 仮想スクロールの offset ページングとバッファマージに対して順序が安定する。
+// 素数の剰余で id を攪拌する。剰余の衝突は第 2 キー g.id で安定化する。
+const RANDOM_SORT_MODULUS = 1000003;
+
+function newRandomSortSeed(): number {
+  return Math.floor(Math.random() * (RANDOM_SORT_MODULUS - 1)) + 1;
+}
+
+let randomSortSeed = newRandomSortSeed();
+
+/// random ソートの並びを引き直す（ソートで「ランダム」を選択したときに呼ぶ）
+export function reseedRandomSort(): void {
+  randomSortSeed = newRandomSortSeed();
+}
+
 function buildOrderBy(sortOrder: SortOrder): { orderBy: string; join: string } {
   switch (sortOrder) {
+    case "random":
+      return {
+        join: "",
+        orderBy: `(g.id * ${randomSortSeed}) % ${RANDOM_SORT_MODULUS}, g.id`,
+      };
     case "recent":
       return {
         join: "LEFT JOIN (SELECT ghost_identity_key, MAX(launched_at) AS last_launched FROM ghost_launches GROUP BY ghost_identity_key) gl ON g.ghost_identity_key = gl.ghost_identity_key",

--- a/src/lib/sspClient.test.ts
+++ b/src/lib/sspClient.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockRecordLaunch } = vi.hoisted(() => ({ mockRecordLaunch: vi.fn() }));
+vi.mock("./ghostDatabase", () => ({ recordLaunch: mockRecordLaunch }));
+
+beforeEach(() => {
+  vi.resetModules();
+  mockRecordLaunch.mockReset();
+  mockRecordLaunch.mockResolvedValue(undefined);
+});
+
+const ghost = { directory_name: "my_ghost", source: "ssp", ghost_identity_key: "sspmy_ghost" };
+
+describe("sspClient", () => {
+  it("launchGhost が launch_ghost IPC を camelCase 引数で呼び、履歴を記録する", async () => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    const { launchGhost } = await import("./sspClient");
+    await launchGhost("C:\\SSP", ghost);
+    expect(invoke).toHaveBeenCalledWith("launch_ghost", {
+      sspPath: "C:\\SSP",
+      ghostDirectoryName: "my_ghost",
+      ghostSource: "ssp",
+    });
+    expect(mockRecordLaunch).toHaveBeenCalledWith("sspmy_ghost");
+  });
+
+  it("ghost_identity_key が空なら履歴を記録しない", async () => {
+    const { launchGhost } = await import("./sspClient");
+    await launchGhost("C:\\SSP", { ...ghost, ghost_identity_key: "" });
+    expect(mockRecordLaunch).not.toHaveBeenCalled();
+  });
+
+  it("履歴記録の失敗は起動成功を妨げない", async () => {
+    mockRecordLaunch.mockRejectedValue(new Error("db down"));
+    const { launchGhost } = await import("./sspClient");
+    await expect(launchGhost("C:\\SSP", ghost)).resolves.toBeUndefined();
+  });
+
+  it("validateSspPath が validate_ssp_path IPC を呼ぶ", async () => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    const { validateSspPath } = await import("./sspClient");
+    await validateSspPath("C:\\SSP");
+    expect(invoke).toHaveBeenCalledWith("validate_ssp_path", { sspPath: "C:\\SSP" });
+  });
+});

--- a/src/lib/sspClient.ts
+++ b/src/lib/sspClient.ts
@@ -1,0 +1,22 @@
+import { invoke } from "@tauri-apps/api/core";
+import { recordLaunch } from "./ghostDatabase";
+import type { GhostView } from "../types";
+
+export type LaunchTarget = Pick<GhostView, "directory_name" | "source" | "ghost_identity_key">;
+
+/// launch_ghost IPC の唯一の入口。起動成功時に起動履歴を fire-and-forget で記録する。
+export async function launchGhost(sspPath: string, ghost: LaunchTarget): Promise<void> {
+  await invoke("launch_ghost", {
+    sspPath,
+    ghostDirectoryName: ghost.directory_name,
+    ghostSource: ghost.source,
+  });
+  if (ghost.ghost_identity_key) {
+    void recordLaunch(ghost.ghost_identity_key).catch(() => {});
+  }
+}
+
+/// validate_ssp_path IPC の唯一の入口。
+export async function validateSspPath(sspPath: string): Promise<void> {
+  await invoke("validate_ssp_path", { sspPath });
+}


### PR DESCRIPTION
## Summary
- **random ソートの構造修正**: ページ単位の JS 局所シャッフル（仮想スクロールと組むと順序破綻）を撤去し、セッションシード付き `ORDER BY (g.id * seed) % 1000003, g.id` に変更。「ランダム」再選択でシードを引き直す。レビューで検出された「reseed が React 不可視」の欠陥は `sortEpoch` を state 化して `useSearch` の resetKey + deps へ配線することで解消
- **IPC ラッパー対称化**: `sspClient.ts` を新設し、`launch_ghost` / `validate_ssp_path` の生 invoke（App.tsx / GhostCard.tsx / SettingsPanel.tsx に散在・重複）を lib 層へ集約。UI 層に残る `@tauri-apps/api/core` は `convertFileSrc` のみ
- **テスト補強**: `build_ghost_arg` 純関数抽出 + Rust テスト 3 件（起動分岐が未テストだった）、`useVirtualizedList` 特性テスト 4 件、`useGhosts` テスト 5 件、`sspClient` テスト 4 件

各タスクは個別レビュー + ブランチ全体レビュー済み（Critical 1 件・Important 1 件はいずれも修正・再レビュー済み）。

## Test plan
- [x] `npm run build` / `npm test`（145 件）/ UI ガイドライン 2 種 / `cargo test --workspace`
- [x] TDD: 各実装タスクで Red → Green を観測（詳細はコミットメッセージ）
- [x] E2E ローカル実行（リリースビルド + WebView2 149.0.4022.98 整合ドライバ）: **9 passed / 1 skipped / 1 failed**
  - 失敗（スクロールテスト）は main ベースラインでも同一に失敗することを確認済み → 本ブランチの退行ではなく既存のテスト脆弱性（#90 として起票）

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)