### PR TITLE
docs: 手当てサイクルの知見を CLAUDE.md 各所へ反映

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,9 +63,10 @@ ghost_launcher/
 │   └── src/
 │       ├── commands/
 │       │   ├── ghost/          # ゴーストスキャン・フィンガープリント
-│       │   ├── ssp.rs          # ゴースト起動コマンド
+│       │   ├── ssp.rs          # ゴースト起動・SSP パス検証コマンド
 │       │   ├── db.rs           # DB リセット（マイグレーション失敗時の自動回復）
 │       │   └── locale.rs       # ユーザー言語ファイル読込
+│       ├── db_path.rs          # ghosts.db パス解決の単一権威
 │       └── lib.rs              # Tauri アプリビルダー
 ├── crates/ghost-meta/          # ゴーストメタデータ解析クレート
 │   └── src/                    # descript.txt パーサー・ゴースト走査・サムネイル解決
@@ -91,7 +92,7 @@ ghost_launcher/
 
 - `lib.rs` — Tauri アプリビルダー。コマンド・プラグイン登録・SQLite マイグレーション
 - `commands/ghost/` — ゴーストスキャン・DB 書き込み・フィンガープリントコマンド群。`scan.rs`（Rayon 並列スキャン + 型変換）、`store.rs`（rusqlite 差分 UPSERT）、`fingerprint.rs`（2 層差分検知）、`path_utils.rs`（パス正規化）、`types.rs`（型定義）
-- `commands/ssp.rs` — `launch_ghost` コマンド。`ssp.exe /g {ghost}` を起動
+- `commands/ssp.rs` — `launch_ghost`（`ssp.exe /g {ghost}` 起動）・`validate_ssp_path` コマンド
 - `crates/ghost-meta/` — ゴーストメタデータ解析ワークスペースクレート。`descript.txt` パーサー・ゴースト走査・サムネイル解決
 
 ### フロントエンド（`src/`）
@@ -126,6 +127,7 @@ ghost_launcher/
    - 変更しないと判断したファイルについても、その根拠を確認する
    - `.github/workflows/ci-build.yml` を読み、変更が CI で正しく検証されるか確認する
 3. **テストを実装する** — コード変更（機能追加・バグ修正）では、期待する振る舞いをテストコードとして先に書く（Red: テストが失敗することを確認する）。ドキュメント更新や CI 設定変更などテスト追加が不適切な作業は、理由をコミットメッセージまたは PR 説明に明記する
+   - 削除リファクタリングは Red が書けないため、「削除対象の本番使用ゼロ」を grep で前提検証し、期待外のヒットが出たら中止する
    - テストの種類と置き場: フック → `renderHook`（`src/hooks/*.test.ts`）、ライブラリ → 純粋関数（`src/lib/*.test.ts`）、コンポーネント → `render` + jsdom（`src/components/*.test.tsx`）
 4. **テストがパスするように実装する** — テストを満たす最小限のコードを書く（Green: テストが通ることを確認する）
 5. **検証する** — コミット前チェックリスト（後述）の全項目が通ることを確認する

--- a/e2e/CLAUDE.md
+++ b/e2e/CLAUDE.md
@@ -7,7 +7,7 @@
 - `e2e/helpers/harness.ts` が tauri-driver の起動・WebDriver セッション確立・後片付けを担当
 - E2E テストはリリースビルドが前提（`npm run tauri build` 後に実行）
 - **CI には含まれないため、UI 操作・言語表示・フォーム入力に関わる変更をした場合はローカルで手動実行が必須**
-- **既知の失敗テスト（依存更新と独立した既存問題）**: issue #69（SearchBox placeholder 反映）、#70（スクロール追加読込）。これらの失敗は環境/実装側の課題であり、依存更新後に再発しても deps 起因と即断しないこと
+- **既知の失敗テスト（依存更新と独立した既存問題）**: issue #69（SearchBox placeholder 反映）、#90（スクロールテストが `visibleGhostNames` の stale element 競合で失敗 — main でも再現）。これらの失敗は環境/実装側の課題であり、依存更新後に再発しても deps 起因と即断しないこと。失敗がブランチの退行か判断に迷ったら main のビルドで同一テストを実行しベースライン比較する
 
 ## 実行方法
 
@@ -17,6 +17,10 @@ npm run e2e:setup
 
 # テスト実行（事前に npm run tauri build が必要）
 npm run e2e
+
+# cargo workspace のためビルド出力はリポジトリ直下 target/release/ に集約される。
+# harness の既定パスは src-tauri/target を指すため、GHOST_LAUNCHER_E2E_APP で明示指定する
+# GHOST_LAUNCHER_E2E_APP='<repo>/target/release/ghost-launcher.exe' npm run e2e
 ```
 
 **EdgeDriver と WebView2 Runtime のバージョン整合**: `edgedriver` パッケージは既定でシステム Edge から版を判定する。システム Edge と WebView2 Runtime の版が乖離している環境（Edge 148 だが WebView2 Runtime 147 など）では `SessionNotCreatedError` で全テストが失敗する。WebView2 Runtime の版は次のレジストリから取得できる: `HKLM\SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\ClientState\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}` の `pv` 値。乖離時は `$env:EDGEDRIVER_VERSION = "147.0.3912.98"` のように WebView2 Runtime の版を環境変数で指定してから実行する。なお `edgedriver` の `download()` は cacheDir 内バイナリを版に関係なく返すため、harness は版指定時のみ `os.tmpdir()/edgedriver-{version}/` をバージョン別 cacheDir として渡す（`harness.ts` 参照）。
@@ -44,4 +48,4 @@ npm run e2e
 | `ghost-name` | ゴースト名テキスト | GhostCard.tsx |
 | `ghost-list-viewport` | 仮想スクロールコンテナ | GhostList.tsx |
 | `empty-state` | 空状態メッセージ | GhostList.tsx / GhostContent.tsx |
-| `random-launch-button` | ランダム起動ボタン | AppHeader.tsx |
+| `random-launch-button` | ランダム起動ボタン | GhostContent.tsx |

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -14,8 +14,12 @@
 
 **外部 UI ライブラリの DOM 出力**: 外部 UI ライブラリの DOM 出力を仮定してアサーションを書かない。先に小さなデバッグテスト（`console.log(element.outerHTML)`）で実際の出力を確認してから assertion を書く。
 
+**テストファイルは型検査されない**: tsconfig は `*.test.ts` を exclude し vitest も型検査しないため、テスト内の型エラーは build/CI で検出されない。コンパイル時の整合検査（`GHOST_VIEW_COLUMNS` の網羅チェック等）は必ず本番ソース側に置く。
+
 ## アーキテクチャメモ
 
 **非同期 singleton の初期化**: 複数のセットアップステップを持つ singleton は、初期化 Promise をキャッシュして並行呼び出しを共有する。エラー時のみ Promise をリセットして再試行可能にする（例: `getDb()` の `dbInitPromise` パターン）。
 
 **循環依存の回避（src/lib/）**: モジュール A が B をインポートし、B も A のエクスポートを必要とする場合、B は A の値（例: `Database` インスタンス）を関数パラメータで受け取り、A の直接インポートを避ける。例: `dbMonitor.ts` の `reportDbSize(db, trigger)` は `getDb()` を内部で呼ばず、呼び出し元から `db` を受け取る。
+
+**モジュールスコープ可変状態と React**: モジュールスコープの可変状態（例: `ghostDatabase.ts` の `randomSortSeed`）は React の effect 依存・リセット判定に映らない。クエリ挙動を変える状態変更は epoch として `useState` 化し、`useSearch` の resetKey / deps に配線する（`sortEpoch` パターン）。怠ると旧状態のバッファと新状態のページがマージ縫合される。


### PR DESCRIPTION
## Summary
- **ルート CLAUDE.md**: ディレクトリ構成に `db_path.rs` を追加し `ssp.rs` の説明を実態（起動 + SSP パス検証）へ。作業フローに「削除リファクタは Red の代わりに削除対象の本番使用ゼロを grep で前提検証」を追記
- **src/CLAUDE.md**: モジュールスコープ可変状態が React の effect 依存に映らない罠（`sortEpoch` パターン、PR #91 の Critical 由来）と、テストファイルが tsc/CI の型検査対象外である罠（`GHOST_VIEW_COLUMNS` 検査を本番ソースに置いた根拠）を追記
- **e2e/CLAUDE.md**: 既知失敗テストを #90 へ現行化し main ベースライン比較の作法を追記。cargo workspace のビルド出力先と `GHOST_LAUNCHER_E2E_APP` の指定理由を明記。`random-launch-button` の所在誤記（AppHeader → GhostContent）を修正

## Test plan
- [x] ドキュメントのみの変更のためテスト追加は不適用
- [x] チェックリスト（build / vitest / UI ガイドライン / cargo workspace）全パス

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)