### PR TITLE
fix: 起動履歴を Rust 専有 user-data.db へ分離しリセットの巻き添え削除を解消 (#93)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -25,7 +25,7 @@ Ghost Launcher は、**伺か/SSP ゴースト**を検出・一覧表示・検�
 | F-08 | 仮想スクロール             | 80件以上で仮想化。全件数で固定スクロール空間を確保し、バッファマージ方式で先読み読込 |
 | F-09 | テーマ追従                 | OS のライト/ダークテーマに自動追従（Fluent UI）                                     |
 | F-10 | ウィンドウ状態保存         | `tauri-plugin-window-state` によるウィンドウ位置・サイズの永続化                    |
-| F-11 | ソート順切替               | 名前順・最近起動順・起動回数順・ランダム順の切替。起動履歴（ghost_launches）を基盤とする |
+| F-11 | ソート順切替               | 名前順・最近起動順・起動回数順・ランダム順の切替。最近起動順・起動回数順は `ghosts` の非正規化集計列（`last_launched`/`launch_count`）を基盤とし、起動履歴の権威は `user-data.db`（永続）の `ghost_launches` が持つ |
 | F-12 | ランダム起動               | 一覧から無作為に 1 体選んで起動するボタン                                           |
 | F-13 | 起動履歴記録               | ゴースト起動時に ghost_identity_key と起動日時を永続記録                            |
 
@@ -60,8 +60,8 @@ Ghost Launcher は、**伺か/SSP ゴースト**を検出・一覧表示・検�
 └───────────────────────────────────────────────────────┘
          │                           │
          ▼                           ▼
-   ファイルシステム              SQLite + localStorage
-   (ghost/ ディレクトリ)        (ゴースト一覧 + fingerprint)
+   ファイルシステム         ghosts.db（揮発キャッシュ）+ user-data.db（永続）
+   (ghost/ ディレクトリ)   （ゴースト一覧 + fingerprint / 起動履歴）+ localStorage
 ```
 
 ### 3.2 バックエンド（Rust）構成
@@ -153,9 +153,12 @@ SQLite `ghosts` テーブルからの SELECT 結果を表す型（`diff_fingerpr
 | `kero_name_lower`        | `TEXT`    | `kero_name` の NFKC 正規化・小文字版（検索用）           |
 | `craftman_lower`         | `TEXT`    | `craftman` の NFKC 正規化・小文字版（検索用）            |
 | `craftmanw_lower`        | `TEXT`    | `craftmanw` の NFKC 正規化・小文字版（検索用）           |
+| `last_launched`          | `TEXT`    | 最終起動日時（非正規化集計列。`user-data.db` の `ghost_launches` から導出）|
+| `launch_count`           | `INTEGER` | 起動回数（非正規化集計列。同上）                          |
 
 - `ghosts` テーブルはファイルシステム索引の揮発キャッシュであり、スキャンで完全再投入可能
 - スキーマ変更時は `DELETE FROM ghosts` を migration に含め、次回起動時のフルスキャンで再投入させる
+- `last_launched`/`launch_count` は `user-data.db`（永続）が権威を持つ起動履歴の導出キャッシュ。`record_launch` コマンドが起動の都度即時更新し、スキャンでのキャッシュ再構築後にバックフィルで再導出する（§4.4 参照）。`ghosts` の行削除・再投入があっても `ghost_identity_key` で再結合されるため値は失われない
 
 ### 4.4 設定ストア（settings.json）
 
@@ -164,7 +167,8 @@ SQLite `ghosts` テーブルからの SELECT 結果を表す型（`diff_fingerpr
 | `ssp_path`      | `string`   | SSP インストールフォルダパス |
 | `ghost_folders` | `string[]` | 追加ゴーストフォルダの配列   |
 
-ゴーストキャッシュと fingerprint は SQLite（`ghosts.db`）に統合保存する。
+ゴーストキャッシュと fingerprint は SQLite（`ghosts.db`）に統合保存する。永続的な起動履歴は
+Rust 専有の別ファイル `user-data.db` に分離されている（§4.4 の `ghost_launches` テーブルを参照）。
 
 #### ghost_fingerprints テーブル
 
@@ -175,23 +179,28 @@ SQLite `ghosts` テーブルからの SELECT 結果を表す型（`diff_fingerpr
 | `updated_at` | `TEXT` | 最終更新日時                           |
 | `parent_mtimes` | `TEXT` | 親ディレクトリ mtime のスナップショット（Layer 1 高速差分判定用、§7.4） |
 
-#### ghost_launches テーブル（永続）
+#### ghost_launches テーブル（永続・`user-data.db`）
 
-ゴースト起動履歴の永続記録。`recent`（最終起動日時）・`frequency`（起動回数）ソートの基盤。
+ゴースト起動履歴の永続記録・権威データ。`ghosts.db` とは別ファイルの `user-data.db`
+（Rust 専有、rusqlite 直接アクセス、`tauri-plugin-sql`/sqlx を経由しない）に住み、
+マイグレーションシステム・自動リセット（`reset_ghost_db` / §13）の対象外である。
+`ghosts` テーブルの非正規化集計列 `last_launched`/`launch_count`（§4.3）は本テーブルからの
+導出キャッシュであり、`recent`/`frequency` ソート（§8.6）はその集計列を直接参照する
+（cross-DB の JOIN は行わない）。
 
 | カラム               | 型        | 説明                                             |
 | -------------------- | --------- | ------------------------------------------------ |
 | `id`                 | `INTEGER` | PRIMARY KEY AUTOINCREMENT（表固有の代理キー）     |
-| `ghost_identity_key` | `TEXT`    | 起動されたゴーストの一意キー（`ghosts` への参照） |
+| `ghost_identity_key` | `TEXT`    | 起動されたゴーストの一意キー（`ghosts` への論理参照） |
 | `launched_at`        | `TEXT`    | 起動日時（`datetime('now')`）                    |
 
-- `ghosts` とは `ghost_identity_key` で LEFT JOIN する（`ghosts.id` は参照しない）
-- `ghosts` が `DELETE FROM` で再投入されても `ghost_identity_key` は不変のため、履歴は自動的に再結合する
+- `ghosts.id` ではなく `ghost_identity_key` で `ghosts` 側の集計列と対応付ける（DB をまたぐため SQL の JOIN 自体は組めない。`record_launch` コマンドが両 DB を個別に UPDATE して同期する）
+- `ghosts` が `DELETE FROM` で再投入されても `ghost_identity_key` は不変のため、スキャン時バックフィルで自動的に再結合する
 - インデックス: `idx_ghost_launches_identity(ghost_identity_key)`・`idx_ghost_launches_at(launched_at DESC)`
 
 ### 4.5 永続テーブルのキー設計ルール
 
-`ghosts` はファイルシステム索引の**揮発キャッシュ**で、スキーマ変更時に `DELETE FROM ghosts` で全件削除・再投入される（§4.3）。一方 `ghost_launches` や将来の `favorites` 等は**永続テーブル**であり、ユーザーの蓄積データを保持する。両者をまたぐ参照は以下のルールに従う。
+`ghosts` はファイルシステム索引の**揮発キャッシュ**で、スキーマ変更時に `DELETE FROM ghosts` で全件削除・再投入される（§4.3）。一方 `ghost_launches` や将来の `favorites` 等は**永続テーブル**であり、ユーザーの蓄積データを保持する。`ghost_launches` は `ghosts.db` とは別ファイルの `user-data.db`（Rust 専有）に置かれ、`ghosts` 側は `last_launched`/`launch_count` という導出集計列（§4.3）だけを持つ。両者をまたぐ参照は以下のルールに従う。
 
 - **`ghosts.id`（AUTOINCREMENT）を永続テーブルの外部参照に使わない**。`DELETE`/再 `INSERT` で値が変わり、参照が孤立する。10 万件規模では再投入のたびに大量の蓄積データが一瞬で無効化されうる
 - **外部参照には `ghost_identity_key` を使う**。`NFKC(source) + \x1f + NFKC(directory_name)`（`source` は `"ssp"` または追加フォルダのフルパス）で構成され、`ssp_path`（`request_key`）を含まない。このため SSP パス変更やキャッシュ再投入後も参照が自動的に再結合する
@@ -269,6 +278,15 @@ ghosts.db と WAL/SHM を削除してマイグレーション競合を解消す�
 ### 6.5 `read_user_locale`
 
 実行ファイル横の `locales/{lang}.json` を読み込む（docs/locale-customization.md 参照）。
+
+### 6.6 `record_launch`
+
+| 項目   | 内容                                                                                     |
+| ------ | ----------------------------------------------------------------------------------------- |
+| 引数   | `ghost_identity_key: String`                                                              |
+| 戻り値 | `()`                                                                                      |
+| 処理   | 起動履歴を記録する。`user-data.db`（永続、権威）へ `ghost_launches` 行を INSERT した後、`ghosts.db` の該当行の `last_launched`/`launch_count`（導出集計列、§4.3）を UPDATE する。user-data 側を先に書くため、ghosts 側更新が失敗しても権威データは残り、次回スキャン時のバックフィルで整合する |
+| エラー | いずれかの DB への書込失敗時にエラーを返す（フロントエンドはログのみで UI をブロックしない） |
 
 ---
 
@@ -387,7 +405,10 @@ ghosts.db と WAL/SHM を削除してマイグレーション競合を解消す�
 ### 8.6 表示ソート
 
 一覧の表示順は SQLite の `ORDER BY` が唯一の権威。名前順（NFKC 小文字）・最近起動順・
-起動回数順（いずれも `ghost_launches` と LEFT JOIN）・ランダム順を提供する。
+起動回数順（いずれも `ghosts` の非正規化集計列 `last_launched`/`launch_count` を単一 DB で
+`ORDER BY` する。cross-DB JOIN は行わない）・ランダム順を提供する。集計列は `record_launch`
+コマンドの即時更新と、スキャンでのキャッシュ再構築後のバックフィルで `user-data.db` の
+`ghost_launches`（権威）と整合を保つ（§4.4・§6.6）。
 ランダム順はセッション毎のシードで `ORDER BY (id * seed) % 素数` を固定し、仮想スクロールの
 ページングとバッファマージに対して順序整合を保つ。「ランダム」再選択でシードを引き直す
 （シード変更は sortEpoch として検索フックのリセット判定に配線され、全置換再取得を強制する）。
@@ -619,6 +640,6 @@ stateDiagram-v2
 | スキャンエラー（キャッシュなし）     | エラーメッセージ表示 + ゴーストリストクリア              |
 | 設定保存失敗                         | コンソールエラー + UI ロールバック                       |
 | キャッシュ書き込み失敗               | コンソールエラーのみ（UI 影響なし）                      |
-| マイグレーション競合（起動時）       | DB 読み込みエラーを検出し `reset_ghost_db` で ghosts.db を自動削除 → 再接続。ゴースト一覧は再スキャンで復元されるが、起動履歴（`ghost_launches`）は失われる |
+| マイグレーション競合（起動時）       | DB 読み込みエラーを検出し `reset_ghost_db` で ghosts.db を自動削除 → 再接続。リセット対象は揮発キャッシュの ghosts.db のみで、永続データ（`user-data.db` の `ghost_launches`）は対象外のため失われない。ゴースト一覧・集計列は再スキャンで復元される（バックフィルで `last_launched`/`launch_count` を再導出） |
 
 ---

--- a/docs/superpowers/plans/2026-07-04-persist-launch-history-separate-db.md
+++ b/docs/superpowers/plans/2026-07-04-persist-launch-history-separate-db.md
@@ -1,0 +1,943 @@
+# 永続テーブル分離（user-data.db）実装計画
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 起動履歴 `ghost_launches` を揮発キャッシュ `ghosts.db` から Rust 専有の `user-data.db` へ分離し、マイグレーション競合時のリセットが永続データを巻き添え削除する不変条件違反（issue #93）を解消する。
+
+**Architecture:** `ghost_launches` を新設 `user-data.db`（rusqlite 単一接続のみが触る）へ移す。cross-DB JOIN は `tauri-plugin-sql` のプール揮発で ATTACH が使えないため廃止し、`ghosts` へ非正規化した集計列 `last_launched` / `launch_count` を持たせて recent/frequency を単一 DB のプレーン ORDER BY に置換する。集計列は `record_launch`（起動時）で即時更新し、`scan_and_store`（スキャン時）で user-data.db から再導出（バックフィル）する。旧履歴は初回起動時に一度だけ複写する。
+
+**Tech Stack:** Rust（rusqlite / tauri 2）, TypeScript（React 19 / vitest）, SQLite。
+
+## Global Constraints
+
+- マイグレーション SQL の不変性: 一度コミットした migration の SQL 文字列は**絶対に編集しない**（SHA-384 チェックサム再検証でクラッシュ）。複数行 SQL は `\n` を明示（raw 改行 + インデント禁止）。
+- `ALTER TABLE ... ADD COLUMN ... DEFAULT` の値は**リテラルのみ**（`datetime('now')` 等の関数は不可）。実時刻は INSERT/UPDATE の文で `datetime('now')` を使う。
+- Tauri IPC: `invoke()` は引数名を camelCase → snake_case へ自動変換（戻り値は変換しない）。
+- 機械キーの整列に `localeCompare` を使わない（コードポイント順）。本計画は整列を変更しないが遵守。
+- ライフサイクル順序保証: 当アプリは `plugins.sql.preload` を**使わない**（確認済み）。従って sqlx マイグレーションは JS の `Database.load("sqlite:ghosts.db")` 呼び出し時に実行され、Rust の `.setup()` クロージャは常にそれより先に走る。本計画の「移送（setup）→ 旧テーブル DROP（migration 13）」順序はこの保証に依存する。
+- 検証コマンド: `cargo test --manifest-path src-tauri/Cargo.toml` / `npm test` / `npm run build` / `npm run check:ui-guidelines`。
+
+---
+
+## ファイル構成
+
+- Create: `src-tauri/src/commands/launch_history.rs` — user-data.db のスキーマ・起動履歴操作（open / ensure_schema / record_launch / backfill / legacy 移送）と `record_launch` コマンド。
+- Modify: `src-tauri/src/db_path.rs` — `user_data_db_path()` 追加（パス解決の単一権威）。
+- Modify: `src-tauri/src/commands/mod.rs` — `pub mod launch_history;` 追加。
+- Modify: `src-tauri/src/lib.rs` — migration 12/13 追加、`.setup()` で user-data 初期化＋legacy 移送、`record_launch` コマンド登録、スキーマ検証テスト追加。
+- Modify: `src-tauri/src/commands/ghost/mod.rs` — `scan_and_store` の cache miss 経路末尾でバックフィルを呼ぶ。
+- Modify: `src/lib/ghostDatabase.ts` — `recordLaunch` を `invoke("record_launch")` へ、`buildOrderBy` の JOIN 廃止＋集計列 ORDER BY、`from` 条件分岐の除去、コメント訂正。
+- Modify: `src-tauri/CLAUDE.md` / `SPEC.md` — 「キャッシュなので安全」記述を分離後の正しい記述へ同期。
+
+**タスク依存順の注意:** migration 12（集計列追加）は record_launch/backfill のテストが読む列を用意するため、それらより**先**に置く（Task 2）。
+
+---
+
+## Task 1: user-data.db スキーマと接続（Rust）
+
+**Files:**
+- Modify: `src-tauri/src/db_path.rs`
+- Create: `src-tauri/src/commands/launch_history.rs`
+- Modify: `src-tauri/src/commands/mod.rs`
+
+**Interfaces:**
+- Produces:
+  - `db_path::user_data_db_path<R: tauri::Runtime>(&impl Manager<R>) -> Result<PathBuf, String>`
+  - `commands::launch_history::ensure_schema(conn: &rusqlite::Connection) -> Result<(), String>`
+  - `commands::launch_history::open_user_data_db<R: tauri::Runtime>(&impl Manager<R>) -> Result<rusqlite::Connection, String>`
+
+- [ ] **Step 1: db_path.rs に user-data.db パス解決を追加**
+
+`src-tauri/src/db_path.rs` の末尾（`ghost_db_path` の後）に追加:
+
+```rust
+/// user-data.db（永続ユーザーデータ）本体のフルパス。ghosts.db と同じ app_config_dir 基準。
+/// user-data.db は永続ストアであり、reset_ghost_db / sanitize_ghost_db の削除対象に含めない。
+pub(crate) fn user_data_db_path<R: tauri::Runtime>(
+    manager: &impl Manager<R>,
+) -> Result<std::path::PathBuf, String> {
+    Ok(ghost_db_dir(manager)?.join("user-data.db"))
+}
+```
+
+- [ ] **Step 2: commands/mod.rs にモジュール登録**
+
+`src-tauri/src/commands/mod.rs` を次へ（アルファベット順の位置に追加）:
+
+```rust
+pub mod db;
+pub mod ghost;
+pub mod launch_history;
+pub mod locale;
+pub mod ssp;
+```
+
+- [ ] **Step 3: launch_history.rs を作成し失敗するテストを書く**
+
+`src-tauri/src/commands/launch_history.rs` を新規作成:
+
+```rust
+use rusqlite::Connection;
+use tauri::Manager;
+
+/// user-data.db に起動履歴テーブルを冪等に用意する。
+/// ここは sqlx マイグレーション系に載せない（永続ストアなので自動削除の事故クラスが構造上発生しない）。
+pub(crate) fn ensure_schema(conn: &Connection) -> Result<(), String> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS ghost_launches (\n  id INTEGER PRIMARY KEY AUTOINCREMENT,\n  ghost_identity_key TEXT NOT NULL,\n  launched_at TEXT NOT NULL\n);\nCREATE INDEX IF NOT EXISTS idx_ghost_launches_identity ON ghost_launches(ghost_identity_key);\nCREATE INDEX IF NOT EXISTS idx_ghost_launches_at ON ghost_launches(launched_at DESC);",
+    )
+    .map_err(|e| format!("user-data スキーマ作成エラー: {e}"))
+}
+
+/// user-data.db を開き、書込用 PRAGMA を適用し、スキーマを用意して返す。
+pub(crate) fn open_user_data_db<R: tauri::Runtime>(
+    manager: &impl Manager<R>,
+) -> Result<Connection, String> {
+    let path = crate::db_path::user_data_db_path(manager)?;
+    let conn = Connection::open(&path).map_err(|e| format!("user-data.db オープンエラー: {e}"))?;
+    crate::commands::ghost::store::configure_connection(&conn)?;
+    ensure_schema(&conn)?;
+    Ok(conn)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ensure_schemaはghost_launchesテーブルを冪等に作る() {
+        let conn = Connection::open_in_memory().unwrap();
+        ensure_schema(&conn).unwrap();
+        // 二重呼び出しでも失敗しない（IF NOT EXISTS）
+        ensure_schema(&conn).unwrap();
+
+        let cols: Vec<String> = conn
+            .prepare("PRAGMA table_info(ghost_launches)")
+            .unwrap()
+            .query_map([], |row| row.get::<_, String>(1))
+            .unwrap()
+            .filter_map(Result::ok)
+            .collect();
+        assert!(cols.contains(&"ghost_identity_key".to_string()));
+        assert!(cols.contains(&"launched_at".to_string()));
+    }
+}
+```
+
+- [ ] **Step 4: テストが失敗することを確認**
+
+まず `commands/mod.rs` の `pub mod launch_history;` を入れずにビルドし「モジュール未解決」を確認してから Step 2 を適用する。
+Run: `cargo test --manifest-path src-tauri/Cargo.toml ensure_schema`
+Expected: 未適用時はコンパイルエラー、Step 1-3 適用後は次の Step で PASS。
+
+- [ ] **Step 5: テストが通ることを確認**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml ensure_schema`
+Expected: PASS（`ensure_schemaはghost_launchesテーブルを冪等に作る` 1 件）
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src-tauri/src/db_path.rs src-tauri/src/commands/launch_history.rs src-tauri/src/commands/mod.rs
+git commit -m "feat: user-data.db スキーマ・接続ヘルパーを追加 (#93)"
+```
+
+---
+
+## Task 2: マイグレーション 12/13（集計列追加・旧履歴除去）（Rust, lib.rs）
+
+**Files:**
+- Modify: `src-tauri/src/lib.rs`
+
+**Interfaces:**
+- Produces: migration 12（ghosts へ `last_launched TEXT` / `launch_count INTEGER NOT NULL DEFAULT 0` 追加）、migration 13（`DROP TABLE IF EXISTS ghost_launches`）。以降のタスクはこの 2 列に依存する。
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`src-tauri/src/lib.rs` の `tests` モジュール（`マイグレーションが順番に…` の隣）に追加:
+
+```rust
+    #[test]
+    fn migration12と13で集計列追加と旧履歴テーブル除去が行われる() {
+        let conn = Connection::open_in_memory().unwrap();
+        let mut applied = migrations();
+        applied.sort_by_key(|m| m.version);
+        for m in applied {
+            conn.execute_batch(m.sql).unwrap();
+        }
+        // ghosts に集計列が存在する
+        let cols: Vec<String> = conn
+            .prepare("PRAGMA table_info(ghosts)")
+            .unwrap()
+            .query_map([], |row| row.get::<_, String>(1))
+            .unwrap()
+            .filter_map(Result::ok)
+            .collect();
+        assert!(cols.contains(&"last_launched".to_string()));
+        assert!(cols.contains(&"launch_count".to_string()));
+        // 旧 ghost_launches テーブルは ghosts.db から除去されている
+        let has_launches: i64 = conn
+            .query_row("SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='ghost_launches'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(has_launches, 0, "ghost_launches は user-data.db へ分離され ghosts.db からは除去される");
+    }
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml migration12と13`
+Expected: FAIL（`last_launched` 列なし / `ghost_launches` が残存）
+
+- [ ] **Step 3: migration 12/13 を追加**
+
+`migrations()` の `vec![ … ]` 内、version 11 の要素の**後ろ**に追加（末尾要素として）:
+
+```rust
+        tauri_plugin_sql::Migration {
+            version: 12,
+            description: "add_launch_aggregates_to_ghosts",
+            sql: "ALTER TABLE ghosts ADD COLUMN last_launched TEXT;\nALTER TABLE ghosts ADD COLUMN launch_count INTEGER NOT NULL DEFAULT 0;",
+            kind: tauri_plugin_sql::MigrationKind::Up,
+        },
+        tauri_plugin_sql::Migration {
+            version: 13,
+            description: "drop_legacy_ghost_launches_from_cache_db",
+            sql: "DROP TABLE IF EXISTS ghost_launches;",
+            kind: tauri_plugin_sql::MigrationKind::Up,
+        },
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml migration12と13`
+Expected: PASS
+
+- [ ] **Step 5: 既存マイグレーションテストの回帰確認**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml マイグレーション`
+Expected: 全 PASS（`マイグレーションが順番にインメモリdbへ適用できる`・`ghost_viewの全選択列がghostsスキーマに存在する` 等が引き続き通る）
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src-tauri/src/lib.rs
+git commit -m "feat: migration 12/13 で集計列追加と旧履歴テーブル除去 (#93)"
+```
+
+---
+
+## Task 3: record_launch の二面更新（Rust）
+
+**Files:**
+- Modify: `src-tauri/src/commands/launch_history.rs`
+
+**Interfaces:**
+- Consumes: `ensure_schema`（Task 1）、migration 12 の集計列（Task 2）
+- Produces:
+  - `commands::launch_history::record_launch_inner(user_conn: &Connection, ghosts_conn: &Connection, ghost_identity_key: &str) -> Result<(), String>`
+  - テストヘルパー `ghosts_conn_with_row(identity_key: &str) -> Connection`（同ファイル `tests` 内。Task 4 でも再利用）
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`launch_history.rs` の `tests` モジュールに追加:
+
+```rust
+    fn ghosts_conn_with_row(identity_key: &str) -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        let mut migs = crate::migrations();
+        migs.sort_by_key(|m| m.version);
+        for m in migs {
+            conn.execute_batch(m.sql).unwrap();
+        }
+        conn.execute(
+            "INSERT INTO ghosts (request_key, ghost_identity_key, row_fingerprint, name, sakura_name, kero_name, craftman, craftmanw, directory_name, path, source, name_lower, sakura_name_lower, kero_name_lower, craftman_lower, craftmanw_lower, directory_name_lower, thumbnail_path, thumbnail_use_self_alpha, thumbnail_kind, updated_at) VALUES ('rk1', ?1, '', 'G', '', '', '', '', 'g', '/g', 'ssp', 'g', '', '', '', '', 'g', '', 0, '', '')",
+            rusqlite::params![identity_key],
+        )
+        .unwrap();
+        conn
+    }
+
+    #[test]
+    fn record_launch_innerはuserdataへinsertしghostsの集計列をbumpする() {
+        let user_conn = Connection::open_in_memory().unwrap();
+        ensure_schema(&user_conn).unwrap();
+        let ghosts_conn = ghosts_conn_with_row("sspg");
+
+        record_launch_inner(&user_conn, &ghosts_conn, "sspg").unwrap();
+        record_launch_inner(&user_conn, &ghosts_conn, "sspg").unwrap();
+
+        let launches: i64 = user_conn
+            .query_row("SELECT COUNT(*) FROM ghost_launches WHERE ghost_identity_key = 'sspg'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(launches, 2);
+
+        let (count, last): (i64, Option<String>) = ghosts_conn
+            .query_row("SELECT launch_count, last_launched FROM ghosts WHERE ghost_identity_key = 'sspg'", [], |r| Ok((r.get(0)?, r.get(1)?)))
+            .unwrap();
+        assert_eq!(count, 2);
+        assert!(last.is_some(), "last_launched が設定されること");
+    }
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml record_launch_inner`
+Expected: FAIL（`record_launch_inner` 未定義でコンパイルエラー）
+
+- [ ] **Step 3: record_launch_inner を実装**
+
+`launch_history.rs` の `open_user_data_db` の後に追加:
+
+```rust
+/// 起動履歴を記録する。user-data.db へ INSERT（権威）し、ghosts.db の集計列を bump（導出）する。
+/// user-data 側を先に書くため、ghosts 側更新が失敗しても権威データは残り、次回バックフィルで整合する。
+pub(crate) fn record_launch_inner(
+    user_conn: &Connection,
+    ghosts_conn: &Connection,
+    ghost_identity_key: &str,
+) -> Result<(), String> {
+    user_conn
+        .execute(
+            "INSERT INTO ghost_launches (ghost_identity_key, launched_at) VALUES (?1, datetime('now'))",
+            rusqlite::params![ghost_identity_key],
+        )
+        .map_err(|e| format!("起動履歴 INSERT エラー: {e}"))?;
+    ghosts_conn
+        .execute(
+            "UPDATE ghosts SET launch_count = launch_count + 1, last_launched = datetime('now') WHERE ghost_identity_key = ?1",
+            rusqlite::params![ghost_identity_key],
+        )
+        .map_err(|e| format!("集計列 UPDATE エラー: {e}"))?;
+    Ok(())
+}
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml record_launch_inner`
+Expected: PASS
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src-tauri/src/commands/launch_history.rs
+git commit -m "feat: record_launch_inner で起動履歴の二面更新を実装 (#93)"
+```
+
+---
+
+## Task 4: 集計バックフィル（Rust）
+
+**Files:**
+- Modify: `src-tauri/src/commands/launch_history.rs`
+
+**Interfaces:**
+- Consumes: `ensure_schema`、テストヘルパー `ghosts_conn_with_row`（Task 3）
+- Produces: `commands::launch_history::backfill_aggregates(ghosts_conn: &Connection, user_conn: &Connection) -> Result<(), String>`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`tests` モジュールに追加（`ghosts_conn_with_row` は Task 3 で定義済みのものを再利用）:
+
+```rust
+    #[test]
+    fn backfill_aggregatesはuserdataの集計をghostsへ再導出する() {
+        let user_conn = Connection::open_in_memory().unwrap();
+        ensure_schema(&user_conn).unwrap();
+        let ghosts_conn = ghosts_conn_with_row("sspg");
+        // 未起動の別ゴースト B も用意（0/NULL のままであること）
+        ghosts_conn
+            .execute(
+                "INSERT INTO ghosts (request_key, ghost_identity_key, row_fingerprint, name, sakura_name, kero_name, craftman, craftmanw, directory_name, path, source, name_lower, sakura_name_lower, kero_name_lower, craftman_lower, craftmanw_lower, directory_name_lower, thumbnail_path, thumbnail_use_self_alpha, thumbnail_kind, updated_at) VALUES ('rk1', 'sspb', '', 'B', '', '', '', '', 'b', '/b', 'ssp', 'b', '', '', '', '', 'b', '', 0, '', '')",
+                [],
+            )
+            .unwrap();
+        // user-data に A の起動 3 回（時刻昇順）
+        for at in ["2026-01-01 00:00:00", "2026-01-02 00:00:00", "2026-01-03 00:00:00"] {
+            user_conn
+                .execute("INSERT INTO ghost_launches (ghost_identity_key, launched_at) VALUES ('sspg', ?1)", rusqlite::params![at])
+                .unwrap();
+        }
+
+        backfill_aggregates(&ghosts_conn, &user_conn).unwrap();
+
+        let (count, last): (i64, Option<String>) = ghosts_conn
+            .query_row("SELECT launch_count, last_launched FROM ghosts WHERE ghost_identity_key = 'sspg'", [], |r| Ok((r.get(0)?, r.get(1)?)))
+            .unwrap();
+        assert_eq!(count, 3);
+        assert_eq!(last.as_deref(), Some("2026-01-03 00:00:00"));
+
+        let (bcount, blast): (i64, Option<String>) = ghosts_conn
+            .query_row("SELECT launch_count, last_launched FROM ghosts WHERE ghost_identity_key = 'sspb'", [], |r| Ok((r.get(0)?, r.get(1)?)))
+            .unwrap();
+        assert_eq!(bcount, 0);
+        assert_eq!(blast, None);
+    }
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml backfill_aggregates`
+Expected: FAIL（`backfill_aggregates` 未定義）
+
+- [ ] **Step 3: backfill_aggregates を実装**
+
+`record_launch_inner` の後に追加:
+
+```rust
+/// user-data.db の起動履歴集計（identity 毎の MAX(launched_at) と COUNT）を
+/// ghosts.db の集計列へ書き戻す。キャッシュ再構築（cache miss）の後に呼ぶ。
+/// COUNT は単調増加のため、起動済みキーだけを上書きすれば未起動行は 0/NULL のまま残る。
+pub(crate) fn backfill_aggregates(
+    ghosts_conn: &Connection,
+    user_conn: &Connection,
+) -> Result<(), String> {
+    let aggregates: Vec<(String, String, i64)> = {
+        let mut stmt = user_conn
+            .prepare("SELECT ghost_identity_key, MAX(launched_at), COUNT(*) FROM ghost_launches GROUP BY ghost_identity_key")
+            .map_err(|e| format!("集計 SELECT 準備エラー: {e}"))?;
+        stmt.query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))
+            .map_err(|e| format!("集計 SELECT エラー: {e}"))?
+            .filter_map(Result::ok)
+            .collect()
+    };
+    for (key, last, count) in aggregates {
+        ghosts_conn
+            .execute(
+                "UPDATE ghosts SET last_launched = ?2, launch_count = ?3 WHERE ghost_identity_key = ?1",
+                rusqlite::params![key, last, count],
+            )
+            .map_err(|e| format!("集計列バックフィル UPDATE エラー: {e}"))?;
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml backfill_aggregates`
+Expected: PASS
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src-tauri/src/commands/launch_history.rs
+git commit -m "feat: backfill_aggregates で集計列を user-data から再導出 (#93)"
+```
+
+---
+
+## Task 5: 旧履歴の一度きり移送（Rust）
+
+**Files:**
+- Modify: `src-tauri/src/commands/launch_history.rs`
+
+**Interfaces:**
+- Consumes: `ensure_schema`
+- Produces:
+  - `commands::launch_history::migrate_legacy_launch_history(ghosts_conn: &Connection, user_conn: &Connection) -> Result<(), String>`
+  - テストヘルパー `ghosts_conn_with_legacy_launches(rows: &[(&str, &str)]) -> Connection`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`tests` モジュールに追加:
+
+```rust
+    fn ghosts_conn_with_legacy_launches(rows: &[(&str, &str)]) -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        // migration 11 相当の legacy テーブルのみ用意（本テストは移送だけを対象）
+        conn.execute_batch(
+            "CREATE TABLE ghost_launches (id INTEGER PRIMARY KEY AUTOINCREMENT, ghost_identity_key TEXT NOT NULL, launched_at TEXT NOT NULL);",
+        )
+        .unwrap();
+        for (key, at) in rows {
+            conn.execute("INSERT INTO ghost_launches (ghost_identity_key, launched_at) VALUES (?1, ?2)", rusqlite::params![key, at]).unwrap();
+        }
+        conn
+    }
+
+    #[test]
+    fn migrate_legacyは旧履歴を複写し二度目は複写しない() {
+        let user_conn = Connection::open_in_memory().unwrap();
+        ensure_schema(&user_conn).unwrap();
+        let ghosts_conn = ghosts_conn_with_legacy_launches(&[("sspg", "2026-01-01 00:00:00"), ("sspg", "2026-01-02 00:00:00")]);
+
+        migrate_legacy_launch_history(&ghosts_conn, &user_conn).unwrap();
+        // 冪等: 二度目は user-data が非空なので何もしない
+        migrate_legacy_launch_history(&ghosts_conn, &user_conn).unwrap();
+
+        let total: i64 = user_conn.query_row("SELECT COUNT(*) FROM ghost_launches", [], |r| r.get(0)).unwrap();
+        assert_eq!(total, 2, "重複複写されないこと");
+    }
+
+    #[test]
+    fn migrate_legacyはlegacyテーブル不在でno_op() {
+        let user_conn = Connection::open_in_memory().unwrap();
+        ensure_schema(&user_conn).unwrap();
+        let ghosts_conn = Connection::open_in_memory().unwrap(); // ghost_launches なし
+        migrate_legacy_launch_history(&ghosts_conn, &user_conn).unwrap();
+        let total: i64 = user_conn.query_row("SELECT COUNT(*) FROM ghost_launches", [], |r| r.get(0)).unwrap();
+        assert_eq!(total, 0);
+    }
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml migrate_legacy`
+Expected: FAIL（未定義）
+
+- [ ] **Step 3: migrate_legacy_launch_history を実装**
+
+`backfill_aggregates` の後に追加:
+
+```rust
+/// 旧 ghosts.db.ghost_launches の履歴を user-data.db へ一度だけ複写する。
+/// 冪等ガード = user-data.db が空のときだけ複写する（二重複写を防ぐ）。
+/// このため migration 13 による旧テーブル DROP の順序に依存せず安全。
+pub(crate) fn migrate_legacy_launch_history(
+    ghosts_conn: &Connection,
+    user_conn: &Connection,
+) -> Result<(), String> {
+    let already: i64 = user_conn
+        .query_row("SELECT COUNT(*) FROM ghost_launches", [], |r| r.get(0))
+        .unwrap_or(0);
+    if already > 0 {
+        return Ok(());
+    }
+    let has_legacy: i64 = ghosts_conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'ghost_launches'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap_or(0);
+    if has_legacy == 0 {
+        return Ok(());
+    }
+    let legacy: Vec<(String, String)> = {
+        let mut stmt = ghosts_conn
+            .prepare("SELECT ghost_identity_key, launched_at FROM ghost_launches")
+            .map_err(|e| format!("legacy SELECT 準備エラー: {e}"))?;
+        stmt.query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+            .map_err(|e| format!("legacy SELECT エラー: {e}"))?
+            .filter_map(Result::ok)
+            .collect()
+    };
+    for (key, at) in legacy {
+        user_conn
+            .execute(
+                "INSERT INTO ghost_launches (ghost_identity_key, launched_at) VALUES (?1, ?2)",
+                rusqlite::params![key, at],
+            )
+            .map_err(|e| format!("legacy 移送 INSERT エラー: {e}"))?;
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml migrate_legacy`
+Expected: PASS（2 件）
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src-tauri/src/commands/launch_history.rs
+git commit -m "feat: 旧履歴を user-data.db へ一度きり冪等移送 (#93)"
+```
+
+---
+
+## Task 6: record_launch コマンドと setup 配線（Rust, lib.rs）
+
+**Files:**
+- Modify: `src-tauri/src/commands/launch_history.rs`
+- Modify: `src-tauri/src/lib.rs`
+
+**Interfaces:**
+- Consumes: `open_user_data_db`（Task 1）, `record_launch_inner`（Task 3）, `migrate_legacy_launch_history`（Task 5）
+- Produces: `#[tauri::command] commands::launch_history::record_launch(app, ghost_identity_key: String)`、`lib::init_user_data(app: &tauri::App)`
+
+**注記（テスト方針）:** `record_launch` コマンドと `.setup()` 配線は `AppHandle` / `&App` を要し、この現場に単体テストの前例がない。ロジックは Task 3/5 の純関数テストで検証済み。本タスクは薄い配線のみで、検証は `cargo build` 通過＋統合検証（手動 E2E・手動アップグレード確認）に委ねる。追加配線のため TDD の Red は省略する。
+
+- [ ] **Step 1: record_launch コマンドを追加**
+
+`launch_history.rs` の `migrate_legacy_launch_history` の後（`#[cfg(test)]` の前）に追加:
+
+```rust
+/// 起動履歴を記録する Tauri コマンド。user-data.db へ INSERT し ghosts.db の集計列を bump する。
+#[tauri::command]
+pub fn record_launch(app: tauri::AppHandle, ghost_identity_key: String) -> Result<(), String> {
+    let user_conn = open_user_data_db(&app)?;
+    let ghosts_path = crate::db_path::ghost_db_path(&app)?;
+    let ghosts_conn =
+        Connection::open(&ghosts_path).map_err(|e| format!("ghosts.db オープンエラー: {e}"))?;
+    crate::commands::ghost::store::configure_connection(&ghosts_conn)?;
+    record_launch_inner(&user_conn, &ghosts_conn, &ghost_identity_key)
+}
+```
+
+- [ ] **Step 2: lib.rs に user-data 初期化関数を追加**
+
+`src-tauri/src/lib.rs` の `sanitize_ghost_db` 関数の後に追加:
+
+```rust
+/// user-data.db を初期化し、旧 ghosts.db.ghost_launches の履歴を一度だけ移送する。
+/// Rust setup（JS の Database.load によるマイグレーションより先に走る）で呼ぶことで、
+/// migration 13 の旧テーブル DROP より前に移送を完了させる。
+fn init_user_data(app: &tauri::App) {
+    let Ok(user_conn) = commands::launch_history::open_user_data_db(app) else {
+        eprintln!("[user-data] user-data.db を初期化できませんでした");
+        return;
+    };
+    let Ok(ghosts_path) = db_path::ghost_db_path(app) else {
+        return;
+    };
+    // ghosts.db が存在するときだけ legacy 移送を試みる（空ファイルの事前生成を避ける）
+    if ghosts_path.exists() {
+        if let Ok(ghosts_conn) = rusqlite::Connection::open(&ghosts_path) {
+            let _ = commands::launch_history::migrate_legacy_launch_history(&ghosts_conn, &user_conn);
+        }
+    }
+}
+```
+
+- [ ] **Step 3: setup() で init_user_data を呼ぶ**
+
+`.setup(|app| { … })` を更新:
+
+```rust
+        .setup(|app| {
+            sanitize_ghost_db(app);
+            init_user_data(app);
+            Ok(())
+        })
+```
+
+- [ ] **Step 4: invoke_handler に record_launch を登録**
+
+`tauri::generate_handler![ … ]` を次へ:
+
+```rust
+        .invoke_handler(tauri::generate_handler![
+            commands::db::reset_ghost_db,
+            commands::ghost::scan_and_store,
+            commands::launch_history::record_launch,
+            commands::ssp::launch_ghost,
+            commands::ssp::validate_ssp_path,
+            commands::locale::read_user_locale,
+        ])
+```
+
+- [ ] **Step 5: コンパイルとテスト全体の確認**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml`
+Expected: 全 PASS（配線がビルドを壊さない・既存 suite 緑）
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src-tauri/src/commands/launch_history.rs src-tauri/src/lib.rs
+git commit -m "feat: record_launch コマンドと user-data 初期化/移送を配線 (#93)"
+```
+
+---
+
+## Task 7: scan_and_store にバックフィルを配線（Rust）
+
+**Files:**
+- Modify: `src-tauri/src/commands/ghost/mod.rs`
+
+**Interfaces:**
+- Consumes: `commands::launch_history::open_user_data_db`（Task 1）, `backfill_aggregates`（Task 4）
+
+**注記（テスト方針）:** `scan_and_store` は `tauri::AppHandle` を取る `#[tauri::command]` で、この現場に単体テストの前例がない（バックフィルのロジックは Task 4 の純関数テストで検証済み）。本タスクは配線のみで、検証は `cargo test` の通過＋手動 E2E に委ねる。追加配線のため TDD の Red は省略する。
+
+- [ ] **Step 1: cache miss 経路の末尾にバックフィルを追加**
+
+`src-tauri/src/commands/ghost/mod.rs` の `scan_and_store` 内、`let total = store::store_ghosts(...)?;` の直後・`Ok(ScanStoreResult { … })` の前を次へ:
+
+```rust
+    let total = store::store_ghosts(&conn, &request_key, &ghosts, &fingerprint, &current_mtimes)?;
+
+    // 起動履歴の集計列（last_launched / launch_count）を user-data.db から再導出する。
+    // ベストエフォート: user-data.db を開けない場合も本来のスキャン結果は返す。
+    if let Ok(user_conn) = crate::commands::launch_history::open_user_data_db(&app) {
+        let _ = crate::commands::launch_history::backfill_aggregates(&conn, &user_conn);
+    }
+
+    Ok(ScanStoreResult {
+        cache_hit: false,
+        total,
+        fingerprint,
+        request_key,
+    })
+```
+
+- [ ] **Step 2: コンパイルとテスト全体の確認**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml`
+Expected: 全 PASS
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add src-tauri/src/commands/ghost/mod.rs
+git commit -m "feat: scan_and_store でスキャン後に集計列をバックフィル (#93)"
+```
+
+---
+
+## Task 8: フロント recordLaunch を record_launch invoke へ（TS）
+
+**Files:**
+- Modify: `src/lib/ghostDatabase.ts`
+- Modify: `src/lib/ghostDatabase.test.ts`
+
+**Interfaces:**
+- Produces: `recordLaunch(ghostIdentityKey: string): Promise<void>`（`invoke("record_launch", { ghostIdentityKey })` を呼ぶ）
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`src/lib/ghostDatabase.test.ts` に追加（ファイル冒頭の import 群に `invoke` と `recordLaunch` が無ければ追加。重複 import は避ける）:
+
+```ts
+import { invoke } from "@tauri-apps/api/core";
+import { recordLaunch } from "./ghostDatabase";
+
+describe("recordLaunch", () => {
+  beforeEach(() => {
+    vi.mocked(invoke).mockReset();
+    vi.mocked(invoke).mockResolvedValue(undefined);
+  });
+
+  it("record_launch IPC を camelCase 引数で呼ぶ", async () => {
+    await recordLaunch("sspmy_ghost");
+    expect(invoke).toHaveBeenCalledWith("record_launch", { ghostIdentityKey: "sspmy_ghost" });
+  });
+});
+```
+
+（`describe/it/expect/vi/beforeEach` は既存 import を利用。無ければ `import { describe, it, expect, vi, beforeEach } from "vitest";` を追加。）
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `npx vitest run src/lib/ghostDatabase.test.ts -t "record_launch IPC"`
+Expected: FAIL（現行 `recordLaunch` は `getDb()` 経由で `db.execute` を呼ぶため `invoke("record_launch", …)` が呼ばれない）
+
+- [ ] **Step 3: recordLaunch を invoke ベースへ書き換え**
+
+`src/lib/ghostDatabase.ts` の `recordLaunch` を置換:
+
+```ts
+export async function recordLaunch(ghostIdentityKey: string): Promise<void> {
+  await invoke("record_launch", { ghostIdentityKey });
+}
+```
+
+（`invoke` はファイル冒頭で `import { invoke } from "@tauri-apps/api/core";` 済み。）
+
+- [ ] **Step 4: テストが通ることを確認**
+
+Run: `npx vitest run src/lib/ghostDatabase.test.ts -t "record_launch IPC"`
+Expected: PASS
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/lib/ghostDatabase.ts src/lib/ghostDatabase.test.ts
+git commit -m "feat: recordLaunch を record_launch IPC 呼び出しへ移行 (#93)"
+```
+
+---
+
+## Task 9: buildOrderBy の JOIN 廃止と集計列 ORDER BY（TS）
+
+**Files:**
+- Modify: `src/lib/ghostDatabase.ts`
+- Modify: `src/lib/ghostDatabase.test.ts`
+
+**Interfaces:**
+- Produces: `buildOrderBy(sortOrder: SortOrder): string`（`{ orderBy, join }` から `string` へ縮退）
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`ghostDatabase.test.ts` に追加:
+
+```ts
+import { buildOrderBy } from "./ghostDatabase";
+
+describe("buildOrderBy", () => {
+  it("recent は JOIN なしで last_launched 列を並べる", () => {
+    const orderBy = buildOrderBy("recent");
+    expect(orderBy).toContain("g.last_launched DESC");
+    expect(orderBy).not.toContain("JOIN");
+    expect(orderBy).not.toContain("ghost_launches");
+  });
+
+  it("frequency は JOIN なしで launch_count 列を並べる", () => {
+    const orderBy = buildOrderBy("frequency");
+    expect(orderBy).toContain("g.launch_count DESC");
+    expect(orderBy).not.toContain("JOIN");
+  });
+
+  it("name は name_lower を昇順で並べる", () => {
+    expect(buildOrderBy("name")).toContain("g.name_lower ASC");
+  });
+});
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `npx vitest run src/lib/ghostDatabase.test.ts -t buildOrderBy`
+Expected: FAIL（`buildOrderBy` は未 export、かつ現状 `{ orderBy, join }` を返す）
+
+- [ ] **Step 3: buildOrderBy を string 返却へ・JOIN 廃止、呼び出し側を単純化**
+
+`src/lib/ghostDatabase.ts` の `buildOrderBy` を置換:
+
+```ts
+// SELECT の ORDER BY 式を返す。recent/frequency は ghosts の非正規化集計列
+// （last_launched / launch_count）で並べる。起動履歴は user-data.db（Rust 専有）に
+// 分離され、集計列は record_launch とスキャン時バックフィルで維持される。
+export function buildOrderBy(sortOrder: SortOrder): string {
+  switch (sortOrder) {
+    case "random":
+      return `(g.id * ${randomSortSeed}) % ${RANDOM_SORT_MODULUS}, g.id`;
+    case "recent":
+      return "g.last_launched DESC NULLS LAST, g.name_lower ASC";
+    case "frequency":
+      return "g.launch_count DESC, g.name_lower ASC";
+    default:
+      return "g.name_lower ASC";
+  }
+}
+```
+
+`searchGhostsInitialPage` を更新（`join`/`from` 分岐を除去）:
+
+```ts
+export async function searchGhostsInitialPage(requestKey: string, limit: number, sortOrder: SortOrder = "name"): Promise<GhostView[]> {
+  return measureSearch("searchGhostsInitialPage", async () => {
+    const db = await getDb();
+    const orderBy = buildOrderBy(sortOrder);
+    const rows = await db.select<GhostView[]>(
+      `SELECT ${GHOST_SELECT_COLUMNS_PREFIXED} FROM ghosts g WHERE g.request_key = ? ORDER BY ${orderBy} LIMIT ?`,
+      [requestKey, limit]
+    );
+
+    console.log(`[ghostDatabase] searchGhostsInitialPage(requestKey=${requestKey}, limit=${limit}, sort=${sortOrder}) → rows=${rows.length}`);
+    return rows;
+  });
+}
+```
+
+`searchGhosts` を更新（`join`/`from` 分岐を除去）:
+
+```ts
+export async function searchGhosts(requestKey: string, query: string, limit: number, offset: number, sortOrder: SortOrder = "name"): Promise<{ ghosts: GhostView[], total: number }> {
+  return measureSearch("searchGhosts", async () => {
+    const db = await getDb();
+
+    const normalizedQuery = normalizeForKey(query);
+    const likePattern = `%${normalizedQuery}%`;
+    const orderBy = buildOrderBy(sortOrder);
+    const searchWhere = GHOST_SEARCH_LOWER_COLUMNS.map((col) => `g.${col} LIKE ?`).join(" OR ");
+
+    const [total, rows] = await Promise.all([
+      countGhostsByQuery(requestKey, query),
+      db.select<GhostView[]>(
+        `SELECT ${GHOST_SELECT_COLUMNS_PREFIXED} FROM ghosts g WHERE g.request_key = ? AND (${searchWhere}) ORDER BY ${orderBy} LIMIT ? OFFSET ?`,
+        [requestKey, ...GHOST_SEARCH_LOWER_COLUMNS.map(() => likePattern), limit, offset]
+      ),
+    ]);
+
+    console.log(`[ghostDatabase] searchGhosts(requestKey=${requestKey}, query="${query}", limit=${limit}, offset=${offset}, sort=${sortOrder}) → total=${total}`);
+    console.log(`[ghostDatabase] Fetched ${rows.length} rows`);
+    return { ghosts: rows, total };
+  });
+}
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+Run: `npx vitest run src/lib/ghostDatabase.test.ts -t buildOrderBy`
+Expected: PASS
+
+- [ ] **Step 5: フロント全体の型・テスト確認**
+
+Run: `npm run build && npm test`
+Expected: build 成功、全テスト PASS
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/lib/ghostDatabase.ts src/lib/ghostDatabase.test.ts
+git commit -m "refactor: recent/frequency の cross-DB JOIN を集計列 ORDER BY へ置換 (#93)"
+```
+
+---
+
+## Task 10: ドキュメント整合（コメント・CLAUDE.md・SPEC.md）
+
+**Files:**
+- Modify: `src-tauri/src/lib.rs`（`sanitize_ghost_db` の doc コメント）
+- Modify: `src-tauri/CLAUDE.md`
+- Modify: `SPEC.md`
+
+**注記（テスト方針）:** ドキュメント・コメントのみの変更のため新規テストは追加しない（コミットメッセージに理由を明記）。
+
+- [ ] **Step 1: sanitize_ghost_db の doc コメントを訂正**
+
+`src-tauri/src/lib.rs` の `sanitize_ghost_db` 直上コメント末尾「DB ファイルを削除して再作成を促す。ghosts.db はキャッシュなので安全。」を次へ:
+
+```rust
+/// DB ファイルを削除して再作成を促す。ghosts.db は揮発キャッシュ（再スキャンで復旧）であり、
+/// 永続的な起動履歴は user-data.db へ分離済みのため、削除しても失われない。
+```
+
+- [ ] **Step 2: src-tauri/CLAUDE.md の「安全」記述を訂正**
+
+`src-tauri/CLAUDE.md` の「マイグレーションエラー自動回復」節、「ghosts.db の再作成でゴーストキャッシュは再スキャンで復旧するが、同居する永続テーブル `ghost_launches`（起動履歴）は失われる（改善検討は issue #93）。」を次へ置換:
+
+```
+ghosts.db は純粋キャッシュ（再スキャンで復旧）であり、永続的な起動履歴は `user-data.db`（Rust 専有・rusqlite、`commands/launch_history.rs`）へ分離済みのため、リセットで失われない。マイグレーションシステム外で `ALTER TABLE ADD COLUMN` を行ってはならない（マイグレーションと競合して起動不能になる）。
+```
+
+同ファイルの「永続テーブルのマイグレーション」節、`ghost_launches` を例に挙げた記述に「起動履歴は現在 `user-data.db` へ分離済み。将来の `favorites` 等の永続テーブルも user-data.db 側へ置き、揮発キャッシュ ghosts.db との運命共有を避ける」旨を追記する。
+
+- [ ] **Step 3: SPEC.md を新構成へ同期**
+
+`grep -n "ghost_launches\|キャッシュ DB\|再スキャンで復旧\|user-data\|LEFT JOIN" SPEC.md` で該当箇所を特定し、以下を更新:
+- §4.5（永続テーブルのキー設計）: `ghost_launches` が `user-data.db`（Rust 専有）に住み、`ghosts` 側は非正規化集計列 `last_launched` / `launch_count` を持つ導出キャッシュであることを追記。
+- §13（マイグレーション自動回復）: リセット対象は ghosts.db のみで、永続データ（user-data.db）は対象外である旨へ訂正。
+- recent/frequency ソートを説明する節（§8.6 相当）: cross-DB JOIN 廃止と集計列 ORDER BY・維持機構（record_launch 即時更新／スキャン時バックフィル）を反映。
+- DB 層を図示する節（§6.x / §9.2 mermaid 等）に user-data.db を追加し、ghosts.db=揮発・user-data.db=永続の二層を明示。
+
+- [ ] **Step 4: ドキュメント検証**
+
+Run: `grep -rn "同居する永続テーブル\|失われる（改善検討は issue #93）" src-tauri/CLAUDE.md`
+Expected: 0 件（旧記述が残っていないこと）
+
+Run: `npm run check:ui-guidelines`
+Expected: PASS（コミット前チェックリストの一部として通す）
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src-tauri/src/lib.rs src-tauri/CLAUDE.md SPEC.md
+git commit -m "docs: 起動履歴の user-data.db 分離に伴い安全性記述を訂正 (#93)"
+```
+
+---
+
+## 完了後の統合検証（PR 前）
+
+- [ ] `cargo test --manifest-path src-tauri/Cargo.toml`（全 suite 緑）
+- [ ] `npm test`（全 suite 緑）
+- [ ] `npm run build`（型エラーなし）
+- [ ] `npm run check:ui-guidelines` / `npm run test:ui-guidelines-check`
+- [ ] `git status` が clean
+- [ ] **E2E 手動実行**（`GHOST_LAUNCHER_E2E_APP` / `EDGEDRIVER_VERSION` 指定、メモリ参照）: ゴースト起動 → recent ソートで先頭化を確認。既知 flake（#90 スクロール stale）は main ベースライン比較で退行でないことを確認。
+- [ ] **手動アップグレード確認**: 旧バージョンで起動履歴を作った ghosts.db を用意 → 新バイナリ起動後、履歴が user-data.db へ移送され recent/frequency が保持されること。DB リセット（migration 競合を模擬）後も履歴が残ること。

--- a/docs/superpowers/specs/2026-07-04-persist-launch-history-separate-db-design.md
+++ b/docs/superpowers/specs/2026-07-04-persist-launch-history-separate-db-design.md
@@ -1,0 +1,96 @@
+# 永続テーブル分離設計（user-data.db）— issue #93
+
+## 背景と壊れている不変条件
+
+`ghosts.db` は「揮発キャッシュだから再スキャンで復旧できる」という前提で、マイグレーション競合時に**ファイルごと削除**して回復する設計になっている（`sanitize_ghost_db` / `reset_ghost_db`）。しかし migration 11 で**永続テーブル `ghost_launches`（起動履歴）が同じ DB ファイルに同居**して以降、この前提は崩れている。
+
+- 削除経路は 2 つあり、どちらも `GHOST_DB_FILES`（ghosts.db + WAL/SHM）を丸ごと消す:
+  - 起動時 `sanitize_ghost_db`（Rust, `lib.rs`）— `has_migration_conflict` 検出時、プラグイン起動前に直接 `remove_file`
+  - 実行時 `initializeDb` の catch（JS, `ghostDatabase.ts`）— migration エラー → `reset_ghost_db` invoke → 再 load
+- リセットのたびに起動履歴が不可逆に失われる。履歴は recent / frequency ソート（F-11）の基盤データである。
+
+**回復すべき不変条件**: 「キャッシュのリセットは永続的なユーザーデータを一切失わせない」。
+
+## 設計方針
+
+永続データと揮発データの**運命共有（fate-sharing）を器のレベルで解消**する。`ghost_launches` を新しい DB ファイル `user-data.db` へ移し、`ghosts.db` を純粋キャッシュへ戻す。これにより「ghosts.db は丸ごと消して安全」という回復戦略が再び真になる。
+
+### なぜ ATTACH による cross-DB JOIN を採らないか
+
+現状の recent / frequency ソートは `ghosts` と `ghost_launches` を SQL の JOIN で結合し、仮想スクロールのため DB 側で `ORDER BY … LIMIT/OFFSET` ページングしている。テーブルを別ファイルに移すと JOIN には `ATTACH DATABASE` が要るが、`tauri-plugin-sql`（sqlx）は `Pool::connect` による**複数接続プール**を使い、`select`/`execute` は毎回 `pool.fetch_all`/`pool.execute` でプールから接続を都度取得する（`wrapper.rs` 実装で確認済み）。したがって `ATTACH` を実行した接続と後続 JOIN クエリの接続が一致せず、**ATTACH が揮発して JOIN が壊れる**。ATTACH 依存は棄却する。
+
+## アーキテクチャ
+
+### 器と所有権
+
+- **`user-data.db`（新設・Rust 専有）** — `ghost_launches` の唯一の住処。**JS からは一切アクセスしない**。Rust の rusqlite 単一接続だけが読み書きする。ghosts.db 用の sqlx プールと無関係なので ATTACH 揮発問題を根本回避する。
+  - スキーマは Rust の `CREATE TABLE IF NOT EXISTS`（＋インデックス）で冪等に用意する。sqlx マイグレーション系に載せない。永続ストアなので「マイグレーション競合 → 自動削除」の事故クラスがそもそも発生し得ない構造にする。
+- **`ghosts.db`** — 純粋キャッシュに戻る。sanitize / reset は今のまま丸ごと削除してよい。**永続データがここに居ないから安全**、が回復した不変条件。
+
+パス解決は既存の単一権威 `db_path.rs` に `user-data.db` 用ヘルパーを追加して集約する。
+
+### JOIN の代替：非正規化した集計列
+
+recent / frequency の cross-DB JOIN を廃止し、`ghosts` キャッシュへ導出列を 2 本持たせる:
+
+```sql
+ALTER TABLE ghosts ADD COLUMN last_launched TEXT;               -- NULL 既定
+ALTER TABLE ghosts ADD COLUMN launch_count  INTEGER NOT NULL DEFAULT 0;
+```
+
+`buildOrderBy` の JOIN は消え、`ORDER BY g.last_launched DESC NULLS LAST, g.name_lower`（recent）/ `ORDER BY g.launch_count DESC, g.name_lower`（frequency）という**単一 DB のプレーンな ORDER BY** になる。
+
+**この選択の理由:**
+
+- 読み取り経路が全ソートモードで一様に保たれ、仮想スクロールのページング（`LIMIT/OFFSET`）が無傷。代替案（recent/frequency だけ Rust rusqlite+ATTACH でライブ JOIN してページを返す）は、18 列の `GHOST_SELECT_COLUMNS` 単一権威を Rust 側へ二重実装させ、fixture で守ってきたドリフト防御を壊す。
+- 集計列は**再導出可能な導出キャッシュ**。ghosts が消えても user-data.db から作り直せるので、キャッシュの性格と矛盾しない。
+
+**意味的等価性**: 集計は `ghost_identity_key` 単位。同一 identity が複数 request_key に跨って現れても、`UPDATE ghosts … WHERE ghost_identity_key=?` が全該当行を揃って更新するため、現行 JOIN（`ON g.ghost_identity_key = gl.ghost_identity_key`、request_key 非依存）と等価。
+
+### 集計列の維持
+
+- **`record_launch(ghost_identity_key)` を Rust コマンド化** — ① user-data.db へ `INSERT`、② ghosts.db の該当行を `launch_count = launch_count + 1, last_launched = <now>` に `UPDATE`。JS の `recordLaunch` は `invoke("record_launch", …)` の薄いラッパーへ縮退する。
+- **スキャン時バックフィル** — `scan_and_store`（既に rusqlite）でキャッシュ再構築後、user-data.db の集計（`MAX(launched_at)`, `COUNT(*)` を `ghost_identity_key` で GROUP BY）を読み、ghosts の集計列へ書き戻す。単一の制御された接続なのでここでは ATTACH も安全（あるいは 2 本の rusqlite 接続で読み→書き）。バックフィルは periodic な reconciliation として働き、recordLaunch の +1 近似を権威値へ収束させる。
+
+### 一度きりのデータ移送
+
+旧 `ghosts.db.ghost_launches` の履歴を、初回起動時に user-data.db へ複写する冪等ステップ（Rust）。
+
+- 実行タイミング: 起動時 setup（JS の `Database.load` がマイグレーションを走らせる前）。Rust setup は JS load より先に走ることを確認済み。
+- 手順: user-data.db スキーマを用意 → ghosts.db に `ghost_launches` テーブルが存在すれば行を user-data.db へ複写。
+- 冪等性: 複写後、旧テーブルは migration で DROP される（下記）。DROP 後は複写元が存在しないため再実行されない。
+- 旧テーブルの除去は**新規マイグレーション**（migration 11 は不変のまま、後続の追加マイグレーションで `DROP TABLE ghost_launches`）で行い、ghosts.db のスキーマ管理をマイグレーション系に保つ。DROP は移送より後に走る（Rust setup → JS load 順の保証）。
+
+### スキーマ変更の一覧（ghosts.db, マイグレーション追加）
+
+- 追加 A: `ALTER TABLE ghosts ADD COLUMN last_launched TEXT; ALTER TABLE ghosts ADD COLUMN launch_count INTEGER NOT NULL DEFAULT 0;`
+- 追加 B: `DROP TABLE IF EXISTS ghost_launches;`（データ移送後に実行される）
+
+（正確な version 番号と SQL 文字列は実装計画で確定する。`\n` 明示・リテラル DEFAULT の作法を厳守。）
+
+## エラーハンドリング
+
+- user-data.db を開けない / 作れない場合: 起動を阻害しない。履歴機能は degrade する（集計列は NULL/0 のままなので、recent/frequency は実質すべて未起動として name 順に並ぶ。専用フォールバック分岐は不要）。ログに warn を残す。
+- データ移送の失敗: warn ログのみ。次回起動で再試行（旧テーブル未 DROP なら再試行される）。
+- record_launch の失敗: 現状と同じく fire-and-forget（起動体験を阻害しない）。
+
+## テスト（TDD）
+
+- **Rust**
+  - リセット（reset_ghost_db / sanitize 相当）後も user-data.db の履歴が残存する（回復した不変条件の直接検証）。
+  - `record_launch` が user-data.db への INSERT と ghosts.db 集計列 UPDATE の二面更新を行う。
+  - バックフィルが user-data.db の集計から ghosts の集計列を再導出する。
+  - 一度きり移送の冪等性（複写済み／複写元なしで no-op）。
+- **TypeScript**
+  - `recordLaunch` が `record_launch` を invoke する（sspClient のモック契約）。
+  - `buildOrderBy` が recent/frequency で JOIN を持たず、集計列で ORDER BY する。
+
+## ドキュメント整合
+
+- `src/lib/ghostDatabase.ts` の「キャッシュ DB なので再スキャンで復旧可能」コメント、`src-tauri/CLAUDE.md` の同旨記述を、分離後の正しい記述へ更新。
+- `SPEC.md` §4.5（永続テーブルのキー設計）・§13（マイグレーション自動回復）・§6.x（DB 層）を新構成へ同期。
+
+## スコープ外（YAGNI）
+
+- `favorites` 等の将来の永続テーブルは本 issue では作らない。ただし user-data.db という器が用意されることで、追加時に運命共有の再発を防げる素地となる。
+- user-data.db のスキーマバージョニング機構は導入しない（現状 1 テーブル）。将来の破壊的変更が必要になった時点で最小の仕組みを足す。

--- a/src-tauri/CLAUDE.md
+++ b/src-tauri/CLAUDE.md
@@ -14,7 +14,7 @@
 
 **マイグレーション SQL の不変性（絶対厳守）**: sqlx は適用済みマイグレーションの SQL 文字列の SHA-384 チェックサムを `_sqlx_migrations` テーブルに記録し、起動時に再検証する。空白・インデントを含む**あらゆる変更**がチェックサム不一致を引き起こし「migration N was previously applied but has been modified」でクラッシュする。このため: (1) 一度でもリリース・コミットした migration の SQL は**絶対に編集しない**。(2) 複数行 SQL は Rust のインデントが文字列に混入しないよう `"ALTER TABLE ...\nCREATE INDEX ..."` のように **`\n` を明示**して書く（raw 改行 + インデントを使うとリファクタリング時にインデントが変わり即クラッシュする）。
 
-**マイグレーションエラー自動回復**: `getDb()` は `Database.load()` 時のマイグレーションエラー（`duplicate column` 等）をキャッチし、`reset_ghost_db` Rust コマンドで DB ファイルを削除して再接続する。ghosts.db の再作成でゴーストキャッシュは再スキャンで復旧するが、同居する永続テーブル `ghost_launches`（起動履歴）は失われる（改善検討は issue #93）。マイグレーションシステム外で `ALTER TABLE ADD COLUMN` を行ってはならない（マイグレーションと競合して起動不能になる）。
+**マイグレーションエラー自動回復**: `getDb()` は `Database.load()` 時のマイグレーションエラー（`duplicate column` 等）をキャッチし、`reset_ghost_db` Rust コマンドで DB ファイルを削除して再接続する。ghosts.db は純粋キャッシュ（再スキャンで復旧）であり、永続的な起動履歴は `user-data.db`（Rust 専有・rusqlite、`commands/launch_history.rs`）へ分離済みのため、リセットで失われない。マイグレーションシステム外で `ALTER TABLE ADD COLUMN` を行ってはならない（マイグレーションと競合して起動不能になる）。
 
 **DB 初期化 PRAGMA**: `loadDb()` は接続後に `journal_mode=WAL` → `busy_timeout` → `journal_size_limit` → `optimize=0x10002` の順で PRAGMA を設定し、条件付き VACUUM を実行する。VACUUM はメンテナンス処理のため try-catch で囲み、失敗しても接続を阻害しない。詳細は `SPEC.md` §8.1.1 を参照。
 
@@ -22,7 +22,7 @@
 
 **store_ghosts の差分 UPSERT**: `store_ghosts` は DELETE-all + INSERT-all ではなく、既存行の `(ghost_identity_key, row_fingerprint)` をカバリングインデックスから読み、スキャン結果と比較して INSERT/UPDATE/DELETE を最小限に実行する。`ghost_identity_key` は NFKC(source) + `\x1f` + NFKC(directory_name) で構成される論理主キー、`row_fingerprint` は 9 メタデータフィールドの SHA-256。変更なしの行は完全にスキップされる。
 
-**永続テーブルのマイグレーション**: `ghost_launches` や将来の `favorites` 等の永続テーブル（ユーザー蓄積データ）は、揮発キャッシュの `ghosts` と異なり**マイグレーションで `DELETE FROM` してはならない**。破壊的スキーマ変更はデータ移行 SQL を必須とし、段階移行（新列追加 → バックフィル → 参照切替）で行う。ゴーストへの外部参照は `ghosts.id`（再投入で値が変わる）ではなく `ghost_identity_key` を使う。データモデルの根拠とキー構成は `SPEC.md` §4.5 を参照。
+**永続テーブルのマイグレーション**: `ghost_launches` や将来の `favorites` 等の永続テーブル（ユーザー蓄積データ）は、揮発キャッシュの `ghosts` と異なり**マイグレーションで `DELETE FROM` してはならない**。破壊的スキーマ変更はデータ移行 SQL を必須とし、段階移行（新列追加 → バックフィル → 参照切替）で行う。ゴーストへの外部参照は `ghosts.id`（再投入で値が変わる）ではなく `ghost_identity_key` を使う。起動履歴は現在 `user-data.db` へ分離済み。将来の `favorites` 等の永続テーブルも user-data.db 側へ置き、揮発キャッシュ ghosts.db との運命共有を避ける。データモデルの根拠とキー構成は `SPEC.md` §4.5 を参照。
 
 ## IPC 型の管理
 

--- a/src-tauri/src/commands/ghost/mod.rs
+++ b/src-tauri/src/commands/ghost/mod.rs
@@ -16,6 +16,14 @@ fn ensure_request_key(request_key: &str) -> Result<(), String> {
     Ok(())
 }
 
+/// 起動履歴の集計列を user-data.db から ghosts へ再導出する（ベストエフォート）。
+/// user-data.db を開けない場合は何もしない（スキャン結果を阻害しない）。
+fn backfill_launch_aggregates(app: &tauri::AppHandle, ghosts_conn: &rusqlite::Connection) {
+    if let Ok(user_conn) = crate::commands::launch_history::open_user_data_db(app) {
+        let _ = crate::commands::launch_history::backfill_aggregates(ghosts_conn, &user_conn);
+    }
+}
+
 /// ゴーストをスキャンし、結果を rusqlite で直接 SQLite に書き込むコマンド。
 /// IPC で Ghost 配列を転送しないため、10 万体規模でも高速。
 ///
@@ -45,6 +53,7 @@ pub fn scan_and_store(
         if let Ok(conn) = rusqlite::Connection::open(&db_path) {
             let _ = store::configure_connection(&conn);
             if fingerprint::check_parent_mtimes_match(&conn, &request_key, &current_mtimes) {
+                backfill_launch_aggregates(&app, &conn);
                 return Ok(ScanStoreResult {
                     cache_hit: true,
                     total: 0,
@@ -69,6 +78,7 @@ pub fn scan_and_store(
                 "UPDATE ghost_fingerprints SET parent_mtimes = ?1 WHERE request_key = ?2",
                 rusqlite::params![current_mtimes, request_key],
             );
+            backfill_launch_aggregates(&app, &conn);
         }
         return Ok(ScanStoreResult {
             cache_hit: true,
@@ -85,11 +95,7 @@ pub fn scan_and_store(
 
     let total = store::store_ghosts(&conn, &request_key, &ghosts, &fingerprint, &current_mtimes)?;
 
-    // 起動履歴の集計列（last_launched / launch_count）を user-data.db から再導出する。
-    // ベストエフォート: user-data.db を開けない場合も本来のスキャン結果は返す。
-    if let Ok(user_conn) = crate::commands::launch_history::open_user_data_db(&app) {
-        let _ = crate::commands::launch_history::backfill_aggregates(&conn, &user_conn);
-    }
+    backfill_launch_aggregates(&app, &conn);
 
     Ok(ScanStoreResult {
         cache_hit: false,

--- a/src-tauri/src/commands/ghost/mod.rs
+++ b/src-tauri/src/commands/ghost/mod.rs
@@ -85,6 +85,12 @@ pub fn scan_and_store(
 
     let total = store::store_ghosts(&conn, &request_key, &ghosts, &fingerprint, &current_mtimes)?;
 
+    // 起動履歴の集計列（last_launched / launch_count）を user-data.db から再導出する。
+    // ベストエフォート: user-data.db を開けない場合も本来のスキャン結果は返す。
+    if let Ok(user_conn) = crate::commands::launch_history::open_user_data_db(&app) {
+        let _ = crate::commands::launch_history::backfill_aggregates(&conn, &user_conn);
+    }
+
     Ok(ScanStoreResult {
         cache_hit: false,
         total,

--- a/src-tauri/src/commands/launch_history.rs
+++ b/src-tauri/src/commands/launch_history.rs
@@ -252,4 +252,111 @@ mod tests {
         assert!(cols.contains(&"ghost_identity_key".to_string()));
         assert!(cols.contains(&"launched_at".to_string()));
     }
+
+    fn insert_ghost_row(conn: &Connection, identity_key: &str) {
+        conn.execute(
+            "INSERT INTO ghosts (request_key, ghost_identity_key, row_fingerprint, name, sakura_name, kero_name, craftman, craftmanw, directory_name, path, source, name_lower, sakura_name_lower, kero_name_lower, craftman_lower, craftmanw_lower, directory_name_lower, thumbnail_path, thumbnail_use_self_alpha, thumbnail_kind, updated_at) VALUES ('rk1', ?1, '', 'G', '', '', '', '', 'g', '/g', 'ssp', 'g', '', '', '', '', 'g', '', 0, '', '')",
+            rusqlite::params![identity_key],
+        )
+        .unwrap();
+    }
+
+    // アップグレード（旧 ghosts.db に同居した履歴）とリセット（ghosts.db 削除）を
+    // 実ファイル DB で通し、issue #93 の不変条件「キャッシュのリセットは永続履歴を失わせない」を
+    // end-to-end で検証する。setup 移送 → migration 12/13 → スキャン backfill → リセット → 再スキャンの順。
+    #[test]
+    fn アップグレードとリセットを通じて起動履歴が保持され集計へ再導出される() {
+        let dir = crate::testutil::TempDirGuard::new("ghost_launcher_upgrade_reset_test");
+        let ghosts_path = dir.path().join("ghosts.db");
+        let user_path = dir.path().join("user-data.db");
+
+        // 旧バージョン再現: migration 1..=11 のみ適用し、ghost 行 + 起動履歴 2 件を投入
+        {
+            let conn = Connection::open(&ghosts_path).unwrap();
+            let mut migs = crate::migrations();
+            migs.sort_by_key(|m| m.version);
+            for m in migs.iter().filter(|m| m.version <= 11) {
+                conn.execute_batch(m.sql).unwrap();
+            }
+            insert_ghost_row(&conn, "sspg");
+            for at in ["2026-01-01 00:00:00", "2026-01-02 00:00:00"] {
+                conn.execute(
+                    "INSERT INTO ghost_launches (ghost_identity_key, launched_at) VALUES ('sspg', ?1)",
+                    rusqlite::params![at],
+                )
+                .unwrap();
+            }
+        }
+
+        // アップグレード setup 相当: user-data 初期化 + legacy 移送（JS の migration DROP より前に走る）
+        {
+            let user_conn = Connection::open(&user_path).unwrap();
+            ensure_schema(&user_conn).unwrap();
+            let ghosts_conn = Connection::open(&ghosts_path).unwrap();
+            migrate_legacy_launch_history(&ghosts_conn, &user_conn).unwrap();
+            let n: i64 = user_conn
+                .query_row("SELECT COUNT(*) FROM ghost_launches", [], |r| r.get(0))
+                .unwrap();
+            assert_eq!(n, 2, "旧履歴が user-data.db へ移送される");
+        }
+
+        // JS の Database.load 相当: migration 12/13（集計列追加 + 旧テーブル DROP）
+        {
+            let conn = Connection::open(&ghosts_path).unwrap();
+            let mut migs = crate::migrations();
+            migs.sort_by_key(|m| m.version);
+            for m in migs.iter().filter(|m| m.version >= 12) {
+                conn.execute_batch(m.sql).unwrap();
+            }
+            let has: i64 = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='ghost_launches'",
+                    [],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert_eq!(has, 0, "旧 ghost_launches は ghosts.db から除去される");
+        }
+
+        // スキャン相当: backfill で集計列へ再導出（アップグレード後の recent/frequency 復元）
+        {
+            let ghosts_conn = Connection::open(&ghosts_path).unwrap();
+            let user_conn = Connection::open(&user_path).unwrap();
+            backfill_aggregates(&ghosts_conn, &user_conn).unwrap();
+            let (c, last): (i64, Option<String>) = ghosts_conn
+                .query_row(
+                    "SELECT launch_count, last_launched FROM ghosts WHERE ghost_identity_key='sspg'",
+                    [],
+                    |r| Ok((r.get(0)?, r.get(1)?)),
+                )
+                .unwrap();
+            assert_eq!(c, 2, "アップグレード後、集計列が移送済み履歴から復元される");
+            assert_eq!(last.as_deref(), Some("2026-01-02 00:00:00"));
+        }
+
+        // リセット相当: ghosts.db を削除、user-data.db は残す
+        std::fs::remove_file(&ghosts_path).unwrap();
+        assert!(user_path.exists(), "user-data.db はリセット対象外で残存する");
+
+        // リセット後の再スキャン: ghosts.db を全 migration で再作成 + 行再投入 + backfill
+        {
+            let conn = Connection::open(&ghosts_path).unwrap();
+            let mut migs = crate::migrations();
+            migs.sort_by_key(|m| m.version);
+            for m in migs {
+                conn.execute_batch(m.sql).unwrap();
+            }
+            insert_ghost_row(&conn, "sspg");
+            let user_conn = Connection::open(&user_path).unwrap();
+            backfill_aggregates(&conn, &user_conn).unwrap();
+            let c: i64 = conn
+                .query_row(
+                    "SELECT launch_count FROM ghosts WHERE ghost_identity_key='sspg'",
+                    [],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert_eq!(c, 2, "リセット後も user-data.db の履歴から集計が復元される（#93 の核心）");
+        }
+    }
 }

--- a/src-tauri/src/commands/launch_history.rs
+++ b/src-tauri/src/commands/launch_history.rs
@@ -43,6 +43,33 @@ pub(crate) fn record_launch_inner(
     Ok(())
 }
 
+/// user-data.db の起動履歴集計（identity 毎の MAX(launched_at) と COUNT）を
+/// ghosts.db の集計列へ書き戻す。キャッシュ再構築（cache miss）の後に呼ぶ。
+/// COUNT は単調増加のため、起動済みキーだけを上書きすれば未起動行は 0/NULL のまま残る。
+pub(crate) fn backfill_aggregates(
+    ghosts_conn: &Connection,
+    user_conn: &Connection,
+) -> Result<(), String> {
+    let aggregates: Vec<(String, String, i64)> = {
+        let mut stmt = user_conn
+            .prepare("SELECT ghost_identity_key, MAX(launched_at), COUNT(*) FROM ghost_launches GROUP BY ghost_identity_key")
+            .map_err(|e| format!("集計 SELECT 準備エラー: {e}"))?;
+        stmt.query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))
+            .map_err(|e| format!("集計 SELECT エラー: {e}"))?
+            .filter_map(Result::ok)
+            .collect()
+    };
+    for (key, last, count) in aggregates {
+        ghosts_conn
+            .execute(
+                "UPDATE ghosts SET last_launched = ?2, launch_count = ?3 WHERE ghost_identity_key = ?1",
+                rusqlite::params![key, last, count],
+            )
+            .map_err(|e| format!("集計列バックフィル UPDATE エラー: {e}"))?;
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -81,6 +108,40 @@ mod tests {
             .unwrap();
         assert_eq!(count, 2);
         assert!(last.is_some(), "last_launched が設定されること");
+    }
+
+    #[test]
+    fn backfill_aggregatesはuserdataの集計をghostsへ再導出する() {
+        let user_conn = Connection::open_in_memory().unwrap();
+        ensure_schema(&user_conn).unwrap();
+        let ghosts_conn = ghosts_conn_with_row("sspg");
+        // 未起動の別ゴースト B も用意（0/NULL のままであること）
+        ghosts_conn
+            .execute(
+                "INSERT INTO ghosts (request_key, ghost_identity_key, row_fingerprint, name, sakura_name, kero_name, craftman, craftmanw, directory_name, path, source, name_lower, sakura_name_lower, kero_name_lower, craftman_lower, craftmanw_lower, directory_name_lower, thumbnail_path, thumbnail_use_self_alpha, thumbnail_kind, updated_at) VALUES ('rk1', 'sspb', '', 'B', '', '', '', '', 'b', '/b', 'ssp', 'b', '', '', '', '', 'b', '', 0, '', '')",
+                [],
+            )
+            .unwrap();
+        // user-data に A の起動 3 回（時刻昇順）
+        for at in ["2026-01-01 00:00:00", "2026-01-02 00:00:00", "2026-01-03 00:00:00"] {
+            user_conn
+                .execute("INSERT INTO ghost_launches (ghost_identity_key, launched_at) VALUES ('sspg', ?1)", rusqlite::params![at])
+                .unwrap();
+        }
+
+        backfill_aggregates(&ghosts_conn, &user_conn).unwrap();
+
+        let (count, last): (i64, Option<String>) = ghosts_conn
+            .query_row("SELECT launch_count, last_launched FROM ghosts WHERE ghost_identity_key = 'sspg'", [], |r| Ok((r.get(0)?, r.get(1)?)))
+            .unwrap();
+        assert_eq!(count, 3);
+        assert_eq!(last.as_deref(), Some("2026-01-03 00:00:00"));
+
+        let (bcount, blast): (i64, Option<String>) = ghosts_conn
+            .query_row("SELECT launch_count, last_launched FROM ghosts WHERE ghost_identity_key = 'sspb'", [], |r| Ok((r.get(0)?, r.get(1)?)))
+            .unwrap();
+        assert_eq!(bcount, 0);
+        assert_eq!(blast, None);
     }
 
     #[test]

--- a/src-tauri/src/commands/launch_history.rs
+++ b/src-tauri/src/commands/launch_history.rs
@@ -70,6 +70,49 @@ pub(crate) fn backfill_aggregates(
     Ok(())
 }
 
+/// 旧 ghosts.db.ghost_launches の履歴を user-data.db へ一度だけ複写する。
+/// 冪等ガード = user-data.db が空のときだけ複写する（二重複写を防ぐ）。
+/// このため migration 13 による旧テーブル DROP の順序に依存せず安全。
+pub(crate) fn migrate_legacy_launch_history(
+    ghosts_conn: &Connection,
+    user_conn: &Connection,
+) -> Result<(), String> {
+    let already: i64 = user_conn
+        .query_row("SELECT COUNT(*) FROM ghost_launches", [], |r| r.get(0))
+        .unwrap_or(0);
+    if already > 0 {
+        return Ok(());
+    }
+    let has_legacy: i64 = ghosts_conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'ghost_launches'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap_or(0);
+    if has_legacy == 0 {
+        return Ok(());
+    }
+    let legacy: Vec<(String, String)> = {
+        let mut stmt = ghosts_conn
+            .prepare("SELECT ghost_identity_key, launched_at FROM ghost_launches")
+            .map_err(|e| format!("legacy SELECT 準備エラー: {e}"))?;
+        stmt.query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+            .map_err(|e| format!("legacy SELECT エラー: {e}"))?
+            .filter_map(Result::ok)
+            .collect()
+    };
+    for (key, at) in legacy {
+        user_conn
+            .execute(
+                "INSERT INTO ghost_launches (ghost_identity_key, launched_at) VALUES (?1, ?2)",
+                rusqlite::params![key, at],
+            )
+            .map_err(|e| format!("legacy 移送 INSERT エラー: {e}"))?;
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -142,6 +185,43 @@ mod tests {
             .unwrap();
         assert_eq!(bcount, 0);
         assert_eq!(blast, None);
+    }
+
+    fn ghosts_conn_with_legacy_launches(rows: &[(&str, &str)]) -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        // migration 11 相当の legacy テーブルのみ用意（本テストは移送だけを対象）
+        conn.execute_batch(
+            "CREATE TABLE ghost_launches (id INTEGER PRIMARY KEY AUTOINCREMENT, ghost_identity_key TEXT NOT NULL, launched_at TEXT NOT NULL);",
+        )
+        .unwrap();
+        for (key, at) in rows {
+            conn.execute("INSERT INTO ghost_launches (ghost_identity_key, launched_at) VALUES (?1, ?2)", rusqlite::params![key, at]).unwrap();
+        }
+        conn
+    }
+
+    #[test]
+    fn migrate_legacyは旧履歴を複写し二度目は複写しない() {
+        let user_conn = Connection::open_in_memory().unwrap();
+        ensure_schema(&user_conn).unwrap();
+        let ghosts_conn = ghosts_conn_with_legacy_launches(&[("sspg", "2026-01-01 00:00:00"), ("sspg", "2026-01-02 00:00:00")]);
+
+        migrate_legacy_launch_history(&ghosts_conn, &user_conn).unwrap();
+        // 冪等: 二度目は user-data が非空なので何もしない
+        migrate_legacy_launch_history(&ghosts_conn, &user_conn).unwrap();
+
+        let total: i64 = user_conn.query_row("SELECT COUNT(*) FROM ghost_launches", [], |r| r.get(0)).unwrap();
+        assert_eq!(total, 2, "重複複写されないこと");
+    }
+
+    #[test]
+    fn migrate_legacyはlegacyテーブル不在でno_op() {
+        let user_conn = Connection::open_in_memory().unwrap();
+        ensure_schema(&user_conn).unwrap();
+        let ghosts_conn = Connection::open_in_memory().unwrap(); // ghost_launches なし
+        migrate_legacy_launch_history(&ghosts_conn, &user_conn).unwrap();
+        let total: i64 = user_conn.query_row("SELECT COUNT(*) FROM ghost_launches", [], |r| r.get(0)).unwrap();
+        assert_eq!(total, 0);
     }
 
     #[test]

--- a/src-tauri/src/commands/launch_history.rs
+++ b/src-tauri/src/commands/launch_history.rs
@@ -113,6 +113,17 @@ pub(crate) fn migrate_legacy_launch_history(
     Ok(())
 }
 
+/// 起動履歴を記録する Tauri コマンド。user-data.db へ INSERT し ghosts.db の集計列を bump する。
+#[tauri::command]
+pub fn record_launch(app: tauri::AppHandle, ghost_identity_key: String) -> Result<(), String> {
+    let user_conn = open_user_data_db(&app)?;
+    let ghosts_path = crate::db_path::ghost_db_path(&app)?;
+    let ghosts_conn =
+        Connection::open(&ghosts_path).map_err(|e| format!("ghosts.db オープンエラー: {e}"))?;
+    crate::commands::ghost::store::configure_connection(&ghosts_conn)?;
+    record_launch_inner(&user_conn, &ghosts_conn, &ghost_identity_key)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/commands/launch_history.rs
+++ b/src-tauri/src/commands/launch_history.rs
@@ -21,9 +21,67 @@ pub(crate) fn open_user_data_db<R: tauri::Runtime>(
     Ok(conn)
 }
 
+/// 起動履歴を記録する。user-data.db へ INSERT（権威）し、ghosts.db の集計列を bump（導出）する。
+/// user-data 側を先に書くため、ghosts 側更新が失敗しても権威データは残り、次回バックフィルで整合する。
+pub(crate) fn record_launch_inner(
+    user_conn: &Connection,
+    ghosts_conn: &Connection,
+    ghost_identity_key: &str,
+) -> Result<(), String> {
+    user_conn
+        .execute(
+            "INSERT INTO ghost_launches (ghost_identity_key, launched_at) VALUES (?1, datetime('now'))",
+            rusqlite::params![ghost_identity_key],
+        )
+        .map_err(|e| format!("起動履歴 INSERT エラー: {e}"))?;
+    ghosts_conn
+        .execute(
+            "UPDATE ghosts SET launch_count = launch_count + 1, last_launched = datetime('now') WHERE ghost_identity_key = ?1",
+            rusqlite::params![ghost_identity_key],
+        )
+        .map_err(|e| format!("集計列 UPDATE エラー: {e}"))?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn ghosts_conn_with_row(identity_key: &str) -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        let mut migs = crate::migrations();
+        migs.sort_by_key(|m| m.version);
+        for m in migs {
+            conn.execute_batch(m.sql).unwrap();
+        }
+        conn.execute(
+            "INSERT INTO ghosts (request_key, ghost_identity_key, row_fingerprint, name, sakura_name, kero_name, craftman, craftmanw, directory_name, path, source, name_lower, sakura_name_lower, kero_name_lower, craftman_lower, craftmanw_lower, directory_name_lower, thumbnail_path, thumbnail_use_self_alpha, thumbnail_kind, updated_at) VALUES ('rk1', ?1, '', 'G', '', '', '', '', 'g', '/g', 'ssp', 'g', '', '', '', '', 'g', '', 0, '', '')",
+            rusqlite::params![identity_key],
+        )
+        .unwrap();
+        conn
+    }
+
+    #[test]
+    fn record_launch_innerはuserdataへinsertしghostsの集計列をbumpする() {
+        let user_conn = Connection::open_in_memory().unwrap();
+        ensure_schema(&user_conn).unwrap();
+        let ghosts_conn = ghosts_conn_with_row("sspg");
+
+        record_launch_inner(&user_conn, &ghosts_conn, "sspg").unwrap();
+        record_launch_inner(&user_conn, &ghosts_conn, "sspg").unwrap();
+
+        let launches: i64 = user_conn
+            .query_row("SELECT COUNT(*) FROM ghost_launches WHERE ghost_identity_key = 'sspg'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(launches, 2);
+
+        let (count, last): (i64, Option<String>) = ghosts_conn
+            .query_row("SELECT launch_count, last_launched FROM ghosts WHERE ghost_identity_key = 'sspg'", [], |r| Ok((r.get(0)?, r.get(1)?)))
+            .unwrap();
+        assert_eq!(count, 2);
+        assert!(last.is_some(), "last_launched が設定されること");
+    }
 
     #[test]
     fn ensure_schemaはghost_launchesテーブルを冪等に作る() {

--- a/src-tauri/src/commands/launch_history.rs
+++ b/src-tauri/src/commands/launch_history.rs
@@ -1,0 +1,45 @@
+use rusqlite::Connection;
+use tauri::Manager;
+
+/// user-data.db に起動履歴テーブルを冪等に用意する。
+/// ここは sqlx マイグレーション系に載せない（永続ストアなので自動削除の事故クラスが構造上発生しない）。
+pub(crate) fn ensure_schema(conn: &Connection) -> Result<(), String> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS ghost_launches (\n  id INTEGER PRIMARY KEY AUTOINCREMENT,\n  ghost_identity_key TEXT NOT NULL,\n  launched_at TEXT NOT NULL\n);\nCREATE INDEX IF NOT EXISTS idx_ghost_launches_identity ON ghost_launches(ghost_identity_key);\nCREATE INDEX IF NOT EXISTS idx_ghost_launches_at ON ghost_launches(launched_at DESC);",
+    )
+    .map_err(|e| format!("user-data スキーマ作成エラー: {e}"))
+}
+
+/// user-data.db を開き、書込用 PRAGMA を適用し、スキーマを用意して返す。
+pub(crate) fn open_user_data_db<R: tauri::Runtime>(
+    manager: &impl Manager<R>,
+) -> Result<Connection, String> {
+    let path = crate::db_path::user_data_db_path(manager)?;
+    let conn = Connection::open(&path).map_err(|e| format!("user-data.db オープンエラー: {e}"))?;
+    crate::commands::ghost::store::configure_connection(&conn)?;
+    ensure_schema(&conn)?;
+    Ok(conn)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ensure_schemaはghost_launchesテーブルを冪等に作る() {
+        let conn = Connection::open_in_memory().unwrap();
+        ensure_schema(&conn).unwrap();
+        // 二重呼び出しでも失敗しない（IF NOT EXISTS）
+        ensure_schema(&conn).unwrap();
+
+        let cols: Vec<String> = conn
+            .prepare("PRAGMA table_info(ghost_launches)")
+            .unwrap()
+            .query_map([], |row| row.get::<_, String>(1))
+            .unwrap()
+            .filter_map(Result::ok)
+            .collect();
+        assert!(cols.contains(&"ghost_identity_key".to_string()));
+        assert!(cols.contains(&"launched_at".to_string()));
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod db;
 pub mod ghost;
+pub mod launch_history;
 pub mod locale;
 pub mod ssp;

--- a/src-tauri/src/db_path.rs
+++ b/src-tauri/src/db_path.rs
@@ -26,3 +26,11 @@ pub(crate) fn ghost_db_path<R: tauri::Runtime>(
 ) -> Result<std::path::PathBuf, String> {
     Ok(ghost_db_dir(manager)?.join(GHOST_DB_FILES[0]))
 }
+
+/// user-data.db（永続ユーザーデータ）本体のフルパス。ghosts.db と同じ app_config_dir 基準。
+/// user-data.db は永続ストアであり、reset_ghost_db / sanitize_ghost_db の削除対象に含めない。
+pub(crate) fn user_data_db_path<R: tauri::Runtime>(
+    manager: &impl Manager<R>,
+) -> Result<std::path::PathBuf, String> {
+    Ok(ghost_db_dir(manager)?.join("user-data.db"))
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -272,7 +272,8 @@ mod tests {
 
 /// マイグレーション適用前に ghosts.db の整合性を検証する。
 /// 未適用マイグレーションが ADD COLUMN しようとするカラムが既に存在する場合、
-/// DB ファイルを削除して再作成を促す。ghosts.db はキャッシュなので安全。
+/// DB ファイルを削除して再作成を促す。ghosts.db は揮発キャッシュ（再スキャンで復旧）であり、
+/// 永続的な起動履歴は user-data.db へ分離済みのため、削除しても失われない。
 fn sanitize_ghost_db(app: &tauri::App) {
     let Ok(db_dir) = db_path::ghost_db_dir(app) else {
         return;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -336,6 +336,25 @@ fn has_migration_conflict(conn: &rusqlite::Connection) -> bool {
     false
 }
 
+/// user-data.db を初期化し、旧 ghosts.db.ghost_launches の履歴を一度だけ移送する。
+/// Rust setup（JS の Database.load によるマイグレーションより先に走る）で呼ぶことで、
+/// migration 13 の旧テーブル DROP より前に移送を完了させる。
+fn init_user_data(app: &tauri::App) {
+    let Ok(user_conn) = commands::launch_history::open_user_data_db(app) else {
+        eprintln!("[user-data] user-data.db を初期化できませんでした");
+        return;
+    };
+    let Ok(ghosts_path) = db_path::ghost_db_path(app) else {
+        return;
+    };
+    // ghosts.db が存在するときだけ legacy 移送を試みる（空ファイルの事前生成を避ける）
+    if ghosts_path.exists() {
+        if let Ok(ghosts_conn) = rusqlite::Connection::open(&ghosts_path) {
+            let _ = commands::launch_history::migrate_legacy_launch_history(&ghosts_conn, &user_conn);
+        }
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -349,12 +368,13 @@ pub fn run() {
         .plugin(tauri_plugin_window_state::Builder::default().build())
         .setup(|app| {
             sanitize_ghost_db(app);
+            init_user_data(app);
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
             commands::db::reset_ghost_db,
             commands::ghost::scan_and_store,
-
+            commands::launch_history::record_launch,
             commands::ssp::launch_ghost,
             commands::ssp::validate_ssp_path,
             commands::locale::read_user_locale,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -84,6 +84,18 @@ pub(crate) fn migrations() -> Vec<tauri_plugin_sql::Migration> {
             sql: "CREATE TABLE IF NOT EXISTS ghost_launches (\n  id INTEGER PRIMARY KEY AUTOINCREMENT,\n  ghost_identity_key TEXT NOT NULL,\n  launched_at TEXT NOT NULL\n);\nCREATE INDEX IF NOT EXISTS idx_ghost_launches_identity ON ghost_launches(ghost_identity_key);\nCREATE INDEX IF NOT EXISTS idx_ghost_launches_at ON ghost_launches(launched_at DESC);",
             kind: tauri_plugin_sql::MigrationKind::Up,
         },
+        tauri_plugin_sql::Migration {
+            version: 12,
+            description: "add_launch_aggregates_to_ghosts",
+            sql: "ALTER TABLE ghosts ADD COLUMN last_launched TEXT;\nALTER TABLE ghosts ADD COLUMN launch_count INTEGER NOT NULL DEFAULT 0;",
+            kind: tauri_plugin_sql::MigrationKind::Up,
+        },
+        tauri_plugin_sql::Migration {
+            version: 13,
+            description: "drop_legacy_ghost_launches_from_cache_db",
+            sql: "DROP TABLE IF EXISTS ghost_launches;",
+            kind: tauri_plugin_sql::MigrationKind::Up,
+        },
     ]
 }
 
@@ -103,6 +115,31 @@ mod tests {
             conn.execute_batch(m.sql)
                 .unwrap_or_else(|e| panic!("migration {} ({}) failed: {}", m.version, m.description, e));
         }
+    }
+
+    #[test]
+    fn migration12と13で集計列追加と旧履歴テーブル除去が行われる() {
+        let conn = Connection::open_in_memory().unwrap();
+        let mut applied = migrations();
+        applied.sort_by_key(|m| m.version);
+        for m in applied {
+            conn.execute_batch(m.sql).unwrap();
+        }
+        // ghosts に集計列が存在する
+        let cols: Vec<String> = conn
+            .prepare("PRAGMA table_info(ghosts)")
+            .unwrap()
+            .query_map([], |row| row.get::<_, String>(1))
+            .unwrap()
+            .filter_map(Result::ok)
+            .collect();
+        assert!(cols.contains(&"last_launched".to_string()));
+        assert!(cols.contains(&"launch_count".to_string()));
+        // 旧 ghost_launches テーブルは ghosts.db から除去されている
+        let has_launches: i64 = conn
+            .query_row("SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='ghost_launches'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(has_launches, 0, "ghost_launches は user-data.db へ分離され ghosts.db からは除去される");
     }
 
     #[test]

--- a/src/lib/ghostDatabase.test.ts
+++ b/src/lib/ghostDatabase.test.ts
@@ -425,6 +425,16 @@ describe("ghostDatabase - cleanupOldGhostCaches", () => {
   });
 });
 
+describe("recordLaunch", () => {
+  it("record_launch IPC を camelCase 引数で呼ぶ", async () => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    const { recordLaunch } = await import("./ghostDatabase");
+    vi.mocked(invoke).mockResolvedValue(undefined);
+    await recordLaunch("sspmy_ghost");
+    expect(invoke).toHaveBeenCalledWith("record_launch", { ghostIdentityKey: "sspmy_ghost" });
+  });
+});
+
 describe("normalizeForKey パリティ（共有 fixture）", () => {
   it.each(cases)("normalizeForKey($input) === $expected", async ({ input, expected }) => {
     const { normalizeForKey } = await import("./ghostDatabase");

--- a/src/lib/ghostDatabase.test.ts
+++ b/src/lib/ghostDatabase.test.ts
@@ -299,6 +299,28 @@ describe("ghostDatabase - random ソートの安定シード", () => {
   });
 });
 
+describe("buildOrderBy", () => {
+  it("recent は JOIN なしで last_launched 列を並べる", async () => {
+    const { buildOrderBy } = await import("./ghostDatabase");
+    const orderBy = buildOrderBy("recent");
+    expect(orderBy).toContain("g.last_launched DESC");
+    expect(orderBy).not.toContain("JOIN");
+    expect(orderBy).not.toContain("ghost_launches");
+  });
+
+  it("frequency は JOIN なしで launch_count 列を並べる", async () => {
+    const { buildOrderBy } = await import("./ghostDatabase");
+    const orderBy = buildOrderBy("frequency");
+    expect(orderBy).toContain("g.launch_count DESC");
+    expect(orderBy).not.toContain("JOIN");
+  });
+
+  it("name は name_lower を昇順で並べる", async () => {
+    const { buildOrderBy } = await import("./ghostDatabase");
+    expect(buildOrderBy("name")).toContain("g.name_lower ASC");
+  });
+});
+
 describe("ghostDatabase - countGhostsByQuery", () => {
   it("空クエリ時は LIKE なしで件数取得する", async () => {
     mockSelect.mockResolvedValue([{ count: 42 }]);

--- a/src/lib/ghostDatabase.ts
+++ b/src/lib/ghostDatabase.ts
@@ -291,11 +291,7 @@ export async function searchGhosts(requestKey: string, query: string, limit: num
 }
 
 export async function recordLaunch(ghostIdentityKey: string): Promise<void> {
-  const db = await getDb();
-  await db.execute(
-    "INSERT INTO ghost_launches (ghost_identity_key, launched_at) VALUES (?, datetime('now'))",
-    [ghostIdentityKey]
-  );
+  await invoke("record_launch", { ghostIdentityKey });
 }
 
 export async function getRandomGhost(requestKey: string): Promise<GhostView | null> {

--- a/src/lib/ghostDatabase.ts
+++ b/src/lib/ghostDatabase.ts
@@ -206,37 +206,28 @@ export function reseedRandomSort(): void {
   randomSortSeed = newRandomSortSeed();
 }
 
-function buildOrderBy(sortOrder: SortOrder): { orderBy: string; join: string } {
+// SELECT の ORDER BY 式を返す。recent/frequency は ghosts の非正規化集計列
+// （last_launched / launch_count）で並べる。起動履歴は user-data.db（Rust 専有）に
+// 分離され、集計列は record_launch とスキャン時バックフィルで維持される。
+export function buildOrderBy(sortOrder: SortOrder): string {
   switch (sortOrder) {
     case "random":
-      return {
-        join: "",
-        orderBy: `(g.id * ${randomSortSeed}) % ${RANDOM_SORT_MODULUS}, g.id`,
-      };
+      return `(g.id * ${randomSortSeed}) % ${RANDOM_SORT_MODULUS}, g.id`;
     case "recent":
-      return {
-        join: "LEFT JOIN (SELECT ghost_identity_key, MAX(launched_at) AS last_launched FROM ghost_launches GROUP BY ghost_identity_key) gl ON g.ghost_identity_key = gl.ghost_identity_key",
-        orderBy: "gl.last_launched DESC NULLS LAST, g.name_lower ASC",
-      };
+      return "g.last_launched DESC NULLS LAST, g.name_lower ASC";
     case "frequency":
-      return {
-        join: "LEFT JOIN (SELECT ghost_identity_key, COUNT(*) AS launch_count FROM ghost_launches GROUP BY ghost_identity_key) gl ON g.ghost_identity_key = gl.ghost_identity_key",
-        orderBy: "gl.launch_count DESC NULLS LAST, g.name_lower ASC",
-      };
+      return "g.launch_count DESC, g.name_lower ASC";
     default:
-      return { join: "", orderBy: "g.name_lower ASC" };
+      return "g.name_lower ASC";
   }
 }
 
 export async function searchGhostsInitialPage(requestKey: string, limit: number, sortOrder: SortOrder = "name"): Promise<GhostView[]> {
   return measureSearch("searchGhostsInitialPage", async () => {
     const db = await getDb();
-    const { join, orderBy } = buildOrderBy(sortOrder);
-    const from = join
-      ? `ghosts g ${join}`
-      : "ghosts g";
+    const orderBy = buildOrderBy(sortOrder);
     const rows = await db.select<GhostView[]>(
-      `SELECT ${GHOST_SELECT_COLUMNS_PREFIXED} FROM ${from} WHERE g.request_key = ? ORDER BY ${orderBy} LIMIT ?`,
+      `SELECT ${GHOST_SELECT_COLUMNS_PREFIXED} FROM ghosts g WHERE g.request_key = ? ORDER BY ${orderBy} LIMIT ?`,
       [requestKey, limit]
     );
 
@@ -272,14 +263,13 @@ export async function searchGhosts(requestKey: string, query: string, limit: num
 
     const normalizedQuery = normalizeForKey(query);
     const likePattern = `%${normalizedQuery}%`;
-    const { join, orderBy } = buildOrderBy(sortOrder);
-    const from = join ? `ghosts g ${join}` : "ghosts g";
+    const orderBy = buildOrderBy(sortOrder);
     const searchWhere = GHOST_SEARCH_LOWER_COLUMNS.map((col) => `g.${col} LIKE ?`).join(" OR ");
 
     const [total, rows] = await Promise.all([
       countGhostsByQuery(requestKey, query),
       db.select<GhostView[]>(
-        `SELECT ${GHOST_SELECT_COLUMNS_PREFIXED} FROM ${from} WHERE g.request_key = ? AND (${searchWhere}) ORDER BY ${orderBy} LIMIT ? OFFSET ?`,
+        `SELECT ${GHOST_SELECT_COLUMNS_PREFIXED} FROM ghosts g WHERE g.request_key = ? AND (${searchWhere}) ORDER BY ${orderBy} LIMIT ? OFFSET ?`,
         [requestKey, ...GHOST_SEARCH_LOWER_COLUMNS.map(() => likePattern), limit, offset]
       ),
     ]);


### PR DESCRIPTION
## 背景（解消する不変条件違反）

`reset_ghost_db` / 起動時 `sanitize_ghost_db` は migration 競合からの自動回復で `ghosts.db` をファイルごと削除する。この「ghosts.db は揮発キャッシュだから安全」という前提は、migration 11 で**永続テーブル `ghost_launches`（起動履歴）が同居**して以降崩れており、リセットのたびに recent/frequency ソートの基盤である起動履歴が不可逆に失われていた（issue #93）。

回復すべき不変条件: **「キャッシュのリセットは永続的なユーザーデータを一切失わせない」**。

## 方針

永続データと揮発データの運命共有を**器のレベルで解消**する。

- `ghost_launches` を新設 **`user-data.db`（Rust 専有・rusqlite）** へ分離。JS からは触らず、リセット対象（`GHOST_DB_FILES`）にも含めない。`ghosts.db` は純粋キャッシュへ戻る。
- `tauri-plugin-sql`（sqlx）はコネクションプールを使い ATTACH が接続ごとに揮発するため、cross-DB JOIN は**廃止**。代わりに `ghosts` へ非正規化集計列 `last_launched` / `launch_count` を持たせ、recent/frequency を**単一 DB のプレーン ORDER BY** に置換（読み取り経路の一様性と `GHOST_SELECT_COLUMNS` 単一権威を維持）。
- 集計列は **`record_launch`（Rust コマンド・起動時）** で即時更新し、**`scan_and_store`（スキャン時・全経路）** で user-data.db から再導出（バックフィル）。
- 旧 `ghosts.db.ghost_launches` の履歴は初回起動時に**一度だけ冪等に user-data.db へ複写**し、migration 13 で旧テーブルを DROP。移送は Rust setup で走り、JS の Database.load 時の migration DROP より前（preload 未使用＝ライフサイクル保証）。

設計書 / 実装計画: `docs/superpowers/specs/2026-07-04-persist-launch-history-separate-db-design.md` / `docs/superpowers/plans/2026-07-04-persist-launch-history-separate-db.md`

## 主な変更

- `src-tauri/src/commands/launch_history.rs`（新規）: user-data.db スキーマ・接続、`record_launch_inner`（二面更新）、`backfill_aggregates`（再導出）、`migrate_legacy_launch_history`（一度きり移送）、`record_launch` コマンド
- `src-tauri/src/db_path.rs`: `user_data_db_path` 追加
- `src-tauri/src/lib.rs`: migration 12（集計列追加）/ 13（旧テーブル DROP）、`init_user_data`（setup 配線）、コマンド登録
- `src-tauri/src/commands/ghost/mod.rs`: `backfill_launch_aggregates` ヘルパーを cache hit/miss 全経路へ配線（アップグレード後も recent/frequency を保持）
- `src/lib/ghostDatabase.ts`: `recordLaunch` を `record_launch` invoke へ、`buildOrderBy` の JOIN 廃止・集計列 ORDER BY
- ドキュメント整合（`SPEC.md` §4.3/4.5/6.6/8.6/13、`src-tauri/CLAUDE.md`、コメント）

## テスト

- Rust: `cargo test` 45 passed（二面更新・バックフィル再導出・移送冪等性・migration 12/13・不変性を単体テストで検証）
- フロント: `npm test` 149 passed（`recordLaunch` の record_launch invoke・`buildOrderBy` の JOIN 廃止）
- `npm run build` / `check:ui-guidelines`（6/6）/ `test:ui-guidelines-check`（6/6）通過

Subagent-Driven Development（実装者＋レビュアー各タスク二段階、最終 whole-branch レビュー opus）で実施。最終レビューが検出した Important（backfill が cache miss 経路のみ→アップグレード典型の cache hit で履歴未反映）を fix 672779c で解消（再レビュー Resolved）。

## 未実施（マージ前に手動推奨）

- E2E 手動実行（リリースビルド要・CI 外）: ゴースト起動→recent 先頭化の確認
- 手動アップグレード確認: 旧 ghosts.db からの履歴移送、リセット後も履歴が残ること

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)