### PR TITLE
docs: /e2e の EDGEDRIVER_VERSION 直書きを実測手順へ改める (#104)

### DIFF
--- a/.claude/skills/e2e/SKILL.md
+++ b/.claude/skills/e2e/SKILL.md
@@ -28,7 +28,7 @@ npx playwright test -c playwright.tauri.config.ts
 ```
 
 - **`GHOST_LAUNCHER_E2E_APP` は必ず指定**する。cargo workspace のため `tauri build` の出力は*ワークスペース直下* `target/release/` に集約されるが、harness の `getAppBinaryPath()` 既定は `src-tauri/target/release/`（化石）を指す。override しないと古いバイナリを検証してしまう。
-- **`EDGEDRIVER_VERSION`** は WebView2 Runtime の版（2026-06 時点 `149.0.4022.80`）に合わせる。レジストリの `pv` は `e2e/CLAUDE.md` 参照。
+- **`EDGEDRIVER_VERSION`** は WebView2 Runtime の版に合わせる。版は環境・時期で変わるため直値を覚えず、**都度レジストリの `pv` を実測**して指定する（取得元のレジストリキーは `e2e/CLAUDE.md` 参照）。
 - 特定テストのみ: `-g "<テスト名>"` を付ける。
 
 ## ステップ 3: 既知の skip 要因を踏まえて結果を解釈


### PR DESCRIPTION
## Summary
- `.claude/skills/e2e/SKILL.md` の `EDGEDRIVER_VERSION` から具体値（`149.0.4022.80`）を排除
- 「都度レジストリの `pv` を実測して指定する」という手順表記へ変更（取得元キーは `e2e/CLAUDE.md` 参照のまま）
- スキル群のグローバル制約「陳腐化する値をハードコードしない」に自らを揃える
- /health-check ベースライン（#102）で検出（実測 pv は既に `.98` へ進行し直値は陳腐化済み）

Closes #104

## Test plan
- スキル定義（`.claude/`）のみの変更でビルド対象外のためテスト追加はなし（コミットに理由明記）
- スキル本文に版数マッチが 0 件であることを grep で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)