### PR TITLE
fix: E2E スクロールテストの stale element 競合を吸収 (#90)

### DIFF
--- a/e2e/ghost-list.e2e.ts
+++ b/e2e/ghost-list.e2e.ts
@@ -1,5 +1,5 @@
 import { test as base, expect } from "@playwright/test";
-import { By, until, Key, type WebDriver } from "selenium-webdriver";
+import { By, until, Key, error as seleniumError, type WebDriver } from "selenium-webdriver";
 import { createHarness, disposeHarness, type Harness } from "./helpers/harness";
 import { waitForAppReady, waitForGhosts, openSettings, closeSettings } from "./helpers/ui";
 
@@ -29,7 +29,21 @@ async function findEmptyStateText(driver: WebDriver): Promise<string | null> {
 /** 現在 DOM に描画されているゴースト名の一覧を取得する（仮想化の窓内のカードのみ） */
 async function visibleGhostNames(driver: WebDriver): Promise<string[]> {
   const els = await driver.findElements(By.css("[data-testid='ghost-name']"));
-  return Promise.all(els.map((el) => el.getText()));
+  return Promise.all(
+    els.map(async (el) => {
+      try {
+        return await el.getText();
+      } catch (err) {
+        // 仮想リストの再描画（SkeletonCard → GhostCard 差し替え）で要素が
+        // 差し替わると getText が stale になる。呼び出し側の wait が次周期で
+        // 再取得するため、この要素は空文字として扱う（他の例外は握り潰さない）。
+        if (err instanceof seleniumError.StaleElementReferenceError) {
+          return "";
+        }
+        throw err;
+      }
+    }),
+  );
 }
 
 // --- テストケース ---


### PR DESCRIPTION
## Summary
- `e2e/ghost-list.e2e.ts` の `visibleGhostNames` を、`getText()` 要素単位の `try-catch` に変更
- **`StaleElementReferenceError` のときだけ**空文字を返し、他の例外は再送出（握り潰さない）
- 仮想リストの SkeletonCard→GhostCard 差し替え再描画と競合しても、`driver.wait` のポーリングが次周期で再取得でき、条件関数の例外による即 reject を回避する
- issue の提案（関数全体を `[]` 返し）より堅牢: 一部要素が stale でも健全な読み取りは残り、最終読み取り（`namesAfter`）での偽陰性を避ける

Closes #90

## 根本原因
`findElements` → `getText` の間に stale 保護が無く、スクロール直後の再描画と競合すると `getText()` が stale 例外を投げ、それが `driver.wait` の条件関数内で起きると wait が即座に reject していた。

## Test plan
- [x] `error.StaleElementReferenceError` の runtime 挙動を node で確認（コンストラクタ実在・instanceof 成立・name 一致）
- [x] スクロールテスト単体を `--repeat-each=10` + 単発 = **11 連続 pass**（間欠レースの安定性確認）
- [x] E2E スイート全体: **10 passed / 1 skip / 0 failed**（skip は SSP 設定済み環境での空状態テストで正当）
- [x] npm run build / npm test (149) / check:ui-guidelines / test:ui-guidelines-check
- TDD Red は省略（理由をコミットに明記）: vitest の include は `src/**/*.test` のみで `e2e/` は対象外、対象は WebDriver の間欠レースで決定的再現が困難。検証は上記 E2E 実行で代替
- 環境: WebView2 Runtime `149.0.4022.98` / 実ゴースト約 1200 件

🤖 Generated with [Claude Code](https://claude.com/claude-code)