### PR TITLE
docs: 機能変更時の locale ドキュメント同期を /implement 締めに明文化 (#109)

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -53,6 +53,7 @@ description: コード変更（機能追加・バグ修正・リファクタリ�
 ## ステップ 7: 締め
 
 - SPEC.md に影響する振る舞い変更は、同一コミットで SPEC.md も更新する
+- `src/locales/*.json` のキーを増減した場合は、同一コミットで `docs/locale-customization.md` のキー一覧を更新する（ユーザー向けドキュメントの drift 防止）
 - `/commit` へ接続する（チェックリストの実行とコミットは `/commit` の責務）
 
 ## 注意事項


### PR DESCRIPTION
## Summary
- `/implement` ステップ 7「締め」に、既存の SPEC.md 同期規約の直下へ locale ドキュメント同期規約を 1 行追加
- `src/locales/*.json` のキー増減時に `docs/locale-customization.md` のキー一覧が置き去りになる drift（#103 で顕在化）を、authoring 時点で構造的に防ぐ
- 新しい表・機構は増やさず既存パターンへ相乗り（KISS・1 in 1 out を尊重）

## 背景
`/health-check` ベースライン（#102）が検出した drift の再発防止。RETROSPECTIVE.md のネクストアクション「ドキュメント同期観点の検討」に対応。

## Test plan
- スキル Markdown のみの変更でコード成果物は不変のため、ビルド・テスト系チェックは非該当
- [x] 参照先 `docs/locale-customization.md` の実在を確認
- [x] 追加行が既存の SPEC.md 同期規約と対称であることを確認

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)