### PR TITLE
docs: launch_history.rs をモジュール構成ドキュメントへ追記 (#113)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,7 @@ ghost_launcher/
 │       ├── commands/
 │       │   ├── ghost/          # ゴーストスキャン・フィンガープリント
 │       │   ├── ssp.rs          # ゴースト起動・SSP パス検証コマンド
+│       │   ├── launch_history.rs # 起動履歴記録（record_launch）・user-data.db 管理
 │       │   ├── db.rs           # DB リセット（マイグレーション失敗時の自動回復）
 │       │   └── locale.rs       # ユーザー言語ファイル読込
 │       ├── db_path.rs          # ghosts.db パス解決の単一権威

--- a/SPEC.md
+++ b/SPEC.md
@@ -74,6 +74,7 @@ Ghost Launcher は、**伺か/SSP ゴースト**を検出・一覧表示・検�
 | `db_path.rs`        | ghosts.db パス解決の単一権威（全経路が app_config_dir 基準を共有）                        |
 | `commands/ghost/`   | ゴーストスキャン一式: 走査と型変換（scan）・差分 UPSERT 書込（store）・二層フィンガープリント（fingerprint）・パス正規化（path_utils）・型定義（types） |
 | `commands/ssp.rs`   | SSP 連携: ゴースト起動（launch_ghost）・SSP パス検証（validate_ssp_path）                 |
+| `commands/launch_history.rs` | 起動履歴の記録（record_launch）と user-data.db 管理: 履歴 INSERT ＋ ghosts 集計列 bump・スキャン時の集計列 backfill・旧 ghosts.db 履歴の移送 |
 | `commands/db.rs`    | キャッシュ DB リセット（マイグレーション競合からの自動回復）                              |
 | `commands/locale.rs`| ユーザー言語ファイル読込                                                                  |
 


### PR DESCRIPTION
## Summary
- SPEC.md §3.2 バックエンドモジュール表に `commands/launch_history.rs` の行を追加
- ルート CLAUDE.md のディレクトリ構成図に同ファイルを追加
- 記述は実装どおり: `record_launch` コマンド・user-data.db 管理・ghosts 集計列の bump／backfill・旧 ghosts.db 履歴の移送

## 背景
`/health-check`（#110 で `/retrospective` 起点に組み込み）の初回ドッグフーディングが検出した drift。#93 の起動履歴サブシステム新設時に構造ドキュメントへの追記が漏れていた。

## 受け入れ基準の充足
- [x] SPEC.md §3.2 モジュール表に追記
- [x] ルート CLAUDE.md 構成図に追記
- [x] 記述内容が実装（`record_launch`・#93 の user-data.db 分離）と一致

## Test plan
- ドキュメントのみの変更でコード成果物は不変のため、ビルド・テスト系チェックは非該当
- [x] `src-tauri/src/commands/launch_history.rs`・`lib.rs` の実装と記述の一致を確認

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)