### PR TITLE
docs: /implement 締めのドキュメント同期規約を同期表へ統合 (#114)

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -52,8 +52,14 @@ description: コード変更（機能追加・バグ修正・リファクタリ�
 
 ## ステップ 7: 締め
 
-- SPEC.md に影響する振る舞い変更は、同一コミットで SPEC.md も更新する
-- `src/locales/*.json` のキーを増減した場合は、同一コミットで `docs/locale-customization.md` のキー一覧を更新する（ユーザー向けドキュメントの drift 防止）
+- コード変更が以下に影響する場合、同一コミットで対応ドキュメントも更新する（ドキュメント drift 防止）:
+
+  | コード変更 | 同期するドキュメント |
+  |---|---|
+  | 振る舞い・DB スキーマ・コマンド仕様 | SPEC.md |
+  | `src-tauri/src/commands/` 等へのモジュール（ファイル）新設・移動・削除 | SPEC.md §3.2 モジュール表・ルート CLAUDE.md ツリー |
+  | `src/locales/*.json` のキー増減 | `docs/locale-customization.md` のキー一覧 |
+
 - `/commit` へ接続する（チェックリストの実行とコミットは `/commit` の責務）
 
 ## 注意事項


### PR DESCRIPTION
## Summary
- `/implement` ステップ 7「締め」の線形に伸びていた同期箇条書き（SPEC.md・locale）を「ドキュメント同期表」へ統合
- モジュール新設・移動・削除時に SPEC.md §3.2 モジュール表とルート CLAUDE.md ツリーを同期する行を追加（#113 launch_history.rs 記述漏れの根本要因への手当て）
- SPEC.md 行を「振る舞い・DB スキーマ・コマンド仕様」へ精緻化し §3.2 の実体と噛み合わせ

## 設計判断
ドキュメント同期義務が 3 つ目に達し「2 回までは許容、3 回目で抽出」の閾値に到達（#117 と同型）。都度の箇条書き追記は線形に伸びるため、表へ構造化して今後の項目追加が肥大しない形にした。箇条書き 2 本を表 1 つへ集約する 1 in 1 out。

## 受け入れ基準の充足
- [x] 新規モジュール追加時の構造ドキュメント（SPEC.md モジュール表・CLAUDE.md ツリー）同期を明文化
- [x] 規約肥大を避け 1 in 1 out を尊重（表への統合で正味削減）
- [x] 参照先（SPEC.md §3.2・CLAUDE.md ツリー・docs/locale-customization.md）の実在を確認

## Test plan
- `*.md` のみの変更のため #117 の規則によりコード系ゲートは非該当

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)