### PR TITLE
fix: サムネイル立ち絵の黒消えを修正（実画像アルファ優先＋キー色抜きガード）

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -112,7 +112,7 @@ descript.txt のパース（文字コード判定含む）・単体ゴースト�
 | `path`                       | `String`  | ゴーストのフルパス                                                              |
 | `source`                     | `String`  | `"ssp"`（SSP 内ゴースト）またはフォルダのフルパス（追加フォルダ）               |
 | `thumbnail_path`             | `String`  | サムネイル画像のフルパス。存在しない場合は空文字列                              |
-| `thumbnail_use_self_alpha`   | `bool`    | `true` = PNG アルファチャンネル透過、`false` = 左上ピクセルをキーカラーとして透過 |
+| `thumbnail_use_self_alpha`   | `bool`    | `true` = PNG アルファチャンネル透過、`false` = 左上ピクセルをキーカラーとして透過。ただし `false` でも実画像が本物のアルファを持つ場合（左上ピクセルが不透明でない）はキー色抜きを行わず native alpha を尊重する（黒消え防止） |
 | `thumbnail_kind`             | `String`  | `"surface"` / `"thumbnail"` / `""`（サムネイルなし）                            |
 | `diff_fingerprint`           | `String`  | 差分更新判定用の軽量フィンガープリント（メタデータ全フィールドの SHA-256）       |
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -112,7 +112,7 @@ descript.txt のパース（文字コード判定含む）・単体ゴースト�
 | `path`                       | `String`  | ゴーストのフルパス                                                              |
 | `source`                     | `String`  | `"ssp"`（SSP 内ゴースト）またはフォルダのフルパス（追加フォルダ）               |
 | `thumbnail_path`             | `String`  | サムネイル画像のフルパス。存在しない場合は空文字列                              |
-| `thumbnail_use_self_alpha`   | `bool`    | `true` = PNG アルファチャンネル透過、`false` = 左上ピクセルをキーカラーとして透過。ただし `false` でも実画像が本物のアルファを持つ場合（左上ピクセルが不透明でない）はキー色抜きを行わず native alpha を尊重する（黒消え防止） |
+| `thumbnail_use_self_alpha`   | `bool`    | `true` = PNG アルファチャンネル透過、`false` = 左上ピクセルをキーカラーとして透過。判定は実画像の color type を優先し、アルファチャンネルを持つ（RGBA / グレースケール+アルファ）場合は descript の `seriko.use_self_alpha` 宣言に関わらず `true`。持たない場合のみ宣言に従う。加えてフロントは `false` でも左上ピクセルが不透明でなければキー色抜きを行わず native alpha を尊重する（黒消え防止の多層防御） |
 | `thumbnail_kind`             | `String`  | `"surface"` / `"thumbnail"` / `""`（サムネイルなし）                            |
 | `diff_fingerprint`           | `String`  | 差分更新判定用の軽量フィンガープリント（メタデータ全フィールドの SHA-256）       |
 

--- a/crates/ghost-meta/src/thumbnail.rs
+++ b/crates/ghost-meta/src/thumbnail.rs
@@ -93,17 +93,16 @@ fn resolve_surface0(
     let filename = apng_files.first().or_else(|| png_files.first())?;
     let path = shell_master.join(filename);
 
-    let descript_alpha = match shell_descript {
-        Some(fields) => seriko_alpha_from_fields(fields),
-        None => read_seriko_use_self_alpha(ghost_root),
-    };
     // 実画像が本物のアルファチャンネルを持つ場合は宣言に関わらず SelfAlpha を優先する。
     // （seriko.use_self_alpha 未宣言の RGBA サーフェスがキーカラー抜きへ流れて
-    // 黒消えする不具合の根本対策。持たない場合のみ descript 由来の判定を使う）
+    // 黒消えする不具合の根本対策。アルファを持たないときだけ descript 宣言に従う）
     let alpha = if png_has_alpha_channel(&path) {
         AlphaMode::SelfAlpha
     } else {
-        descript_alpha
+        match shell_descript {
+            Some(fields) => seriko_alpha_from_fields(fields),
+            None => read_seriko_use_self_alpha(ghost_root),
+        }
     };
 
     Some(ThumbnailInfo {

--- a/crates/ghost-meta/src/thumbnail.rs
+++ b/crates/ghost-meta/src/thumbnail.rs
@@ -89,28 +89,28 @@ fn resolve_surface0(
     apng_files.sort_by_key(|f| f.to_ascii_lowercase());
     png_files.sort_by_key(|f| f.to_ascii_lowercase());
 
-    let alpha = match shell_descript {
+    // APNG が PNG より優先。選ばれたファイルを 1 つに決める
+    let filename = apng_files.first().or_else(|| png_files.first())?;
+    let path = shell_master.join(filename);
+
+    let descript_alpha = match shell_descript {
         Some(fields) => seriko_alpha_from_fields(fields),
         None => read_seriko_use_self_alpha(ghost_root),
     };
+    // 実画像が本物のアルファチャンネルを持つ場合は宣言に関わらず SelfAlpha を優先する。
+    // （seriko.use_self_alpha 未宣言の RGBA サーフェスがキーカラー抜きへ流れて
+    // 黒消えする不具合の根本対策。持たない場合のみ descript 由来の判定を使う）
+    let alpha = if png_has_alpha_channel(&path) {
+        AlphaMode::SelfAlpha
+    } else {
+        descript_alpha
+    };
 
-    // APNG が PNG より優先
-    if let Some(filename) = apng_files.first() {
-        return Some(ThumbnailInfo {
-            path: shell_master.join(filename),
-            alpha,
-            kind: ThumbnailKind::Surface,
-        });
-    }
-    if let Some(filename) = png_files.first() {
-        return Some(ThumbnailInfo {
-            path: shell_master.join(filename),
-            alpha,
-            kind: ThumbnailKind::Surface,
-        });
-    }
-
-    None
+    Some(ThumbnailInfo {
+        path,
+        alpha,
+        kind: ThumbnailKind::Surface,
+    })
 }
 
 /// HashMap から seriko.use_self_alpha を判定する。
@@ -137,34 +137,42 @@ fn read_seriko_use_self_alpha(ghost_root: &Path) -> AlphaMode {
     AlphaMode::KeyColor
 }
 
-/// thumbnail.png のアルファチャンネルを検査して AlphaMode を返す。
-/// feature: "thumbnail" が有効な場合、PNG の IHDR ヘッダーのみ読み込んで color type を検査する。
-/// feature が無効な場合は常に KeyColor を返す。
+/// PNG/APNG が本物のアルファチャンネルを持つか検査する。
+/// feature: "thumbnail" が有効な場合、IHDR ヘッダーのみ読み込んで color type を検査する
+/// （全ピクセル展開はしない）。feature が無効な場合は常に false を返す。
 #[cfg(feature = "thumbnail")]
-fn detect_thumbnail_alpha(path: &Path) -> AlphaMode {
+fn png_has_alpha_channel(path: &Path) -> bool {
     use image::codecs::png::PngDecoder;
     use image::ColorType;
     use image::ImageDecoder;
 
     let Ok(file) = fs::File::open(path) else {
-        return AlphaMode::KeyColor;
+        return false;
     };
     // PngDecoder は BufRead + Seek を要求するため BufReader で包む
     let Ok(decoder) = PngDecoder::new(std::io::BufReader::new(file)) else {
-        return AlphaMode::KeyColor;
+        return false;
     };
-    // color_type() は ImageDecoder トレイトのメソッド。IHDR チャンクのみ参照し全ピクセル展開は行わない
-    match decoder.color_type() {
-        ColorType::Rgba8 | ColorType::La8 | ColorType::Rgba16 | ColorType::La16 => {
-            AlphaMode::SelfAlpha
-        }
-        _ => AlphaMode::KeyColor,
-    }
+    // color_type() は ImageDecoder トレイトのメソッド。IHDR チャンクのみ参照する
+    matches!(
+        decoder.color_type(),
+        ColorType::Rgba8 | ColorType::La8 | ColorType::Rgba16 | ColorType::La16
+    )
 }
 
 #[cfg(not(feature = "thumbnail"))]
-fn detect_thumbnail_alpha(_path: &Path) -> AlphaMode {
-    AlphaMode::KeyColor
+fn png_has_alpha_channel(_path: &Path) -> bool {
+    false
+}
+
+/// thumbnail.png のアルファチャンネルの有無を AlphaMode へ写す。
+/// アルファ持ちなら SelfAlpha、なければ KeyColor。
+fn detect_thumbnail_alpha(path: &Path) -> AlphaMode {
+    if png_has_alpha_channel(path) {
+        AlphaMode::SelfAlpha
+    } else {
+        AlphaMode::KeyColor
+    }
 }
 
 #[cfg(test)]
@@ -366,6 +374,51 @@ mod tests {
 
         let alpha = detect_thumbnail_alpha(&path);
         assert_eq!(alpha, AlphaMode::KeyColor);
+    }
+
+    // --- surface0 実画像アルファ検査（宣言より実体を優先） ---
+
+    #[cfg(feature = "thumbnail")]
+    #[test]
+    fn surface0がrgbaなら宣言なしでもself_alphaになる() {
+        use image::{ImageBuffer, Rgba};
+        let tmp = TempDirGuard::new("ghost_meta_surface_rgba_self_alpha");
+        let shell_master = create_shell_master(tmp.path());
+        // descript も seriko.use_self_alpha 宣言もない。実画像のアルファのみで判定させる
+        let img: image::RgbaImage = ImageBuffer::from_pixel(2, 2, Rgba([0u8, 0, 0, 0]));
+        img.save(shell_master.join("surface0.png")).unwrap();
+
+        let info = resolve_thumbnail(tmp.path(), None).unwrap();
+        assert_eq!(info.alpha, AlphaMode::SelfAlpha);
+    }
+
+    #[cfg(feature = "thumbnail")]
+    #[test]
+    fn surface0がrgbで宣言なしならkey_colorのまま() {
+        use image::{ImageBuffer, Rgb};
+        let tmp = TempDirGuard::new("ghost_meta_surface_rgb_key_color");
+        let shell_master = create_shell_master(tmp.path());
+        // アルファチャンネルを持たない画像は従来どおりキーカラー抜き対象
+        let img: image::RgbImage = ImageBuffer::from_pixel(2, 2, Rgb([0u8, 255, 0]));
+        img.save(shell_master.join("surface0.png")).unwrap();
+
+        let info = resolve_thumbnail(tmp.path(), None).unwrap();
+        assert_eq!(info.alpha, AlphaMode::KeyColor);
+    }
+
+    #[cfg(feature = "thumbnail")]
+    #[test]
+    fn surface0がrgbでも宣言があればself_alphaになる() {
+        use image::{ImageBuffer, Rgb};
+        let tmp = TempDirGuard::new("ghost_meta_surface_rgb_declared_self_alpha");
+        let shell_master = create_shell_master(tmp.path());
+        // アルファ非保持でも descript 宣言があれば SelfAlpha を維持（フォールバック）
+        write_shell_descript(tmp.path(), "charset,UTF-8\nseriko.use_self_alpha,1\n");
+        let img: image::RgbImage = ImageBuffer::from_pixel(2, 2, Rgb([0u8, 255, 0]));
+        img.save(shell_master.join("surface0.png")).unwrap();
+
+        let info = resolve_thumbnail(tmp.path(), None).unwrap();
+        assert_eq!(info.alpha, AlphaMode::SelfAlpha);
     }
 
     #[cfg(not(feature = "thumbnail"))]

--- a/src/components/GhostCard.tsx
+++ b/src/components/GhostCard.tsx
@@ -14,6 +14,7 @@ import {
 import { PlayRegular } from "@fluentui/react-icons";
 import { getSourceFolderLabel } from "../lib/ghostLaunchUtils";
 import { formatErrorDetail } from "../lib/ghostScanUtils";
+import { applyKeyColorAlpha } from "../lib/keyColorAlpha";
 import { launchGhost } from "../lib/sspClient";
 import type { GhostView } from "../types";
 
@@ -173,13 +174,7 @@ const ThumbnailCanvas = memo(function ThumbnailCanvas({ src, className }: { src:
       ctx.drawImage(img, 0, 0);
       try {
         const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
-        const data = imageData.data;
-        const [keyR, keyG, keyB] = [data[0], data[1], data[2]];
-        for (let i = 0; i < data.length; i += 4) {
-          if (data[i] === keyR && data[i + 1] === keyG && data[i + 2] === keyB) {
-            data[i + 3] = 0;
-          }
-        }
+        applyKeyColorAlpha(imageData.data);
         ctx.putImageData(imageData, 0, 0);
       } catch {
         // CORS 等で getImageData が失敗した場合はそのまま表示

--- a/src/lib/keyColorAlpha.test.ts
+++ b/src/lib/keyColorAlpha.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { applyKeyColorAlpha } from "./keyColorAlpha";
+
+describe("applyKeyColorAlpha", () => {
+  it("左上が透明（本物のアルファ持ち）の画像はキー色抜きせず、黒ピクセルを残す", () => {
+    // pixel0: 完全透明の黒（RGBA 読み戻しで RGB は (0,0,0) になる）
+    // pixel1: 不透明の黒（キャラクターの線画・髪など）
+    const data = new Uint8ClampedArray([0, 0, 0, 0, /* */ 0, 0, 0, 255]);
+
+    applyKeyColorAlpha(data);
+
+    // 黒消えバグの回帰防止: 不透明な黒ピクセルのアルファは維持される
+    expect(data[7]).toBe(255);
+    // もともと透明なピクセルは透明のまま
+    expect(data[3]).toBe(0);
+  });
+
+  it("左上が不透明なキー色（緑）の画像は、一致ピクセルを透明化し黒は残す", () => {
+    // pixel0: 不透明の緑（キー色）
+    // pixel1: 不透明の黒（キャラクター本体）
+    // pixel2: 不透明の緑（背景）
+    const data = new Uint8ClampedArray([
+      0, 255, 0, 255, /* */ 0, 0, 0, 255, /* */ 0, 255, 0, 255,
+    ]);
+
+    applyKeyColorAlpha(data);
+
+    expect(data[3]).toBe(0); // 緑キー色 → 透明
+    expect(data[7]).toBe(255); // 黒 → 維持
+    expect(data[11]).toBe(0); // 緑キー色 → 透明
+  });
+});

--- a/src/lib/keyColorAlpha.ts
+++ b/src/lib/keyColorAlpha.ts
@@ -1,0 +1,18 @@
+// KeyColor 透過アルゴリズム。
+// 左上ピクセルをキー色として読み取り、一致するピクセルを透明化する。
+// RGBA 配列（ImageData.data 形式）を破壊的に書き換える。
+export function applyKeyColorAlpha(data: Uint8ClampedArray): void {
+  const keyR = data[0];
+  const keyG = data[1];
+  const keyB = data[2];
+  const keyA = data[3];
+  // 左上が不透明でない = 画像が本物のアルファチャンネルを持つ。
+  // このときキー色（透明ピクセルの RGB は読み戻しで (0,0,0) に化ける）で
+  // 抜くと黒い線画・髪などが消えるため、native alpha を尊重して抜かない。
+  if (keyA < 255) return;
+  for (let i = 0; i < data.length; i += 4) {
+    if (data[i] === keyR && data[i + 1] === keyG && data[i + 2] === keyB) {
+      data[i + 3] = 0;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- 本物のアルファチャンネルを持つ RGBA surface（例: `seriko.use_self_alpha` 未宣言の APNG）が KeyColor 経路へ誤送され、canvas 読み戻しで透明ピクセルの RGB が `(0,0,0)` に化けてキー色=黒となり、立ち絵の黒い線画・髪・濃色部が全消えする不具合を修正。
- **バックエンド（根本修正）**: `resolve_surface0` で選択した surface 画像の実 color type を検査し、アルファチャンネルを持つ（RGBA / グレースケール+アルファ）場合は descript 宣言に関わらず `SelfAlpha` と判定 → フロントは `<img>` 経路（native alpha ＋ APNG アニメーション再生）。`detect_thumbnail_alpha` と共有する `png_has_alpha_channel`（IHDR のみ読む）を抽出。
- **フロント（多層防御）**: キー色抜きロジックを純粋関数 `applyKeyColorAlpha` へ抽出し、左上ピクセルが不透明でない（＝本物のアルファ持ち）ときはキー色抜きを行わず native alpha を尊重するガードを追加。単体テスト付き。
- 判定変更は `diff_fingerprint` に含まれるため、**再読込（強制フルスキャン）で既存キャッシュへ伝播**する。
- SPEC.md の `thumbnail_use_self_alpha` の判定仕様を同期。

## Test plan
- [x] `npm run build`
- [x] `npm test`（151 passed）
- [x] `npm run check:ui-guidelines` / `npm run test:ui-guidelines-check`
- [x] `cargo test --workspace`
- [x] `cargo test -p ghost-meta --features thumbnail,serde`（34 passed）＋ 非 feature 構成（30 passed）
- [x] 実機確認: 実 `Roche_Limit` シェルで再読込→ホバー時に黒い線画・濃色部が保持され、周囲は正しく透過（実ファイル `surface0.apng` が RGBA と実測、`resolve_thumbnail` が `SelfAlpha` を返すことも確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)