### PR TITLE
chore: target フォルダ肥大化対策として profile.dev 縮小と cargo-sweep 導入

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,9 @@ npm run e2e:setup
 
 # E2E テストの実行（事前に npm run tauri build が必要）
 npm run e2e
+
+# target フォルダ肥大化時のクリーン（30日以上未使用のビルド成果物を削除。要 cargo install cargo-sweep）
+cargo sweep -t 30 .
 ```
 
 ## ディレクトリ構成

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,11 @@ resolver = "2"
 [workspace.dependencies]
 encoding_rs = "0.8"
 
+[profile.dev]
+# フル debug info は不要（行番号ベースのブレークポイントで十分）。target/debug の
+# デバッグシンボルサイズを削減し、ディスク肥大化を抑える。
+debug = "line-tables-only"
+
 [profile.release]
 lto = true
 codegen-units = 1


### PR DESCRIPTION
## Summary
- ルート Cargo.toml に `[profile.dev] debug = "line-tables-only"` を追加し、debug ビルドのデバッグシンボルサイズを削減（行番号ベースのブレークポイントは維持）
- cargo-sweep を導入し、未使用ビルド成果物を手動でクリーンする手順を CLAUDE.md のコマンド一覧に追記
- 調査の過程で、既存の `src-tauri/target`（22.2GB）が現行のワークスペース構成では実際には使われていない残骸だったと判明し、cargo clean で解放済み（実際のビルド先はワークスペースルートの `target/`）

## Test plan
- [x] `npm run build`
- [x] `npm test`
- [x] `npm run check:ui-guidelines`
- [x] `npm run test:ui-guidelines-check`
- [x] `cargo test --workspace`
- [x] `cargo test -p ghost-meta --features thumbnail,serde`
- [x] `cargo check --workspace` と `npx tauri build --debug --no-bundle` で target 生成先とビルド成功を実測確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)