### PR TITLE
docs: git ワークフロー系スキルを標準 git へ簡素化

### DIFF
--- a/.claude/skills/post-merge-sync/SKILL.md
+++ b/.claude/skills/post-merge-sync/SKILL.md
@@ -8,7 +8,7 @@ disable-model-invocation: true
 
 GitHub 上で PR がマージされた後、ローカル `main` を最新化し、作業ブランチを安全に削除する。
 
-> **この環境固有の制約（gh-HTTPS 方式の正典）**: `origin`（`git@github.com:finelagusaz/ghost_launcher.git`、SSH）への `git push`/`fetch` は `~/.ssh/config` の ACL で失敗する。`gh` はトークン認証済みのため、HTTPS + gh 資格情報ヘルパーで迂回する。SSH remote にも永続 git config にも触れない。この「gh-HTTPS 方式」の理由はこのスキルが一次記述であり、`/pr`・`/start-issue` は操作（push/pull）だけ差し替えて同方式を参照する。
+> `origin` は HTTPS remote、認証は Git Credential Manager が担うため、標準の `git pull`/`git push origin` がそのまま通る。特別な迂回は不要。
 
 ## 引数
 
@@ -22,33 +22,16 @@ gh pr view <PR番号 or ブランチ> --json number,state,headRefName,mergedAt
 
 `state` が `MERGED` でなければ中断し「PR がまだマージされていません」と伝える。`headRefName` を対象ブランチ名として控える。
 
-## ステップ 2: リモートブランチの削除（API 経由）
+> リモートブランチは GitHub の auto-delete-on-merge 設定でマージ時に自動削除される。手動削除は不要。万一残っていれば `git push origin --delete <branch>` で消す。
 
-```bash
-gh api -X DELETE repos/finelagusaz/ghost_launcher/git/refs/heads/<branch>
-```
-
-（GitHub の自動削除設定で既に消えている場合は 404。無視してよい。）
-
-## ステップ 3: main をローカル同期（gh-HTTPS）
+## ステップ 2: main をローカル同期
 
 ```bash
 git switch main
-git -c credential.helper= -c credential.helper='!gh auth git-credential' \
-  pull https://github.com/finelagusaz/ghost_launcher.git main --ff-only
+git pull origin main --ff-only
 ```
 
-## ステップ 4: 追跡参照を整える
-
-URL 指定の pull は `refs/remotes/origin/main` を更新しないため、`status` が "ahead by N" と誤表示する。`update-ref` で揃える:
-
-```bash
-git update-ref refs/remotes/origin/main "$(git rev-parse main)"
-```
-
-> **禁止**: `git fetch <url> main:refs/remotes/origin/main` は `refs/remotes/origin/main` と `origin/HEAD` を壊して `[gone]` 化させる。追跡参照の同期は必ず `update-ref` で行う。
-
-## ステップ 5: ローカル作業ブランチの削除
+## ステップ 3: ローカル作業ブランチの削除
 
 ```bash
 git branch -D <branch>
@@ -56,6 +39,6 @@ git branch -D <branch>
 
 （スカッシュマージでは元コミットが main の祖先に入らないため `-d` は「未マージ」と誤検知する。内容が取り込まれているかは `git diff main..<branch> --stat` がほぼゼロであることで確認済みなら `-D` で削除してよい。）
 
-## ステップ 6: 結果の報告
+## ステップ 4: 結果の報告
 
 `git log --oneline -3 main` と `git status` を示し、main が最新・作業ツリーが clean になったことを伝える。

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -37,16 +37,13 @@ git log --oneline main..HEAD  # PR に含まれるコミット一覧
 - **影響範囲**: どのモジュール・レイヤーに変更が及んでいるか
 - **要点**: ユーザーが PR レビュアーに伝えたい核心は何か
 
-### ステップ 3: リモートへの push（gh-HTTPS）
-
-> SSH push が `~/.ssh/config` の ACL で失敗するため、`/post-merge-sync` の「gh-HTTPS 方式」で迂回する（理由の詳細は同スキルが正典）。操作は push のみ差し替える。SSH remote にも永続 git config にも触れない。
+### ステップ 3: リモートへの push
 
 ```bash
-git -c credential.helper= -c credential.helper='!gh auth git-credential' \
-  push https://github.com/finelagusaz/ghost_launcher.git HEAD
+git push -u origin HEAD
 ```
 
-URL 指定の push は upstream を設定しないため、`gh pr create` には `--head <ブランチ名>` を明示する。
+`-u` で upstream を張るため、以降 `gh pr create` は現在のブランチを自動で head に取る（`--head <ブランチ名>` の明示は任意）。
 
 ### ステップ 4: PR の作成
 

--- a/.claude/skills/start-issue/SKILL.md
+++ b/.claude/skills/start-issue/SKILL.md
@@ -23,15 +23,11 @@ gh issue view <N>
 
 `git status` が "nothing to commit, working tree clean" であることを確認する。未コミット変更がある場合は中断し、ユーザーに退避（コミット or stash）を確認する。
 
-## ステップ 3: main の最新化（gh-HTTPS）
-
-> SSH push/fetch が失敗するため、`/post-merge-sync` の「gh-HTTPS 方式」で迂回する（理由の詳細は同スキルが正典）。操作は pull + update-ref のみ差し替える。
+## ステップ 3: main の最新化
 
 ```bash
 git switch main
-git -c credential.helper= -c credential.helper='!gh auth git-credential' \
-  pull https://github.com/finelagusaz/ghost_launcher.git main --ff-only
-git update-ref refs/remotes/origin/main "$(git rev-parse main)"
+git pull origin main --ff-only
 ```
 
 ## ステップ 4: ブランチ作成

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,7 @@ ghost_launcher/
 | `/retrospective` | サイクル終了後 | 教訓抽出→RETROSPECTIVE.md 上書き |
 | `/deps-update` | 依存更新時 | cargo/npm 一括更新と検証 |
 | `/commit` | コミット時 | コミット前チェックリスト実行→コミット |
-| `/pr` | PR 作成時 | 変更分析→gh-HTTPS push→PR 作成 |
+| `/pr` | PR 作成時 | 変更分析→push→PR 作成 |
 | `/e2e` | E2E 実行時 | 環境固有の E2E 実行手順 |
 | `/post-merge-sync` | PR マージ後 | main 同期・ブランチ後始末 |
 


### PR DESCRIPTION
## Summary
- git 問題（SSH ACL）の解消に伴い、`post-merge-sync`（正典）・`/pr`・`/start-issue` の「gh-HTTPS 方式」迂回手順を撤去し、標準 git へ復帰
- API 経由リモートブランチ削除・URL 直指定 pull/push・`update-ref` による追跡参照補正・fetch 禁止令を廃し、`git pull/push origin` と auto-delete-on-merge に委任（`post-merge-sync` は 6→4 ステップへ軽量化）
- `CLAUDE.md` スキル表の「gh-HTTPS push」表記を修正

## Test plan
docs-only 変更のためコード系ゲート（build/test/cargo）は非該当。振る舞いの前提を実測で裏取り:
- [x] `origin` は HTTPS・認証は Git Credential Manager・素の `git push origin` 動作をユーザー確認済み → gh 資格情報ヘルパー全廃
- [x] `delete_branch_on_merge: true` を確認 → リモート削除ステップを撤去（マージ時に自動削除）
- [x] `remote.origin.fetch` が標準 refspec（`+refs/heads/*:refs/remotes/origin/*`）を確認 → `update-ref` 撤去でも `origin/main` は自動追随
- [x] 生きているファイルへの迂回路参照はゼロ（`git grep` 掃討。歴史記録 `docs/superpowers/{specs,plans}` は意図的に温存）
- [x] `git push -u origin HEAD` の実地動作（本 PR の push で確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)