### PR TITLE
test: 10万体規模の性能計測ハーネス（SQL層/FS走査層）を新設

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "anyhow"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,6 +393,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -440,6 +458,58 @@ dependencies = [
  "serde",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "combine"
@@ -550,6 +620,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -591,6 +697,12 @@ name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1309,6 +1421,7 @@ dependencies = [
 name = "ghost-launcher"
 version = "0.1.0"
 dependencies = [
+ "criterion",
  "encoding_rs",
  "ghost-meta",
  "rayon",
@@ -1485,6 +1598,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1548,6 +1672,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1873,6 +2003,26 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -2499,6 +2649,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2676,6 +2832,34 @@ dependencies = [
  "quick-xml",
  "serde",
  "time",
+]
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
 ]
 
 [[package]]
@@ -4386,6 +4570,16 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/docs/perf/baseline-100k.md
+++ b/docs/perf/baseline-100k.md
@@ -1,0 +1,103 @@
+# 性能ベースライン（10万体規模）
+
+- 計測日: 2026-07-16
+- 目的: 修正の優先順位を実測で決めるためのベースライン。修正は本数値を根拠に別サイクル。
+
+## 実行環境
+
+- OS: Microsoft Windows 11 Pro 64 ビット（10.0.26200）
+- CPU: AMD Ryzen 7 9700X 8-Core Processor（8 コア / 16 論理プロセッサ）
+- メモリ: 約 32 GB
+- ディスク: SSD（`Get-PhysicalDisk` で確認した 2 台とも `MediaType=SSD`。ワークスペースは SSD 上）
+- ビルドプロファイル: `bench` プロファイル（`cargo bench --features bench`。release 最適化を継承）
+- SQL 層（search_bench）: 同一プロセス内で同一 DB 接続に対し criterion の warm-up（3 秒）後に繰り返しクエリを発行するため、OS ページキャッシュ・SQLite ページキャッシュともに温まった定常状態（warm-cache）での計測。
+- FS 走査層（scan_bench）: ツリー生成直後に同一プロセス内で繰り返し走査するため、NTFS メタデータ・ファイル内容ともに OS キャッシュが温まった状態（warm）での計測。ディスクからの実読み込みを伴うコールドキャッシュのシナリオより高速に出ている可能性がある点に留意。
+
+## 実行手順
+
+```bash
+cargo bench --manifest-path src-tauri/Cargo.toml --features bench --bench search_bench
+cargo bench --manifest-path src-tauri/Cargo.toml --features bench --bench scan_bench
+```
+
+## SQL 層（search_bench）
+
+### EXPLAIN QUERY PLAN（n=1000）
+
+```
+--- empty+name ---
+  SEARCH g USING INDEX idx_ghosts_request_key_name_lower (request_key=?)
+--- like+name ---
+  SEARCH g USING INDEX idx_ghosts_request_key_name_lower (request_key=?)
+--- empty+recent ---
+  SCAN g
+  USE TEMP B-TREE FOR ORDER BY
+--- empty+frequency ---
+  SCAN g
+  USE TEMP B-TREE FOR ORDER BY
+--- empty+random ---
+  SEARCH g USING INDEX idx_ghosts_request_key_identity_fingerprint (request_key=?)
+  USE TEMP B-TREE FOR ORDER BY
+```
+
+**判定**: `like+name`（先頭ワイルドカード LIKE 付き）も `empty+name`（検索語なし）と全く同じ `SEARCH g USING INDEX idx_ghosts_request_key_name_lower (request_key=?)` になる。これは **LIKE 自体が index 最適化された訳ではない**。複合 index `idx_ghosts_request_key_name_lower` が `request_key` の等値条件でパーティションを絞り込み、かつ index の並び順がそのまま `ORDER BY name_lower` を満たすために index が選ばれているだけであり、`%…%` の LIKE 条件はそのパーティション内を行ごとに評価する残余フィルタとして働く（index にはヒットせず、行ごとの文字列比較になる）。
+
+`empty+recent` / `empty+frequency` は `SCAN g` + `USE TEMP B-TREE FOR ORDER BY`（`request_key` の絞り込みにすら index が使われず、全表相当のスキャン＋全件を一時 B-Tree でソート）。`empty+random` は `request_key` の絞り込みには別 index（`idx_ghosts_request_key_identity_fingerprint`、たまたま request_key を前方に含む別の複合 index）が使われるが、ORDER BY 式（`(g.id * 定数) % 定数` の計算式）は index 化できないため、こちらも `USE TEMP B-TREE FOR ORDER BY` になる。3 ソート形状（recent/frequency/random）はいずれも並び替えに index を使えず全件を一時 B-Tree でソートする点で共通する。
+
+### レイテンシ中央値
+
+| 形状 | n=1k | n=10k | n=100k |
+|---|---|---|---|
+| empty_sort/name | 30.08 µs | 30.36 µs | 31.91 µs |
+| empty_sort/recent | 151.05 µs | 1.4095 ms | 13.993 ms |
+| empty_sort/frequency | 148.60 µs | 1.4107 ms | 14.343 ms |
+| empty_sort/random | 149.23 µs | 610.08 µs | 7.1803 ms |
+| like/none | 247.75 µs | 9.7022 ms | 116.84 ms |
+| like/rare | 250.65 µs | 9.7459 ms | 42.186 ms |
+| like/common | 186.25 µs | 5.7838 ms | 68.390 ms |
+| offset/0 | 32.74 µs | 30.53 µs | 33.20 µs |
+| offset/mid | 40.39 µs | 119.27 µs | 1.0168 ms |
+| offset/deep | 52.23 µs | 208.52 µs | 4.0289 ms |
+| count_plus_select_common | 310.10 µs | 7.5121 ms | 89.719 ms |
+
+（値は criterion の `time: [下限 中央値 上限]` の中央値。）
+
+**like/rare と like/common の逆転について（フィクスチャ由来・一般化不可）**: n=100k で `like/rare`（42.186 ms）が `like/common`（68.390 ms）より速いという、素朴な「マッチ率が高いほど早期終了で速い」という予測に反する結果が出た。原因は `bench_support.rs::synth_ghost` の合成データ生成ロジックにある。`Q_RARE`（`craftman='作者777'`、`i % 1000 == 777`）にマッチする行は必ず `i` が奇数かつ `i % 5 == 2` になるため、名前が例外なく `en[2]="Ghost"` 由来の `"Ghost{i}"` になる。この "Ghost" プレフィックスは ASCII のため `name_lower` 順で非常に早い位置に集まり、`ORDER BY name_lower LIMIT 50` が早期に 50 件へ到達する。一方 `Q_COMMON`（`name` が `"さくら…"`、`i % 10 == 0`）はソートキーである `name_lower` 自身が一致条件のため、集団は "さくら" の Unicode 位置（全角カタカナ・漢字圏内、他の日本語プレフィックスの中間あたり）まで走査が進んでから初めて見つかる。この逆転は **合成データにおける「マッチ列と並び替え列の相関」というフィクスチャ固有の副作用であり、一般化できる知見ではない**（実データでは craftman と name は独立なので、この逆転は起きない見込み）。一般化できる知見は次の一点のみ: **先頭ワイルドカード LIKE は index 最適化されず、`request_key` の絞り込み以降は行ごとの残余フィルタになる**（`like/none` が index 経路の 3662 倍という事実。詳細は後述の所見を参照）。
+
+## FS 走査層（scan_bench）
+
+| 形状 | n=1k | n=10k | n=100k(indicative) |
+|---|---|---|---|
+| full_scan | 26.663 ms | 299.83 ms | 3.4693 s |
+| layer1_hit | 13.195 µs | 13.248 µs | 13.357 µs |
+| store_initial | 8.0681 ms | 66.750 ms | 707.14 ms |
+| store_rescan_nodiff | 722.32 µs | 4.6802 ms | 84.026 ms |
+
+（n=100k は `sample_size=10` の indicative 値。full_scan はツリー生成直後の warm cache 状態での計測であり、コールドキャッシュのディスク読み込みを含まない点に留意。）
+
+**フル走査 − Layer1 hit = 1 体増減で払う代償**: n=100k で 3.4693 s − 0.013357 ms ≈ **3.469 秒**（約 259,800 倍）。NTFS の親ディレクトリ mtime は「配下の何かが変わった」ことしか示さず、どのゴーストが変わったかまでは分からない粒度のため、100k 体中のどれか 1 体を追加・削除・更新しただけで Layer 1（親 mtime 一致判定）がミスし、100k 体全件の再走査（ディレクトリ列挙 + `descript.txt` パース）が発生する。full_scan は N に対しほぼ線形（1k→10k で 11.25 倍、10k→100k で 11.57 倍。単純な線形なら 10 倍のところ、ディレクトリ規模拡大に伴う readdir コスト増でやや超線形）。
+
+## 所見（修正は別サイクル・推奨のみ）
+
+- **検索（LIKE 先頭ワイルドカード）**: `like/none`（0 件マッチ、パーティション全走査）が index 経路（`empty_sort/name`＝31.91 µs）に対し n=100k で **約 3662 倍**（116.84 ms / 31.91 µs）。先頭ワイルドカード `%…%` は index を使えず、`request_key` で絞られたパーティション内を行ごとに走査する残余フィルタになる（前掲 EXPLAIN QUERY PLAN の判定どおり）。さらに `count_plus_select_common`（本番の 1 検索で毎回併走する `countGhostsByQuery`。`LIMIT` なしのため常にパーティション全走査）は index 経路に対し **約 2812 倍**（89.719 ms / 31.91 µs）で、これはマッチ密度に依らず**検索 1 回ごとに必ず払う不可避コスト**である。→ FTS5 or 前方一致（`LIKE 'prefix%'`、先頭ワイルドカードなしなら index 利用可）の検討。
+- **全走査（Layer 1 ミス時のフル再走査）**: `full_scan` が `layer1_hit` に対し n=100k で **約 259,800 倍**（絶対値では 3.469 秒）。全計測項目中で最大の絶対レイテンシであり、NTFS 親 mtime 粒度ゆえゴースト 1 体の増減だけで 100k 体全件の walk+parse が走る。→ fingerprint 粒度細分化（子ディレクトリ単位の変更検知）or 進捗 UI/streaming。
+- **ソート（TEMP B-TREE 全ソート）**: `recent`/`frequency`/`random` が `name`（index-ordered top-N）に対し n=100k でそれぞれ **約 438 倍・449 倍・225 倍**（13.993 ms / 14.343 ms / 7.1803 ms ÷ 31.91 µs）。3 ソートとも EXPLAIN QUERY PLAN で `USE TEMP B-TREE FOR ORDER BY` が出ており、全件を一時 B-Tree でソートしてから LIMIT している。→ `(request_key, launch_count)` 等の複合 index。
+- **OFFSET（深いページングの線形コスト）**: `offset/deep` が `offset/0` に対し n=100k で **約 121 倍**（4.0289 ms / 33.20 µs）。SQLite の `OFFSET` は指定件数分を読み飛ばすだけで index シークできないため、深いページほど線形に悪化する。→ keyset ページング（前ページ最終行の `name_lower` を境界にした `WHERE name_lower > ?` 方式）。
+
+**推奨優先順位**（絶対レイテンシ × 発生頻度で判断。単純な倍率の大小だけでは優先度を誤る）:
+
+1. **全走査（Layer 1 ミス時のフル再走査）** — 倍率・絶対値とも最大（3.469 秒/回）。ゴースト 1 体の追加・削除という日常的な操作のたびに、100k 体規模ではユーザーが数秒間 UI フリーズを体感しうる。N に対しほぼ線形なので、より小規模な環境でも比例して重くなる。
+2. **検索 LIKE 先頭ワイルドカード** — 倍率は全走査に次ぐが、**検索ボックスの 1 キー入力ごと**に発生する最頻の操作であり、`count_plus_select` の不可避コスト（約 90 ms/回）は数千体規模でも累積的な体感遅延になりうる。
+3. **ソート（recent/frequency/random の TEMP B-TREE）** — 絶対値は 13〜14 ms とキー入力ほど頻度は高くないが、タブ切り替え・起動直後の既定ソート表示のたびに発生しうる。
+4. **OFFSET 深いページング** — 絶対値が最小（4 ms 程度）かつ、本アプリの UI 上で深いページングが頻繁に発生する操作パターンかは未確認。優先度は最も低い。
+
+## 回帰確認（Step 4）
+
+feature 無効の通常ビルド・テストが崩れていないことを確認した（本番 API 不変）。
+
+| コマンド | 結果 |
+|---|---|
+| `cargo test --manifest-path src-tauri/Cargo.toml` | PASS |
+| `cargo check --manifest-path src-tauri/Cargo.toml` | PASS |
+| `npm test` | PASS（22 files / 176 tests） |
+| `npm run build` | PASS |

--- a/docs/perf/baseline-100k.md
+++ b/docs/perf/baseline-100k.md
@@ -75,6 +75,8 @@ cargo bench --manifest-path src-tauri/Cargo.toml --features bench --bench scan_b
 
 （n=100k は `sample_size=10` の indicative 値。full_scan はツリー生成直後の warm cache 状態での計測であり、コールドキャッシュのディスク読み込みを含まない点に留意。）
 
+**store 行の計測条件（PRAGMA）に関する注記**: `store_initial` / `store_rescan_nodiff` は、ベンチが `open_bench_db` で開いた**読み取り経路 PRAGMA**（本番 `loadDb` 準拠。`synchronous=FULL`・SQLite ページキャッシュ約 2 MB・mmap なし）の接続上で `store_ghosts` を計測している。一方、本番の書き込み経路（`scan_and_store` が `configure_connection` で張る `synchronous=NORMAL`・`cache_size≈64 MB`・`temp_store=MEMORY`・`mmap_size=128 MB`）は本値より速いため、これらの store 行は**本番書込よりやや悲観的（遅め）に出ている可能性がある上界**とみなすべき（特に `store_rescan_nodiff` の既存行カバリング index 読み取りは cache サイズ差の影響を受ける）。ヘッドラインの `full_scan`（純 FS・PRAGMA 非依存）・`layer1_hit`（indexed 1 行 + FS stat・実質 PRAGMA 非依存）・および SQL 層の検索/ソート/OFFSET 指標（正しい読み取り接続で計測）はこの差の影響を受けず、下記の推奨優先順位は変わらない。
+
 **フル走査 − Layer1 hit = 1 体増減で払う代償**: n=100k で 3.4693 s − 0.013357 ms ≈ **3.469 秒**（約 259,800 倍）。NTFS の親ディレクトリ mtime は「配下の何かが変わった」ことしか示さず、どのゴーストが変わったかまでは分からない粒度のため、100k 体中のどれか 1 体を追加・削除・更新しただけで Layer 1（親 mtime 一致判定）がミスし、100k 体全件の再走査（ディレクトリ列挙 + `descript.txt` パース）が発生する。full_scan は N に対しほぼ線形（1k→10k で 11.25 倍、10k→100k で 11.57 倍。単純な線形なら 10 倍のところ、ディレクトリ規模拡大に伴う readdir コスト増でやや超線形）。
 
 ## 所見（修正は別サイクル・推奨のみ）

--- a/docs/superpowers/plans/2026-07-16-perf-benchmark-harness.md
+++ b/docs/superpowers/plans/2026-07-16-perf-benchmark-harness.md
@@ -1,0 +1,1316 @@
+# 10万体規模の性能計測ハーネス Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 10万体規模のゴーストでどこが性能ボトルネックになるかを実測するため、SQL層(search/sort/OFFSET)とFS走査層(scan/fingerprint/store)を計測する常設ハーネスとベースライン数値を構築する。
+
+**Architecture:** `bench` feature 下でのみ本番内部関数を最小限 pub 露出し、`bench_support` モジュールが合成フィクスチャ生成器(SQL seeder / FS tree generator)と本番経路への薄いラッパーを提供する。criterion ベンチ2本(`search_bench` / `scan_bench`)がそれを駆動し、`EXPLAIN QUERY PLAN` と N を振ったレイテンシを吐く。修正は本ハーネスの数値を見て別サイクルで行う。
+
+**Tech Stack:** Rust (rusqlite 0.32 bundled, rayon, unicode-normalization, encoding_rs), criterion 0.5, TypeScript/vitest(パリティテスト)。
+
+## Global Constraints
+
+- **rusqlite は 0.32 に固定**（`tauri-plugin-sql` の libsqlite3-sys 共有制約。`src-tauri/CLAUDE.md`）。criterion は sqlite にリンクしない純 Rust dev-dependency ゆえ制約に影響しない。
+- **`bench` feature は本番 API・可視性を変えてはならない**。露出はすべて `#[cfg(feature = "bench")]` ガード下に置き、feature 無効の `cargo build`/`cargo check` は従来通り通ること。
+- **既にリリース・コミット済みの migration SQL は絶対に編集しない**（sqlx チェックサム。`src-tauri/CLAUDE.md`）。本計画は migration を追加も編集もしない。
+- **コードコメントは日本語**。UI テキストは日本語。
+- Rust edition 2024 / rust-version 1.93。
+- 検索の WHERE 列・ORDER BY 式は `src/lib/ghostDatabase.ts` が真の権威。ベンチ側の複製は共有 fixture `src/test/fixtures/search-sql-shapes.json` でパリティを縛る。
+- FS フィクスチャの生成先は scratchpad の temp（非コミット）。`TempDirGuard`（`src-tauri/src/testutil.rs`）流儀で確実削除する。
+
+---
+
+## Task 1: bench feature の配線と bench_support スケルトン
+
+feature フラグ・criterion 依存・feature ゲート付き再エクスポート・空の `bench_support` を用意し、`--features bench` あり/なし双方でコンパイルが通る土台を作る。
+
+**Files:**
+- Modify: `src-tauri/Cargo.toml`（`[features]`・`[dev-dependencies]` に criterion 追加）
+- Modify: `src-tauri/src/lib.rs:4` 付近（`pub(crate) mod testutil;` の並びに feature ゲート付き `pub mod bench_support;` を追加）
+- Modify: `src-tauri/src/commands/ghost/mod.rs:6` 付近（`mod types;` の後に feature ゲート付き再エクスポート）
+- Create: `src-tauri/src/bench_support.rs`
+
+**Interfaces:**
+- Produces: `#[cfg(feature = "bench")] pub mod bench_support`（クレートルート）。以降のタスクが中身を埋める。
+- Produces（feature ゲート下の crate 内可視化）: `crate::commands::ghost::{Ghost, scan_ghosts_with_fingerprint_internal, check_parent_mtimes_match, collect_parent_mtimes}`。
+
+- [ ] **Step 1: criterion を dev-dependency に追加**
+
+`src-tauri/Cargo.toml` の `[dev-dependencies]` を次にする（`ts-rs` は既存）:
+
+```toml
+[features]
+bench = []
+
+[dev-dependencies]
+ts-rs = "12"
+criterion = "0.5"
+```
+
+- [ ] **Step 2: ghost モジュールに feature ゲート付き再エクスポートを追加**
+
+`src-tauri/src/commands/ghost/mod.rs` の先頭のモジュール宣言群（`mod types;` まで）の直後に追記する:
+
+```rust
+// ベンチ計測用の内部関数・型の最小露出。feature 無効時は一切影響しない。
+#[cfg(feature = "bench")]
+pub(crate) use fingerprint::{check_parent_mtimes_match, collect_parent_mtimes};
+#[cfg(feature = "bench")]
+pub(crate) use scan::scan_ghosts_with_fingerprint_internal;
+#[cfg(feature = "bench")]
+pub(crate) use types::Ghost;
+```
+
+- [ ] **Step 3: lib.rs に bench_support モジュールを宣言**
+
+`src-tauri/src/lib.rs` の `pub(crate) mod testutil;`（4 行目付近）の直後に追記する:
+
+```rust
+#[cfg(feature = "bench")]
+pub mod bench_support;
+```
+
+- [ ] **Step 4: bench_support.rs にスモークテスト付きスケルトンを作成**
+
+`src-tauri/src/bench_support.rs` を新規作成する:
+
+```rust
+//! 10万体規模の性能計測用フィクスチャ生成器と本番経路ラッパー。
+//! `bench` feature 有効時のみコンパイルされ、本番ビルドには含まれない。
+
+use rusqlite::Connection;
+
+/// クレートルートから内部経路へ到達できることを確認するプレースホルダ。
+/// 後続タスクで seeder / generator / wrapper に置き換える。
+#[doc(hidden)]
+pub fn __bench_support_linked() -> bool {
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bench_support_がリンクされる() {
+        assert!(__bench_support_linked());
+    }
+
+    #[test]
+    fn 内部型と関数へ到達できる() {
+        // 再エクスポート4種すべての疎通確認（import できてコンパイルが通れば可視性は正しい）。
+        // 全てに触れることで feature ビルドの unused 警告も防ぐ。
+        use crate::commands::ghost::{
+            check_parent_mtimes_match, collect_parent_mtimes,
+            scan_ghosts_with_fingerprint_internal, Ghost,
+        };
+        let _ = std::mem::size_of::<Ghost>();
+        let _ = collect_parent_mtimes as fn(&str, &[String]) -> String;
+        let _ = check_parent_mtimes_match as fn(&Connection, &str, &str) -> bool;
+        let _ = scan_ghosts_with_fingerprint_internal
+            as fn(&str, &[String]) -> Result<(Vec<Ghost>, String), String>;
+    }
+}
+```
+
+- [ ] **Step 5: 両ビルドが通ることを確認**
+
+Run:
+```bash
+cargo check --manifest-path src-tauri/Cargo.toml
+cargo test --manifest-path src-tauri/Cargo.toml --features bench bench_support
+```
+Expected: 1つ目（feature 無効）が警告なく通る。2つ目で `bench_support::tests` の2件が PASS。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src-tauri/Cargo.toml src-tauri/src/lib.rs src-tauri/src/commands/ghost/mod.rs src-tauri/src/bench_support.rs
+git commit -m "$(cat <<'EOF'
+test: 性能計測ハーネスの bench feature 配線と bench_support スケルトン
+
+bench feature 下でのみ内部関数(scan/fingerprint/Ghost)を最小露出し、
+本番ビルドには一切影響しない土台を作る。
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: SQL seeder（FS 非依存の行投入）
+
+一時ファイル DB に本番読み取り接続と同じ PRAGMA を設定し、現実寄せ分布の N 行を本番の `store_ghosts` 経由で投入する。recent/frequency ソートの現実性のため起動集計列をばらけさせる。
+
+**Files:**
+- Modify: `src-tauri/src/bench_support.rs`
+- Test: `src-tauri/src/bench_support.rs`（`#[cfg(test)] mod tests`）
+
+**Interfaces:**
+- Consumes: `crate::commands::ghost::Ghost`、`crate::commands::ghost::store::{store_ghosts, configure_connection}`、`crate::migrations()`。
+- Produces:
+  - `pub fn open_bench_db(path: &std::path::Path) -> Result<Connection, String>` — migrations 適用 + 本番読み取り PRAGMA。
+  - `pub fn seed_ghosts_db(conn: &Connection, request_key: &str, n: usize) -> Result<(), String>` — N 行投入 + 起動集計列 sprinkle。
+  - クエリ定数: `pub const Q_NONE: &str`（0件）, `pub const Q_RARE: &str`（~0.1%）, `pub const Q_COMMON: &str`（~10%）。
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`src-tauri/src/bench_support.rs` の `mod tests` に追加する:
+
+```rust
+use crate::testutil::TempDirGuard;
+
+#[test]
+fn seed_ghosts_db_が_n_行を投入する() {
+    let tmp = TempDirGuard::new("bench_seed_count");
+    let db = tmp.path().join("ghosts.db");
+    let conn = open_bench_db(&db).unwrap();
+    seed_ghosts_db(&conn, "rk", 500).unwrap();
+
+    let count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM ghosts WHERE request_key = ?1",
+            ["rk"],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(count, 500);
+}
+
+#[test]
+fn seed_ghosts_db_が_lower_列を正規化する() {
+    let tmp = TempDirGuard::new("bench_seed_lower");
+    let db = tmp.path().join("ghosts.db");
+    let conn = open_bench_db(&db).unwrap();
+    seed_ghosts_db(&conn, "rk", 50).unwrap();
+
+    // name_lower は全て小文字（NFKC + lower 済み）
+    let bad: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM ghosts WHERE request_key='rk' AND name_lower != lower(name_lower)",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(bad, 0);
+}
+
+#[test]
+fn seed_ghosts_db_が起動集計列をばらけさせる() {
+    let tmp = TempDirGuard::new("bench_seed_launch");
+    let db = tmp.path().join("ghosts.db");
+    let conn = open_bench_db(&db).unwrap();
+    seed_ghosts_db(&conn, "rk", 400).unwrap();
+
+    let launched: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM ghosts WHERE request_key='rk' AND last_launched IS NOT NULL",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    // 一部のみ非 NULL（全 NULL でも全非 NULL でもない）
+    assert!(launched > 0 && launched < 400);
+}
+
+#[test]
+fn クエリセットの選択率が意図の桁に収まる() {
+    let tmp = TempDirGuard::new("bench_seed_selectivity");
+    let db = tmp.path().join("ghosts.db");
+    let conn = open_bench_db(&db).unwrap();
+    seed_ghosts_db(&conn, "rk", 10_000).unwrap();
+
+    let count = |q: &str| -> i64 {
+        let like = format!("%{}%", q);
+        conn.query_row(
+            "SELECT COUNT(*) FROM ghosts WHERE request_key='rk' AND \
+             (name_lower LIKE ?1 OR sakura_name_lower LIKE ?1 OR kero_name_lower LIKE ?1 \
+              OR craftman_lower LIKE ?1 OR craftmanw_lower LIKE ?1 OR directory_name_lower LIKE ?1)",
+            [like],
+            |r| r.get(0),
+        )
+        .unwrap()
+    };
+    assert_eq!(count(Q_NONE), 0);
+    assert!(count(Q_RARE) > 0 && count(Q_RARE) < 100); // ~0.1% = ~10
+    assert!(count(Q_COMMON) > 500); // ~10% = ~1000
+}
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml --features bench bench_support::tests`
+Expected: FAIL（`open_bench_db`/`seed_ghosts_db`/`Q_NONE` 未定義でコンパイルエラー）。
+
+- [ ] **Step 3: seeder を実装**
+
+`src-tauri/src/bench_support.rs` の冒頭 use と本体を実装する（`__bench_support_linked` は残してよい）:
+
+```rust
+use std::path::Path;
+
+use rusqlite::Connection;
+
+use crate::commands::ghost::store::{configure_connection, store_ghosts};
+use crate::commands::ghost::Ghost;
+
+/// どの行にもマッチしない語（0 件）
+pub const Q_NONE: &str = "該当なし_zzzq";
+/// 約 0.1% にマッチ（craftman が "作者777" の行 = i % 1000 == 777）
+pub const Q_RARE: &str = "作者777";
+/// 約 10% にマッチ（name が "さくら…" の行 = i % 10 == 0）
+pub const Q_COMMON: &str = "さくら";
+
+/// 本番読み取り接続（loadDb, ghostDatabase.ts）と同じ PRAGMA で一時 DB を開く。
+/// ghosts テーブルが未作成のときだけ migrations を適用する（同一ファイルへの
+/// 二度目の open で ALTER TABLE ADD COLUMN が "duplicate column" で落ちるのを防ぐ）。
+/// 書き込み用 configure_connection の大 cache は引かない。
+pub fn open_bench_db(path: &Path) -> Result<Connection, String> {
+    let conn = Connection::open(path).map_err(|e| format!("DB open: {e}"))?;
+    let has_schema: bool = conn
+        .query_row(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='ghosts'",
+            [],
+            |_| Ok(true),
+        )
+        .unwrap_or(false);
+    if !has_schema {
+        let mut ms = crate::migrations();
+        ms.sort_by_key(|m| m.version);
+        for m in &ms {
+            conn.execute_batch(m.sql)
+                .map_err(|e| format!("migration {}: {e}", m.version))?;
+        }
+    }
+    // 本番読み取り接続の PRAGMA（loadDb と同順）。大 cache/mmap は意図的に引かない。
+    // データ投入後の再 open では optimize=0x10002 の ANALYZE が本番同様に統計を作る。
+    conn.execute_batch(
+        "PRAGMA journal_mode=WAL;\
+         PRAGMA busy_timeout=5000;\
+         PRAGMA journal_size_limit=4194304;\
+         PRAGMA optimize=0x10002;",
+    )
+    .map_err(|e| format!("PRAGMA: {e}"))?;
+    Ok(conn)
+}
+
+/// 現実寄せ分布の合成ゴースト 1 件を生成する（決定的・index ベース）。
+fn synth_ghost(i: usize) -> Ghost {
+    let jp = ["さくら", "うにゅう", "ゴースト", "妖精", "式神"];
+    let en = ["Alice", "Bob", "Ghost", "Fairy", "Nova"];
+    // i % 10 == 0 の行だけ名前を "さくら…" にして Q_COMMON の選択率を ~10% に固定
+    let base = if i % 10 == 0 {
+        "さくら"
+    } else if i % 2 == 0 {
+        jp[i % jp.len()]
+    } else {
+        en[i % en.len()]
+    };
+    Ghost {
+        diff_fingerprint: format!("fp-{i}"),
+        name: format!("{base}{i}"),
+        sakura_name: if i % 3 == 0 { format!("{base}の精") } else { String::new() },
+        kero_name: if i % 5 == 0 { format!("相方{i}") } else { String::new() },
+        // i % 1000 == 777 の行だけ craftman が "作者777" → Q_RARE の選択率 ~0.1%
+        craftman: format!("作者{}", i % 1000),
+        craftmanw: String::new(),
+        directory_name: format!("dir_{i:06}"),
+        path: format!("C:/ghosts/dir_{i:06}"),
+        source: "ssp".to_string(),
+        thumbnail_path: String::new(),
+        thumbnail_use_self_alpha: false,
+        thumbnail_kind: String::new(),
+    }
+}
+
+/// N 行を本番の store_ghosts 経由で投入し、起動集計列を一部にばらけさせる。
+pub fn seed_ghosts_db(conn: &Connection, request_key: &str, n: usize) -> Result<(), String> {
+    configure_connection(conn)?; // 書き込みは本番と同じ PRAGMA で高速化（読み取り計測とは別接続想定）
+    let ghosts: Vec<Ghost> = (0..n).map(synth_ghost).collect();
+    store_ghosts(conn, request_key, &ghosts, "bench-fp", "bench-mtimes")?;
+
+    // recent/frequency ソートの現実性: 25% に last_launched、一部に launch_count を付与
+    conn.execute(
+        "UPDATE ghosts SET \
+           last_launched = datetime('now', '-' || (id % 30) || ' days'), \
+           launch_count = (id % 7) \
+         WHERE request_key = ?1 AND id % 4 = 0",
+        [request_key],
+    )
+    .map_err(|e| format!("sprinkle: {e}"))?;
+    Ok(())
+}
+```
+
+> 注: `open_bench_db` は読み取り計測用 PRAGMA を張るが、`seed_ghosts_db` 内で `configure_connection`（書き込み PRAGMA）を上書きする。search ベンチは「seed 後に別接続で開き直す」ことで読み取り PRAGMA を保証する（Task 4 で担保）。
+
+- [ ] **Step 4: テストが通ることを確認**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml --features bench bench_support::tests`
+Expected: 全 PASS（Task 1 の2件 + 本タスクの4件）。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src-tauri/src/bench_support.rs
+git commit -m "$(cat <<'EOF'
+test: SQL層ベンチ用の行 seeder を追加
+
+本番 store_ghosts 経由で現実寄せ分布の N 行を投入し、0件/希少/多数の
+固定クエリと起動集計列の sprinkle を用意する。
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: SQL 形状ビルダーと言語間パリティ fixture
+
+検索の WHERE 列と ORDER BY 式を Rust/TS 双方が共有 fixture に対して縛る。これによりベンチの計測対象が本番クエリ形状からずれれば TS/Rust いずれかのテストが Red になる。
+
+**Files:**
+- Create: `src/test/fixtures/search-sql-shapes.json`
+- Modify: `src-tauri/src/bench_support.rs`（ビルダー + Rust パリティテスト）
+- Modify: `src/lib/ghostDatabase.ts:178`（`GHOST_SEARCH_LOWER_COLUMNS` を export）
+- Create: `src/lib/searchSqlShapes.parity.test.ts`
+
+**Interfaces:**
+- Produces（Rust）:
+  - `pub const SEARCH_LOWER_COLUMNS: [&str; 6]`
+  - `pub fn search_where_prefixed() -> String`（`g.col LIKE ? OR …`、searchGhosts と同形）
+  - `pub fn order_by(sort: &str) -> String`（name/recent/frequency/random）
+- Produces（TS）: `export const GHOST_SEARCH_LOWER_COLUMNS`。
+
+- [ ] **Step 1: 共有 fixture を作成**
+
+`src/test/fixtures/search-sql-shapes.json`:
+
+```json
+{
+  "searchLowerColumns": [
+    "name_lower",
+    "sakura_name_lower",
+    "kero_name_lower",
+    "craftman_lower",
+    "craftmanw_lower",
+    "directory_name_lower"
+  ],
+  "orderBy": {
+    "name": "g.name_lower ASC",
+    "recent": "g.last_launched DESC NULLS LAST, g.name_lower ASC",
+    "frequency": "g.launch_count DESC, g.name_lower ASC"
+  }
+}
+```
+
+> `random` は session シードを含み動的なため、パリティ縛りの対象外（ベンチ側は固定シードで再現）。
+
+- [ ] **Step 2: Rust パリティテストを書く（失敗する）**
+
+`src-tauri/src/bench_support.rs` の `mod tests` に追加:
+
+```rust
+#[test]
+fn sql形状が共有fixtureと一致する() {
+    let path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../src/test/fixtures/search-sql-shapes.json"
+    );
+    let raw = std::fs::read_to_string(path).expect("fixture を読めること");
+    let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
+
+    let cols: Vec<String> = v["searchLowerColumns"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|x| x.as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(SEARCH_LOWER_COLUMNS.to_vec(), cols);
+
+    assert_eq!(order_by("name"), v["orderBy"]["name"].as_str().unwrap());
+    assert_eq!(order_by("recent"), v["orderBy"]["recent"].as_str().unwrap());
+    assert_eq!(
+        order_by("frequency"),
+        v["orderBy"]["frequency"].as_str().unwrap()
+    );
+}
+```
+
+（`serde_json` は src-tauri の通常依存にあり、テストから利用可。）
+
+- [ ] **Step 3: テストが失敗することを確認**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml --features bench bench_support::tests::sql形状`
+Expected: FAIL（`SEARCH_LOWER_COLUMNS`/`order_by` 未定義）。
+
+- [ ] **Step 4: ビルダーを実装**
+
+`src-tauri/src/bench_support.rs` に追加（ghostDatabase.ts:178/212/267 と同形に保つ）:
+
+```rust
+/// 検索対象の _lower 列（GHOST_SEARCH_LOWER_COLUMNS と一致）。真の権威は ghostDatabase.ts。
+pub const SEARCH_LOWER_COLUMNS: [&str; 6] = [
+    "name_lower",
+    "sakura_name_lower",
+    "kero_name_lower",
+    "craftman_lower",
+    "craftmanw_lower",
+    "directory_name_lower",
+];
+
+/// searchGhosts と同形の WHERE（g. 前置き・6 列 OR）。
+pub fn search_where_prefixed() -> String {
+    SEARCH_LOWER_COLUMNS
+        .iter()
+        .map(|c| format!("g.{c} LIKE ?"))
+        .collect::<Vec<_>>()
+        .join(" OR ")
+}
+
+/// buildOrderBy(ghostDatabase.ts:212) と同形の ORDER BY 式。
+/// random は固定シード/剰余で再現（本番は session シード）。
+pub fn order_by(sort: &str) -> String {
+    const RANDOM_SORT_MODULUS: u64 = 1000003;
+    const BENCH_SEED: u64 = 2654435761 % RANDOM_SORT_MODULUS;
+    match sort {
+        "random" => format!("(g.id * {BENCH_SEED}) % {RANDOM_SORT_MODULUS}, g.id"),
+        "recent" => "g.last_launched DESC NULLS LAST, g.name_lower ASC".to_string(),
+        "frequency" => "g.launch_count DESC, g.name_lower ASC".to_string(),
+        _ => "g.name_lower ASC".to_string(),
+    }
+}
+```
+
+- [ ] **Step 5: Rust テストが通ることを確認**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml --features bench bench_support::tests`
+Expected: 全 PASS。
+
+- [ ] **Step 6: TS 側で列定数を export**
+
+`src/lib/ghostDatabase.ts:178` の `const GHOST_SEARCH_LOWER_COLUMNS` を `export const GHOST_SEARCH_LOWER_COLUMNS` に変更する（値・利用箇所は不変）。
+
+- [ ] **Step 7: TS パリティテストを書く**
+
+`src/lib/searchSqlShapes.parity.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import shapes from "../test/fixtures/search-sql-shapes.json";
+import { GHOST_SEARCH_LOWER_COLUMNS, buildOrderBy } from "./ghostDatabase";
+
+describe("検索 SQL 形状の言語間パリティ", () => {
+  it("検索対象列が fixture と一致する", () => {
+    expect([...GHOST_SEARCH_LOWER_COLUMNS]).toEqual(shapes.searchLowerColumns);
+  });
+
+  it("name/recent/frequency の ORDER BY が fixture と一致する", () => {
+    expect(buildOrderBy("name")).toBe(shapes.orderBy.name);
+    expect(buildOrderBy("recent")).toBe(shapes.orderBy.recent);
+    expect(buildOrderBy("frequency")).toBe(shapes.orderBy.frequency);
+  });
+});
+```
+
+- [ ] **Step 8: TS テストが通ることを確認**
+
+Run: `npx vitest run src/lib/searchSqlShapes.parity.test.ts`
+Expected: PASS（2 件）。tsconfig の `resolveJsonModule` が無効ならエラーになるため、その場合は `tsconfig.json` の `compilerOptions` に `"resolveJsonModule": true` を追加する。
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/test/fixtures/search-sql-shapes.json src-tauri/src/bench_support.rs src/lib/ghostDatabase.ts src/lib/searchSqlShapes.parity.test.ts
+git commit -m "$(cat <<'EOF'
+test: 検索 SQL 形状の Rust/TS パリティ fixture を追加
+
+WHERE 列と ORDER BY 式を共有 fixture で縛り、ベンチの計測対象が本番
+クエリ形状からずれれば Red になるようにする。
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: search_bench（SQL 層 criterion ベンチ）
+
+seed 済み DB を本番読み取り PRAGMA で開き直し、空/LIKE 3 種/sort 4 種/OFFSET 3 深度/COUNT+SELECT 併走を N∈{1k,10k,100k} で計測。各形状の `EXPLAIN QUERY PLAN` を先に出力する。
+
+**Files:**
+- Create: `src-tauri/benches/search_bench.rs`
+- Modify: `src-tauri/Cargo.toml`（`[[bench]]` エントリ）
+
+**Interfaces:**
+- Consumes: `ghost_launcher_lib::bench_support::{open_bench_db, seed_ghosts_db, search_where_prefixed, order_by, Q_NONE, Q_RARE, Q_COMMON}`。
+
+- [ ] **Step 1: bench エントリを Cargo.toml に追加**
+
+`src-tauri/Cargo.toml` 末尾に追記:
+
+```toml
+[[bench]]
+name = "search_bench"
+harness = false
+required-features = ["bench"]
+```
+
+- [ ] **Step 2: search_bench.rs を実装**
+
+`src-tauri/benches/search_bench.rs`:
+
+```rust
+//! SQL 層(search/sort/OFFSET)の計測。cargo bench --features bench --bench search_bench
+
+use std::time::Duration;
+
+use criterion::{BenchmarkId, Criterion};
+use ghost_launcher_lib::bench_support::{
+    open_bench_db, order_by, search_where_prefixed, seed_ghosts_db, Q_COMMON, Q_NONE, Q_RARE,
+};
+use rusqlite::Connection;
+
+const RK: &str = "bench-rk";
+const LIMIT: i64 = 50;
+// 本番 GHOST_SELECT_COLUMNS_PREFIXED と同じ 18 列（materialize コストを再現）
+const SELECT_COLS: &str = "g.name, g.sakura_name, g.kero_name, g.craftman, g.craftmanw, \
+    g.directory_name, g.path, g.source, g.name_lower, g.sakura_name_lower, g.kero_name_lower, \
+    g.craftman_lower, g.craftmanw_lower, g.directory_name_lower, g.thumbnail_path, \
+    g.thumbnail_use_self_alpha, g.thumbnail_kind, g.ghost_identity_key";
+
+/// seed 済み一時 DB を本番読み取り PRAGMA で開き直して返す（seed 接続の書き込み PRAGMA を継がない）。
+/// tag は N ごとに一意化してディレクトリ名衝突を避ける。
+fn seeded_readonly_db(tag: &str, n: usize) -> (tempfile_dir::Guard, Connection) {
+    let guard = tempfile_dir::Guard::new(tag);
+    let path = guard.path().join("ghosts.db");
+    {
+        let seed_conn = open_bench_db(&path).unwrap();
+        seed_ghosts_db(&seed_conn, RK, n).unwrap();
+    } // seed 接続を閉じる
+    let read_conn = open_bench_db(&path).unwrap(); // 読み取り PRAGMA で開き直す
+    (guard, read_conn)
+}
+
+/// rusqlite の異種パラメータ配列問題を避けるため Params ジェネリックにする。
+/// 呼び出し側は rusqlite::params![..] を渡す。
+fn run_select<P: rusqlite::Params>(conn: &Connection, sql: &str, params: P) -> usize {
+    let mut stmt = conn.prepare_cached(sql).unwrap();
+    stmt.query_map(params, |_r| Ok(()))
+        .unwrap()
+        .filter_map(|r| r.ok())
+        .count()
+}
+
+fn dump_query_plans() {
+    let (_g, conn) = seeded_readonly_db("plan", 1000);
+    let where_c = search_where_prefixed();
+    // EXPLAIN QUERY PLAN は未束縛 ? を嫌うため、リテラル値で組む（プランは値非依存で SCAN/index が判る）。
+    let where_lit = where_c.replace("LIKE ?", "LIKE '%さくら%'");
+    let shapes: Vec<(&str, String)> = vec![
+        ("empty+name", format!("SELECT {SELECT_COLS} FROM ghosts g WHERE g.request_key='{RK}' ORDER BY {} LIMIT 50", order_by("name"))),
+        ("like+name", format!("SELECT {SELECT_COLS} FROM ghosts g WHERE g.request_key='{RK}' AND ({where_lit}) ORDER BY {} LIMIT 50", order_by("name"))),
+        ("empty+recent", format!("SELECT {SELECT_COLS} FROM ghosts g WHERE g.request_key='{RK}' ORDER BY {} LIMIT 50", order_by("recent"))),
+        ("empty+frequency", format!("SELECT {SELECT_COLS} FROM ghosts g WHERE g.request_key='{RK}' ORDER BY {} LIMIT 50", order_by("frequency"))),
+        ("empty+random", format!("SELECT {SELECT_COLS} FROM ghosts g WHERE g.request_key='{RK}' ORDER BY {} LIMIT 50", order_by("random"))),
+    ];
+    println!("\n===== EXPLAIN QUERY PLAN (n=1000) =====");
+    for (label, sql) in shapes {
+        println!("--- {label} ---");
+        let mut stmt = conn.prepare(&format!("EXPLAIN QUERY PLAN {sql}")).unwrap();
+        // EXPLAIN QUERY PLAN の detail 列は index 3
+        let mut rows = stmt.query([]).unwrap();
+        while let Some(row) = rows.next().unwrap() {
+            let detail: String = row.get(3).unwrap();
+            println!("  {detail}");
+        }
+    }
+    println!("=======================================\n");
+}
+
+fn bench_search(c: &mut Criterion) {
+    let where_c = search_where_prefixed();
+    // COUNT は本番 countGhostsByQuery と同形（前置きなし 6 列 OR）
+    let count_where = where_c.replace("g.", "");
+    for &n in &[1_000usize, 10_000, 100_000] {
+        let (_g, conn) = seeded_readonly_db(&format!("n{n}"), n);
+        let like_none = format!("%{Q_NONE}%");
+        let like_rare = format!("%{Q_RARE}%");
+        let like_common = format!("%{Q_COMMON}%");
+
+        let mut group = c.benchmark_group(format!("search_n{n}"));
+        if n >= 100_000 {
+            group.sample_size(20).measurement_time(Duration::from_secs(15));
+        }
+
+        // 空クエリ × 各ソート（無名 ? 統一。params: [rk, limit]）
+        for sort in ["name", "recent", "frequency", "random"] {
+            let sql = format!(
+                "SELECT {SELECT_COLS} FROM ghosts g WHERE g.request_key=? ORDER BY {} LIMIT ?",
+                order_by(sort)
+            );
+            group.bench_with_input(BenchmarkId::new("empty_sort", sort), &sql, |b, sql| {
+                b.iter(|| run_select(&conn, sql, rusqlite::params![RK, LIMIT]));
+            });
+        }
+
+        // LIKE 選択率 3 種（sort=name 固定。params: [rk, like×6, limit]）
+        for (label, like) in [("none", &like_none), ("rare", &like_rare), ("common", &like_common)] {
+            let sql = format!(
+                "SELECT {SELECT_COLS} FROM ghosts g WHERE g.request_key=? AND ({where_c}) \
+                 ORDER BY {} LIMIT ?",
+                order_by("name")
+            );
+            group.bench_with_input(BenchmarkId::new("like", label), &sql, |b, sql| {
+                b.iter(|| {
+                    run_select(
+                        &conn,
+                        sql,
+                        rusqlite::params![RK, like, like, like, like, like, like, LIMIT],
+                    )
+                });
+            });
+        }
+
+        // OFFSET 深度（空クエリ・sort=name。params: [rk, limit, offset]）
+        for (label, offset) in [("0", 0i64), ("mid", (n as i64) / 2), ("deep", (n as i64 - LIMIT).max(0))] {
+            let sql = format!(
+                "SELECT {SELECT_COLS} FROM ghosts g WHERE g.request_key=? ORDER BY {} LIMIT ? OFFSET ?",
+                order_by("name")
+            );
+            group.bench_with_input(BenchmarkId::new("offset", label), &offset, |b, &offset| {
+                b.iter(|| run_select(&conn, &sql, rusqlite::params![RK, LIMIT, offset]));
+            });
+        }
+
+        // COUNT + SELECT 併走（本番 1 検索の実コスト・common クエリ）
+        // count は前置きなし 6 列 OR（本番 countGhostsByQuery）、params: [rk, like×6]
+        let count_sql = format!(
+            "SELECT COUNT(*) FROM ghosts WHERE request_key=? AND ({count_where})"
+        );
+        // select は g. 前置き（本番 searchGhosts）、params: [rk, like×6, limit]
+        let select_sql = format!(
+            "SELECT {SELECT_COLS} FROM ghosts g WHERE g.request_key=? AND ({where_c}) \
+             ORDER BY {} LIMIT ?",
+            order_by("name")
+        );
+        group.bench_function("count_plus_select_common", |b| {
+            b.iter(|| {
+                let lc = &like_common;
+                let _c: i64 = conn
+                    .query_row(&count_sql, rusqlite::params![RK, lc, lc, lc, lc, lc, lc], |r| r.get(0))
+                    .unwrap();
+                run_select(
+                    &conn,
+                    &select_sql,
+                    rusqlite::params![RK, lc, lc, lc, lc, lc, lc, LIMIT],
+                );
+            });
+        });
+
+        group.finish();
+    }
+}
+
+// TempDirGuard は lib 内部（非 pub）なので、ベンチ用の最小 tmp ガードをローカルに持つ。
+mod tempfile_dir {
+    use std::path::{Path, PathBuf};
+    pub struct Guard(PathBuf);
+    impl Guard {
+        pub fn new(prefix: &str) -> Self {
+            // scratchpad ではなく OS 一時ディレクトリ配下。ベンチ終了時に削除。
+            let mut base = std::env::temp_dir();
+            base.push(format!("ghost_bench_{prefix}_{}", std::process::id()));
+            std::fs::create_dir_all(&base).unwrap();
+            Guard(base)
+        }
+        pub fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+}
+
+fn main() {
+    dump_query_plans();
+    let mut c = Criterion::default().configure_from_args();
+    bench_search(&mut c);
+    c.final_summary();
+}
+```
+
+> `Guard` の一時ディレクトリ名は `tag`（`plan` / `n1000` / `n10000` / `n100000`）＋ `std::process::id()` で一意化する。`seeded_readonly_db` が呼び出し毎に異なる tag を渡すため、同一プロセス内でも衝突しない。
+
+- [ ] **Step 3: ベンチが起動確認モードで通ることを確認**
+
+Run: `cargo bench --manifest-path src-tauri/Cargo.toml --features bench --bench search_bench -- --test`
+Expected: `EXPLAIN QUERY PLAN` が出力され、各ベンチが1回ずつ実行されてエラーなく終了。query plan で `like` 系が `SCAN`、`empty+name` が `USING INDEX idx_ghosts_request_key_name_lower`、`recent`/`frequency`/`random` が `SCAN`＋`USE TEMP B-TREE FOR ORDER BY` になることを目視確認。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src-tauri/Cargo.toml src-tauri/benches/search_bench.rs
+git commit -m "$(cat <<'EOF'
+test: SQL層 search/sort/OFFSET の criterion ベンチを追加
+
+空/LIKE 3種/sort 4種/OFFSET 3深度/COUNT+SELECT併走を N∈{1k,10k,100k}で
+計測し、各形状の EXPLAIN QUERY PLAN を出力する。
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: FS tree generator
+
+一時ディレクトリに N 個の `{dir}/ghost/master/descript.txt` を生成し、一部に `shell/master/surface0.png` と Shift_JIS descript を混ぜる。ghost-meta の文字コード判定・thumbnail 解決経路を踏ませる。
+
+**Files:**
+- Modify: `src-tauri/src/bench_support.rs`
+- Test: `src-tauri/src/bench_support.rs`
+
+**Interfaces:**
+- Consumes: `encoding_rs::SHIFT_JIS`（src-tauri の workspace 依存）。
+- Produces: `pub fn generate_ghost_tree(ssp_root: &std::path::Path, n: usize) -> Result<std::path::PathBuf, String>` — `{ssp_root}/ghost` 配下に N 体を生成し `ssp_root` を返す。
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`mod tests` に追加:
+
+```rust
+#[test]
+fn generate_ghost_tree_が_n_体を生成する() {
+    let tmp = TempDirGuard::new("bench_tree");
+    let ssp = tmp.path().join("ssp");
+    let returned = generate_ghost_tree(&ssp, 20).unwrap();
+    assert_eq!(returned, ssp);
+
+    let ghost_dir = ssp.join("ghost");
+    let count = std::fs::read_dir(&ghost_dir).unwrap().count();
+    assert_eq!(count, 20);
+
+    // 各体に descript.txt が存在する
+    for entry in std::fs::read_dir(&ghost_dir).unwrap() {
+        let d = entry.unwrap().path().join("ghost").join("master").join("descript.txt");
+        assert!(d.exists(), "descript missing: {}", d.display());
+    }
+}
+
+#[test]
+fn generate_ghost_tree_を本番スキャンが読める() {
+    let tmp = TempDirGuard::new("bench_tree_scan");
+    let ssp = tmp.path().join("ssp");
+    generate_ghost_tree(&ssp, 30).unwrap();
+
+    let (ghosts, _fp) = crate::commands::ghost::scan_ghosts_with_fingerprint_internal(
+        &ssp.to_string_lossy(),
+        &[],
+    )
+    .unwrap();
+    assert_eq!(ghosts.len(), 30);
+}
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml --features bench bench_support::tests::generate`
+Expected: FAIL（`generate_ghost_tree` 未定義）。
+
+- [ ] **Step 3: generator を実装**
+
+`bench_support.rs` に追加:
+
+```rust
+use std::fs;
+
+/// {ssp_root}/ghost 配下に N 体のゴーストツリーを生成する。
+/// - 全体に ghost/master/descript.txt（UTF-8、一部 Shift_JIS）
+/// - i % 3 == 0 に shell/master/surface0.png（thumbnail 解決経路）
+pub fn generate_ghost_tree(ssp_root: &Path, n: usize) -> Result<PathBuf, String> {
+    let ghost_dir = ssp_root.join("ghost");
+    fs::create_dir_all(&ghost_dir).map_err(|e| format!("mkdir ghost: {e}"))?;
+
+    for i in 0..n {
+        let g = synth_ghost(i);
+        let master = ghost_dir.join(&g.directory_name).join("ghost").join("master");
+        fs::create_dir_all(&master).map_err(|e| format!("mkdir master: {e}"))?;
+
+        let descript = format!(
+            "name,{}\nsakura.name,{}\nkero.name,{}\ncraftman,{}\n",
+            g.name,
+            if g.sakura_name.is_empty() { "" } else { &g.sakura_name },
+            if g.kero_name.is_empty() { "" } else { &g.kero_name },
+            g.craftman
+        );
+        let descript_path = master.join("descript.txt");
+        if i % 7 == 0 {
+            // Shift_JIS（charset 明示）で文字コード判定経路を踏む
+            let sjis_body = format!("charset,Shift_JIS\n{descript}");
+            let (bytes, _, _) = encoding_rs::SHIFT_JIS.encode(&sjis_body);
+            fs::write(&descript_path, bytes).map_err(|e| format!("write sjis: {e}"))?;
+        } else {
+            let utf8_body = format!("charset,UTF-8\n{descript}");
+            fs::write(&descript_path, utf8_body).map_err(|e| format!("write utf8: {e}"))?;
+        }
+
+        // 一部に surface0.png を置き thumbnail 解決を発生させる
+        if i % 3 == 0 {
+            let shell_master = ghost_dir.join(&g.directory_name).join("shell").join("master");
+            fs::create_dir_all(&shell_master).map_err(|e| format!("mkdir shell: {e}"))?;
+            fs::write(shell_master.join("surface0.png"), b"")
+                .map_err(|e| format!("write png: {e}"))?;
+        }
+    }
+    Ok(ssp_root.to_path_buf())
+}
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml --features bench bench_support::tests`
+Expected: 全 PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src-tauri/src/bench_support.rs
+git commit -m "$(cat <<'EOF'
+test: FS走査層ベンチ用のゴーストツリー生成器を追加
+
+N 体の実ツリーを生成し、一部に Shift_JIS descript と surface0.png を混ぜて
+文字コード判定・thumbnail 解決経路を踏ませる。
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: scan/store ラッパーと opaque ハンドル
+
+FS 走査層ベンチが本番 `scan_ghosts_with_fingerprint_internal` / `store_ghosts` / `check_parent_mtimes_match` を叩くための薄い pub ラッパーを用意する。`Ghost`（非 pub 型）は opaque ハンドルで隠蔽する。
+
+**Files:**
+- Modify: `src-tauri/src/bench_support.rs`
+- Test: `src-tauri/src/bench_support.rs`
+
+**Interfaces:**
+- Consumes: `crate::commands::ghost::{scan_ghosts_with_fingerprint_internal, collect_parent_mtimes, check_parent_mtimes_match, store::store_ghosts}`。
+- Produces:
+  - `pub struct ScannedGhosts`（opaque。フィールド非公開）
+  - `pub fn scan_to_handle(ssp_path: &str) -> Result<(ScannedGhosts, String), String>`
+  - `pub fn store_handle(conn: &Connection, request_key: &str, h: &ScannedGhosts, fp: &str) -> Result<usize, String>`
+  - `pub fn store_with_real_mtimes(conn: &Connection, request_key: &str, h: &ScannedGhosts, fp: &str, ssp_path: &str) -> Result<usize, String>`（layer1 hit を真に成立させるセットアップ用）
+  - `pub fn full_scan_count(ssp_path: &str) -> Result<usize, String>`
+  - `pub fn layer1_hit(conn: &Connection, request_key: &str, ssp_path: &str) -> bool`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`mod tests` に追加:
+
+```rust
+#[test]
+fn scan_to_handle_と_store_handle_が往復する() {
+    let tmp = TempDirGuard::new("bench_scan_store");
+    let ssp = tmp.path().join("ssp");
+    generate_ghost_tree(&ssp, 40).unwrap();
+
+    let (handle, fp) = scan_to_handle(&ssp.to_string_lossy()).unwrap();
+    let db = tmp.path().join("ghosts.db");
+    let conn = open_bench_db(&db).unwrap();
+    let stored = store_handle(&conn, "rk", &handle, &fp).unwrap();
+    assert_eq!(stored, 40);
+    // 2 回目は差分ゼロ（同一 handle）→ 行数不変
+    let stored2 = store_handle(&conn, "rk", &handle, &fp).unwrap();
+    assert_eq!(stored2, 40);
+}
+
+#[test]
+fn full_scan_count_が体数を返す() {
+    let tmp = TempDirGuard::new("bench_full_scan");
+    let ssp = tmp.path().join("ssp");
+    generate_ghost_tree(&ssp, 25).unwrap();
+    assert_eq!(full_scan_count(&ssp.to_string_lossy()).unwrap(), 25);
+}
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml --features bench bench_support::tests::scan_to_handle`
+Expected: FAIL（未定義）。
+
+- [ ] **Step 3: ラッパーを実装**
+
+`bench_support.rs` に追加:
+
+```rust
+use crate::commands::ghost::{
+    check_parent_mtimes_match, collect_parent_mtimes, scan_ghosts_with_fingerprint_internal,
+};
+use crate::commands::ghost::store::store_ghosts;
+
+/// スキャン結果の Ghost 群を外部ベンチに対して opaque に保持する。
+pub struct ScannedGhosts {
+    ghosts: Vec<Ghost>,
+}
+
+/// フル走査を 1 回行い、opaque ハンドルと fingerprint を返す。
+pub fn scan_to_handle(ssp_path: &str) -> Result<(ScannedGhosts, String), String> {
+    let (ghosts, fp) = scan_ghosts_with_fingerprint_internal(ssp_path, &[])?;
+    Ok((ScannedGhosts { ghosts }, fp))
+}
+
+/// ハンドルの Ghost 群を本番 store_ghosts で書き込む（差分 UPSERT）。
+pub fn store_handle(
+    conn: &Connection,
+    request_key: &str,
+    h: &ScannedGhosts,
+    fp: &str,
+) -> Result<usize, String> {
+    store_ghosts(conn, request_key, &h.ghosts, fp, "bench-mtimes")
+}
+
+/// ハンドルを実際の親 mtime 付きで書き込む。これを使うと後続の layer1_hit が真に成立する
+/// （store_handle は "bench-mtimes" 固定のため mtime 照合が必ず外れる）。
+pub fn store_with_real_mtimes(
+    conn: &Connection,
+    request_key: &str,
+    h: &ScannedGhosts,
+    fp: &str,
+    ssp_path: &str,
+) -> Result<usize, String> {
+    let mtimes = collect_parent_mtimes(ssp_path, &[]);
+    store_ghosts(conn, request_key, &h.ghosts, fp, &mtimes)
+}
+
+/// フル走査を行い体数だけ返す（walk+parse コスト計測用）。
+pub fn full_scan_count(ssp_path: &str) -> Result<usize, String> {
+    let (ghosts, _fp) = scan_ghosts_with_fingerprint_internal(ssp_path, &[])?;
+    Ok(ghosts.len())
+}
+
+/// Layer 1 高速パス（親 mtime 一致判定）を測る。事前に store_with_real_mtimes で
+/// 保存していれば true（hit）、store_handle で保存していれば false（miss）を返すが、
+/// 計測対象の「1 行 SELECT + 文字列比較」コストはどちらも同等。
+pub fn layer1_hit(conn: &Connection, request_key: &str, ssp_path: &str) -> bool {
+    let mtimes = collect_parent_mtimes(ssp_path, &[]);
+    check_parent_mtimes_match(conn, request_key, &mtimes)
+}
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml --features bench bench_support::tests`
+Expected: 全 PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src-tauri/src/bench_support.rs
+git commit -m "$(cat <<'EOF'
+test: FS走査/storeベンチ用の opaque ハンドルとラッパーを追加
+
+scan_to_handle/store_handle/full_scan_count/layer1_hit で本番経路を叩き、
+非pub の Ghost 型を ScannedGhosts で隠蔽する。
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: scan_bench（FS 走査層 criterion ベンチ）
+
+生成済みツリーに対しフル走査・Layer1 hit・初回 store・差分 store を N∈{1k,10k,100k} で計測。100k は sample を絞る。
+
+**Files:**
+- Create: `src-tauri/benches/scan_bench.rs`
+- Modify: `src-tauri/Cargo.toml`（`[[bench]]` エントリ）
+
+**Interfaces:**
+- Consumes: `ghost_launcher_lib::bench_support::{generate_ghost_tree, open_bench_db, scan_to_handle, store_handle, full_scan_count, layer1_hit}`。
+
+- [ ] **Step 1: bench エントリを追加**
+
+`src-tauri/Cargo.toml` 末尾に追記:
+
+```toml
+[[bench]]
+name = "scan_bench"
+harness = false
+required-features = ["bench"]
+```
+
+- [ ] **Step 2: scan_bench.rs を実装**
+
+`src-tauri/benches/scan_bench.rs`:
+
+```rust
+//! FS走査層(scan/fingerprint/store)の計測。cargo bench --features bench --bench scan_bench
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use criterion::Criterion;
+use ghost_launcher_lib::bench_support::{
+    full_scan_count, generate_ghost_tree, layer1_hit, open_bench_db, scan_to_handle, store_handle,
+    store_with_real_mtimes,
+};
+
+/// ベンチ用の一時ディレクトリガード（lib 内部 TempDirGuard は非 pub のためローカルに持つ）。
+struct Guard(PathBuf);
+impl Guard {
+    fn new(tag: &str) -> Self {
+        let mut base = std::env::temp_dir();
+        base.push(format!("ghost_scan_bench_{tag}_{}", std::process::id()));
+        std::fs::create_dir_all(&base).unwrap();
+        Guard(base)
+    }
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+impl Drop for Guard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+fn bench_scan(c: &mut Criterion) {
+    for &n in &[1_000usize, 10_000, 100_000] {
+        // ツリーは 1 回だけ生成（計測外）
+        let guard = Guard::new(&format!("n{n}"));
+        let ssp = guard.path().join("ssp");
+        generate_ghost_tree(&ssp, n).unwrap();
+        let ssp_str = ssp.to_string_lossy().to_string();
+
+        // store 用に seed 済み DB（Layer1 hit と差分 store のセットアップ）
+        let (handle, fp) = scan_to_handle(&ssp_str).unwrap();
+        let db_path = guard.path().join("ghosts.db");
+
+        let mut group = c.benchmark_group(format!("scan_n{n}"));
+        if n >= 100_000 {
+            group.sample_size(10).measurement_time(Duration::from_secs(30));
+        } else {
+            group.sample_size(20);
+        }
+
+        // フル走査（1 体増減毎に払うコスト）
+        group.bench_function("full_scan", |b| {
+            b.iter(|| full_scan_count(&ssp_str).unwrap());
+        });
+
+        // Layer1 hit（無変更時の高速パス）。実 mtimes を保存して真の hit にする。
+        {
+            let conn = open_bench_db(&db_path).unwrap();
+            store_with_real_mtimes(&conn, "rk", &handle, &fp, &ssp_str).unwrap();
+            debug_assert!(layer1_hit(&conn, "rk", &ssp_str), "layer1 は hit のはず");
+            group.bench_function("layer1_hit", |b| {
+                b.iter(|| layer1_hit(&conn, "rk", &ssp_str));
+            });
+        }
+
+        // 初回 store（毎回空 DB に N INSERT）
+        group.bench_function("store_initial", |b| {
+            b.iter_batched(
+                || {
+                    let p = guard.path().join(format!("init_{}.db", fastrand_like()));
+                    let conn = open_bench_db(&p).unwrap();
+                    (conn, p)
+                },
+                |(conn, _p)| {
+                    store_handle(&conn, "rk", &handle, &fp).unwrap();
+                },
+                criterion::BatchSize::PerIteration,
+            );
+        });
+
+        // 差分ゼロ再 store（既存 N 行に同一 handle → 読み取り+比較オーバーヘッド）
+        {
+            let conn = open_bench_db(&guard.path().join("diff.db")).unwrap();
+            store_handle(&conn, "rk", &handle, &fp).unwrap();
+            group.bench_function("store_rescan_nodiff", |b| {
+                b.iter(|| store_handle(&conn, "rk", &handle, &fp).unwrap());
+            });
+        }
+
+        group.finish();
+    }
+}
+
+/// process id + 単調カウンタで一意なファイル名断片を作る（Math.random 不使用）。
+fn fastrand_like() -> u64 {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static C: AtomicU64 = AtomicU64::new(0);
+    C.fetch_add(1, Ordering::Relaxed)
+}
+
+fn main() {
+    let mut c = Criterion::default().configure_from_args();
+    bench_scan(&mut c);
+    c.final_summary();
+}
+```
+
+> `store_initial` の各反復は空 DB を作り直す（`iter_batched` の setup で DB を新規化し、計測本体は store のみ）。ファイル名衝突は単調カウンタで避ける。100k で `store_initial` を毎反復やるとディスクを食うため、100k のみ `sample_size(10)` で抑える（既に上で設定済み）。
+
+- [ ] **Step 3: 起動確認モードで通ることを確認（軽量 N のみ）**
+
+Run: `cargo bench --manifest-path src-tauri/Cargo.toml --features bench --bench scan_bench -- --test scan_n1000`
+Expected: `scan_n1000` グループの各ベンチが1回ずつ実行されエラーなく終了。
+
+> 全 N（100k 含む）を `--test` で回すと FS 生成に数分かかる。起動確認は `scan_n1000` フィルタで足りる。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src-tauri/Cargo.toml src-tauri/benches/scan_bench.rs
+git commit -m "$(cat <<'EOF'
+test: FS走査層 scan/fingerprint/store の criterion ベンチを追加
+
+フル走査/Layer1 hit/初回store/差分ゼロ再store を N∈{1k,10k,100k}で計測。
+100k は sample を絞る。フル走査-Layer1hit が1体増減の代償。
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: ベースライン数値レポートの実走と記述
+
+両ベンチを実走し、`docs/perf/baseline-100k.md` に N×形状の数値・query plan 抜粋・所見・実行手順を記す。
+
+**Files:**
+- Create: `docs/perf/baseline-100k.md`
+
+**Interfaces:**
+- Consumes: `search_bench` / `scan_bench` の実行結果。
+
+- [ ] **Step 1: search_bench を実走して数値を採取**
+
+Run: `cargo bench --manifest-path src-tauri/Cargo.toml --features bench --bench search_bench 2>&1 | tee /tmp/search_bench.txt`
+（Windows Git Bash では `tee` 利用可。scratchpad 配下に出力しても可。）
+Expected: `EXPLAIN QUERY PLAN` と各グループの中央値が出力される。100k の `like`/`empty_sort recent|frequency|random`/`offset deep` が `name`/index 経路より桁で遅いことを確認。
+
+- [ ] **Step 2: scan_bench を実走して数値を採取**
+
+Run: `cargo bench --manifest-path src-tauri/Cargo.toml --features bench --bench scan_bench 2>&1 | tee /tmp/scan_bench.txt`
+Expected: `full_scan` が `layer1_hit`（<1ms 想定）より桁で遅いこと、N に対しほぼ線形に伸びることを確認。100k は sample=10 で indicative 値。
+
+- [ ] **Step 3: レポートを記述**
+
+`docs/perf/baseline-100k.md` を作成する。**実走で得た実数値**を各表に埋める（下記はテンプレート。`…` は実測値で置換すること。空欄・TBD を残さない）:
+
+````markdown
+# 性能ベースライン（10万体規模）
+
+- 計測日: <YYYY-MM-DD>
+- 目的: 修正の優先順位を実測で決めるためのベースライン。修正は本数値を根拠に別サイクル。
+
+## 実行環境
+
+- OS / CPU コア数 / **ディスク種別（SSD/HDD）** / ビルドプロファイル(release)
+- 数値はディスク種別・ページキャッシュ温度で大きく動く。SQL 層は warm-cache 定常状態、FS 層は cold/warm を明記。
+
+## 実行手順
+
+```bash
+cargo bench --manifest-path src-tauri/Cargo.toml --features bench --bench search_bench
+cargo bench --manifest-path src-tauri/Cargo.toml --features bench --bench scan_bench
+```
+
+## SQL 層（search_bench）
+
+### EXPLAIN QUERY PLAN（n=1000）
+
+```
+empty+name:  <SEARCH ghosts USING INDEX idx_ghosts_request_key_name_lower ...>
+like+name:   <SCAN ghosts ...>
+empty+recent:    <SCAN ... USE TEMP B-TREE FOR ORDER BY>
+empty+frequency: <SCAN ... USE TEMP B-TREE FOR ORDER BY>
+empty+random:    <SCAN ... USE TEMP B-TREE FOR ORDER BY>
+```
+
+### レイテンシ中央値
+
+| 形状 | n=1k | n=10k | n=100k |
+|---|---|---|---|
+| empty_sort/name | … | … | … |
+| empty_sort/recent | … | … | … |
+| empty_sort/frequency | … | … | … |
+| empty_sort/random | … | … | … |
+| like/none | … | … | … |
+| like/rare | … | … | … |
+| like/common | … | … | … |
+| offset/0 | … | … | … |
+| offset/mid | … | … | … |
+| offset/deep | … | … | … |
+| count_plus_select_common | … | … | … |
+
+## FS 走査層（scan_bench）
+
+| 形状 | n=1k | n=10k | n=100k(indicative) |
+|---|---|---|---|
+| full_scan | … | … | … |
+| layer1_hit | … | … | … |
+| store_initial | … | … | … |
+| store_rescan_nodiff | … | … | … |
+
+**フル走査 − Layer1 hit = 1 体増減で払う代償**: <n=100k での差分>
+
+## 所見（修正は別サイクル・推奨のみ）
+
+- 検索: like/* が index 経路(name)に対し n=100k で <倍率>。先頭ワイルドカードが index を無効化。→ FTS5 or 前方一致の検討。
+- 全走査: full_scan が layer1_hit に対し <倍率>。NTFS 親 mtime 粒度ゆえ 1 体増減で全走査。→ fingerprint 粒度細分化 or 進捗 UI/streaming。
+- ソート: recent/frequency/random が name に対し <倍率>（TEMP B-TREE 全ソート）。→ (request_key, launch_count) 等の複合 index。
+- OFFSET: offset/deep が offset/0 に対し <倍率>。→ keyset ページング。
+
+推奨優先順位: <数値に基づく順位>。
+````
+
+- [ ] **Step 4: 全体の回帰確認**
+
+Run:
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml
+cargo check --manifest-path src-tauri/Cargo.toml
+npm test
+npm run build
+```
+Expected: feature 無効の通常ビルド・テストが全 PASS（本番 API 不変）。TS パリティテスト含む vitest が PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/perf/baseline-100k.md
+git commit -m "$(cat <<'EOF'
+docs: 10万体規模の性能ベースライン数値を記録
+
+search_bench/scan_bench の実走結果(N×形状のレイテンシ・EXPLAIN QUERY PLAN)
+と所見を固める。修正の優先順位を数値で根拠づける起点資料。
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## 実装後の確認（PR 前）
+
+- `/commit` チェックリスト全パス（Task 8 Step 4 でコード系ゲートを実行済み。ベンチは CI 必須にしない）。
+- `git status` clean。
+- 全フェーズ完了後に一括で PR を作成する（`/pr`）。修正 PR は本 PR マージ後、`docs/perf/baseline-100k.md` の数値を根拠に別途起票。

--- a/docs/superpowers/specs/2026-07-16-perf-benchmark-harness-design.md
+++ b/docs/superpowers/specs/2026-07-16-perf-benchmark-harness-design.md
@@ -1,0 +1,170 @@
+# 10万体規模の性能計測ハーネス 設計書
+
+- 日付: 2026-07-16
+- 種別: テスト基盤 / 性能計測ハーネス（常設）
+- 前提: `main` から派生ブランチ（`feature/perf-benchmark-harness`）で実装する。本 spec は **計測基盤とベースライン数値の取得までがスコープ**であり、**修正（FTS5 化・fingerprint 粒度細分化・複合 index・keyset ページング等）は対象外**。修正は本ハーネスが吐いた数字を根拠に、別サイクルで個別に設計・実装する。
+
+## 背景
+
+10 万体規模でどこがボトルネックになるかを、コード読解から 4 局面の仮説として立てた（`src-tauri/src/commands/ghost/`・`src/lib/ghostDatabase.ts` の実測読解に基づく）。
+
+1. **部分一致検索（定常状態・タイプ毎）**: `searchGhosts`（`src/lib/ghostDatabase.ts:260`）は `%query%`（先頭ワイルドカード、`:250`）を 6 列 OR（`:187`）で評価する。先頭 `%` は B-tree index を無効化するため、request_key パーティションの全行フルスキャン。さらに `Promise.all`（`:269`）で COUNT と SELECT の 2 クエリが走る。
+2. **初回＝全走査スキャン（cold start・1 体増減毎）**: `scan_and_store`（`src-tauri/src/commands/ghost/mod.rs:33`）は Layer 1 で親ディレクトリ mtime を照合（`:55`, `fingerprint.rs:103`、hit なら <1ms）。ミス時は Layer 2 で `scan_ghosts_with_fingerprint_internal`（`scan.rs:193`）が全ゴーストを歩き直し、各件で `read_ghost`（`ghost.rs:31`、descript.txt を 2 回パース＋ thumbnail 解決）。NTFS の親 mtime はゴースト 1 体の追加・削除で変化する（`mod.rs:50` のコメント）ため、**catalog を触るたびに Layer 1 ミス→全走査**が蘇る。差分 UPSERT（`store.rs`）が節約するのは DB 書き込みのみで、fingerprint 再計算のための FS 全走査は丸ごと走る。
+3. **特殊ソート（recent/frequency/random 選択時）**: `buildOrderBy`（`ghostDatabase.ts:212`）の `name` は `idx_ghosts_request_key_name_lower`（`lib.rs:30`）に乗るが、`recent`（`last_launched`）・`frequency`（`launch_count`）は migration 12（`lib.rs:90`）が列追加のみで index 未張り、`random` は式ソートで index 不可。いずれも毎ページ全ソート。
+4. **スクロール（深い OFFSET のみ）**: `useVirtualizedList` は DOM を O(窓) に抑える（描画は非問題）が、フェッチは OFFSET ページング（`ghostDatabase.ts:272`）で O(offset)。上記 2・3 を OFFSET 越しに増幅する。
+
+**この仮説は「コード読解」であって「実測」ではない。** 修正の優先順位を推測で決めるのは本末転倒であり、まず N を振った数値と `EXPLAIN QUERY PLAN` で裏を取る。
+
+## 決定
+
+- **A. 二層計測ハーネスを常設する。** SQL 層（search/sort/OFFSET）と FS 走査層（scan/fingerprint/store）を、criterion ベンチ＋共有フィクスチャ生成器で計測する。E2E は対象外。
+- **B. ベースライン数値レポートをコミットする。** N×計測形状の表と query plan 抜粋を人間可読の markdown に固め、修正サイクルの起点資料にする。
+- **C. 修正は数字を見てから別サイクルで決める。** 本 spec では一切修正しない。
+
+設計原則: **推測ではなく実測で修正を選ぶ。計測基盤は再現可能な回帰ガードとして常設する（使い捨てにしない）。**
+
+## 計測の faithfulness（なぜ Rust / criterion か）
+
+- アプリ本番の SQL 経路は sqlx（`tauri-plugin-sql`）だが、rusqlite と **同一 libsqlite3 を共有する**（`links = "sqlite3"` 制約、`src-tauri/CLAUDE.md` 記載）。ゆえに rusqlite + criterion の SQL 計測は、本番が支払うエンジンコスト（index 選択・LIKE スキャン・ソート・OFFSET）を忠実に反映する。TS 層の IPC / デシリアライズ差分は本スコープ外（それは FS/E2E 層の関心事）。
+- criterion は sqlite にリンクしない純 Rust の dev-dependency。`libsqlite3-sys` 共有制約（`src-tauri/CLAUDE.md`）に影響しない。
+
+## A. 二層計測ハーネス
+
+### A-1. 共有フィクスチャ生成器（lib 内・`bench` feature で pub 露出）
+
+`src-tauri/src/bench_support.rs` を新設し、`lib.rs` に `#[cfg(feature = "bench")] pub mod bench_support;` を追加する。ベンチ（外部クレート扱い）から `ghost_launcher_lib::bench_support::*` として参照する。同 feature で以下も pub 露出する（現在 `pub(crate)`）:
+
+- `migrations()`（`lib.rs`）— seeder がスキーマ適用に使う。
+- `commands::ghost` の `scan_ghosts_with_fingerprint_internal`・`store::store_ghosts`・`store::configure_connection` への薄い pub ラッパー。
+
+いずれも `#[cfg(feature = "bench")]` ガード下でのみ pub になり、本番ビルド（feature 無効）では可視性・API は不変。
+
+**seeder（SQL 層・FS 非依存）:**
+
+```rust
+/// 一時ファイル DB に migrations を適用し、N 行の合成ゴーストを 1 トランザクションで投入する。
+/// 名前分布は現実寄せ（下記）。単一 request_key パーティションに入れる。
+pub fn seed_ghosts_db(conn: &Connection, request_key: &str, n: usize);
+```
+
+- 列は `store.rs` の INSERT と一致（`name`/`sakura_name`/…/`_lower` 列・`ghost_identity_key`・`row_fingerprint`・`last_launched`・`launch_count`）。`_lower` 列は `normalize_for_key` 相当で生成。
+- **現実寄せの分布**（全同一名だと LIKE 選択率が歪み誤誘導する）:
+  - 名前: 日本語語彙（例: 「さくら」「ゴースト」+ 連番）と ASCII 語彙を混在。
+  - 作者名・sakura.name・kero.name も一定割合で埋める（検索 6 列の実効性を測るため）。
+  - `last_launched`/`launch_count`: 一部のみ非 NULL / 非ゼロにばらけさせる（recent/frequency ソートの現実性）。
+- **固定シードのクエリセット**（決定的・再現可能）:
+  - `q0`: どの行にもマッチしない語（0 件）。
+  - `q_rare`: 数十件だけマッチする語。
+  - `q_common`: 数千〜万件マッチする語。
+
+**tree generator（FS 走査層）:**
+
+```rust
+/// temp（scratchpad）配下に N 個の {dir}/ghost/master/descript.txt を生成する。
+/// 一定割合に shell/master/surface0.png を置き thumbnail 解決経路も測る。
+/// 戻り値は生成した ssp ルート（{root}/ghost を親に持つ）。
+pub fn generate_ghost_tree(root: &Path, n: usize) -> PathBuf;
+```
+
+- descript.txt は現実的な UTF-8 内容（`charset,UTF-8` / `name,...` / `craftman,...` / `sakura.name,...`）。
+- Shift_JIS の descript を一定割合混ぜ、`crates/ghost-meta` の文字コード判定経路も踏む。
+
+### A-2. ベンチ入口（criterion）
+
+`Cargo.toml` に追加:
+
+```toml
+[features]
+bench = []
+
+[dev-dependencies]
+criterion = "…"   # 実装時に cargo info で最新安定を確認しピン留め
+
+[[bench]]
+name = "search_bench"
+harness = false
+required-features = ["bench"]
+
+[[bench]]
+name = "scan_bench"
+harness = false
+required-features = ["bench"]
+```
+
+実行は `cargo bench --features bench`。各ベンチは `harness = false` の **カスタム `fn main()`** とし、順序は「① 代表形状の `EXPLAIN QUERY PLAN` を stdout に出力 → ② criterion 計測グループ」。criterion は `Criterion::default().configure_from_args()` を手動駆動する。
+
+**`search_bench`（SQL 層）:** 一時ファイル DB を **本番の読み取り接続 `loadDb`（`ghostDatabase.ts:35`）と同じ PRAGMA**（`journal_mode=WAL`・`busy_timeout`・`journal_size_limit`・`optimize`）で開き、`seed_ghosts_db` で N 行投入。書き込み用 `configure_connection`（`store.rs`、`cache_size=-65536`・大 mmap）は**引かない**——検索は本番では sqlx の読み取り接続上で走るため、書き込み側の大 cache を積むと 100k スキャンが本番より速く出て数字が甘くなる。cache 依存の差はレポートに注記する。DB はグループ開始前に 1 回だけ構築し、計測クロージャ内は SELECT のみ（seeding を計測に含めない）。criterion は多数反復でページキャッシュが温まるため、計測値は「タイプ中の warm-cache 定常状態」を表す旨も注記する。N∈{1k, 10k, 100k}。計測形状:
+
+| 形状 | クエリ | 検証したい事実 |
+|---|---|---|
+| 空クエリ | WHERE request_key=? ORDER BY name_lower LIMIT | index 経路の基準値 |
+| LIKE 0 件 | `q0` を 6 列 OR LIKE | フルスキャンの下限コスト |
+| LIKE 希少 | `q_rare` | スキャン + 少数ソート |
+| LIKE 多数 | `q_common` | スキャン + 多数ソート |
+| sort=name | ORDER BY name_lower | index-ordered top-N |
+| sort=recent | ORDER BY last_launched DESC | 全ソート（index 無し） |
+| sort=frequency | ORDER BY launch_count DESC | 全ソート（index 無し） |
+| sort=random | ORDER BY (id*seed)%mod | 式ソート（index 不可） |
+| OFFSET 0 / 中 / 深 | LIMIT ? OFFSET {0, N/2, N-limit} | O(offset) の可視化 |
+| COUNT+SELECT 併走 | `Promise.all` 相当の 2 クエリ合算 | 本番 1 検索の実コスト |
+
+各形状で `EXPLAIN QUERY PLAN` を 1 回出力し、`SCAN` か `SEARCH ... USING INDEX` かを証拠として記録する。
+
+**`scan_bench`（FS 走査層）:** `generate_ghost_tree` で N 個のツリーを 1 回生成し（計測外）、以下を計測。N∈{1k, 10k, 100k}。100k は `sample_size(10)` に絞り indicative 値とする（各サンプルが数秒〜数十秒）。
+
+| 形状 | 対象 | 検証したい事実 |
+|---|---|---|
+| フル走査 | `scan_ghosts_with_fingerprint_internal` | Layer 2 全走査 = 1 体増減毎に蘇るコスト |
+| Layer 1 hit | `check_parent_mtimes_match` | 無変更時の <1ms 高速パス |
+| 初回 store | `store_ghosts`（既存 0 行→N INSERT） | 初回全挿入の書き込みコスト |
+| 差分 store | `store_ghosts`（既存 N 行→1 行差分） | 差分 UPSERT の実コスト |
+
+**フル走査 vs Layer 1 hit の差分が「1 体の追加・削除で払う代償」の実測値**である旨をレポートに明記する。
+
+### A-3. 生成器の単体テスト
+
+`bench_support` に小さな単体テスト（`#[cfg(test)]`、feature ゲート下）:
+- `seed_ghosts_db(_, _, n)` 後の行数が n。
+- `_lower` 列が `normalize_for_key` の出力と一致（既存 `normalize-key-cases.json` 流儀に整合）。
+- `generate_ghost_tree(_, n)` が n 個の descript.txt を持つツリーを作る。
+- クエリセット `q_rare`/`q_common` の実マッチ件数が意図した桁（希少/多数）に収まる。
+
+## B. ベースライン数値レポート
+
+`docs/perf/baseline-100k.md` を新設・コミット。内容:
+- 実行環境（OS・CPU コア数・**ディスク種別**・ビルドプロファイル）。数値はディスク種別で大きく動くため必須明記。
+- SQL 層: N×形状の中央値レイテンシ表 ＋ `EXPLAIN QUERY PLAN` 抜粋。
+- FS 層: N×形状の表（100k は indicative）＋「フル走査 − Layer1 hit」の差分。
+- 所見: 4 局面仮説のどれが数値で裏付いたか、修正の優先順位（推奨のみ・実装は別サイクル）。
+
+レポートの数値取得は実装フェーズ（`cargo bench --features bench` の実走）で埋める。本 spec ではテンプレートと項目を確定する。
+
+## C. 既知の留意点（設計上の傷）
+
+- **SQL 文字列の複製ドリフト**: ベンチは検索の WHERE / ORDER BY を再現するが、真の権威は `ghostDatabase.ts`（`GHOST_SEARCH_WHERE`・`buildOrderBy`）。対策として、リポジトリ既存の「共有フィクスチャで言語間パリティを縛る」流儀（`src/test/fixtures/normalize-key-cases.json`）に倣い、**SQL 形状（WHERE テンプレート・各 ORDER BY 式）を `src/test/fixtures/search-sql-shapes.json` に切り出し、TS 側パリティテストとベンチの双方が参照する**。これによりベンチの計測対象が本番クエリ形状からずれれば TS テストが Red になる。
+- **`bench` feature の pub 露出**: FS 層ベンチは実 crate 関数を測るため `pub(crate)` を最小限 pub に上げる。feature ガードで本番 API は不変に保つ。
+- **FS 生成コスト**: 100k ツリーは Windows NTFS で ~30〜50 万小ファイル・数分・数 GB。scaling curve（1k→10k→100k）で O(n) を可視化し、100k は sample を絞る。生成先は scratchpad の temp（`TempDirGuard` 流儀で確実削除）、**非コミット**。
+
+## テスト方針
+
+- 生成器: A-3 の単体テスト（feature ゲート下、`cargo test --features bench`）。
+- パリティ: `search-sql-shapes.json` を TS 側テスト（vitest）とベンチ双方が参照。
+- ベンチ自体はテストではないため CI 必須にはしない（実走が重く不安定なため）。最小確認として `cargo bench --features bench -- --test`（criterion の 1 回だけ実行モード）が壊れず通ること。
+- 本番ビルド不変: feature 無効の `cargo check` / `cargo build` が従来通り（公開 API・可視性が変わらない）。
+
+## スコープ外（YAGNI）
+
+- **修正の実装全般**（FTS5 化、fingerprint 粒度細分化、`(request_key, launch_count)` 等の複合 index、keyset ページング、スキャンの streaming / 進捗 UI）。数字を見てから別サイクル。
+- E2E / 実アプリ体感計測（WebView + IPC）。今回は SQL 層と FS 走査層に限定。
+- TS 層の IPC / デシリアライズオーバーヘッド計測。
+- CI へのベンチ組み込み・性能回帰の自動 gate。ハーネスは常設するが、閾値による自動失敗は別件。
+
+## PR 構成
+
+A（生成器＋ベンチ入口）・A-3（生成器テスト）・B（レポートテンプレート＋実走数値）・C のパリティ fixture は、いずれも「計測基盤の新設」で一貫するため **単一 PR**。レポートの数値埋めは同 PR 内の実走で行う。修正 PR は本 PR マージ後、数値を根拠に別途起票する。
+
+## 却下した代替案
+
+- **TS/vitest bench で本番関数を直接叩く**: SQL 文字列の複製を避けられる利点はあるが、`getDb()`＝`Database.load` が Tauri 束縛で Node では別物の shim になり忠実性が落ち、かつ FS 走査層（本 spec の対象）を一切測れない。単独では不足。SQL 形状パリティは C の共有 fixture で担保する方が軽い。
+- **使い捨て計測（scratchpad で測りコミットしない）**: 身軽だが再現が手作業になり、性能に敏感なこれらの経路の回帰を将来検知できない。「リポジトリに残す」判断に基づき却下。
+- **criterion を使わず自前 Instant 計測のみ**: 統計的厳密さ（外れ値除去・信頼区間）を失う。SQL 層の高速クエリは分散が効くため criterion を採る。FS 層の重い 100k のみ sample を絞って併用する。

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,3 +37,8 @@ bench = []
 [dev-dependencies]
 ts-rs = "12"
 criterion = "0.5"
+
+[[bench]]
+name = "search_bench"
+harness = false
+required-features = ["bench"]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,5 +31,9 @@ rusqlite = { version = "0.32", features = ["bundled"] }
 unicode-normalization = "0.1"
 rayon = "1"
 
+[features]
+bench = []
+
 [dev-dependencies]
 ts-rs = "12"
+criterion = "0.5"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,3 +42,8 @@ criterion = "0.5"
 name = "search_bench"
 harness = false
 required-features = ["bench"]
+
+[[bench]]
+name = "scan_bench"
+harness = false
+required-features = ["bench"]

--- a/src-tauri/benches/scan_bench.rs
+++ b/src-tauri/benches/scan_bench.rs
@@ -1,0 +1,104 @@
+//! FS走査層(scan/fingerprint/store)の計測。cargo bench --features bench --bench scan_bench
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use criterion::Criterion;
+use ghost_launcher_lib::bench_support::{
+    full_scan_count, generate_ghost_tree, layer1_hit, open_bench_db, scan_to_handle, store_handle,
+    store_with_real_mtimes,
+};
+
+/// ベンチ用の一時ディレクトリガード（lib 内部 TempDirGuard は非 pub のためローカルに持つ）。
+struct Guard(PathBuf);
+impl Guard {
+    fn new(tag: &str) -> Self {
+        let mut base = std::env::temp_dir();
+        base.push(format!("ghost_scan_bench_{tag}_{}", std::process::id()));
+        std::fs::create_dir_all(&base).unwrap();
+        Guard(base)
+    }
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+impl Drop for Guard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+fn bench_scan(c: &mut Criterion) {
+    for &n in &[1_000usize, 10_000, 100_000] {
+        // ツリーは 1 回だけ生成（計測外）
+        let guard = Guard::new(&format!("n{n}"));
+        let ssp = guard.path().join("ssp");
+        generate_ghost_tree(&ssp, n).unwrap();
+        let ssp_str = ssp.to_string_lossy().to_string();
+
+        // store 用に seed 済み DB（Layer1 hit と差分 store のセットアップ）
+        let (handle, fp) = scan_to_handle(&ssp_str).unwrap();
+        let db_path = guard.path().join("ghosts.db");
+
+        let mut group = c.benchmark_group(format!("scan_n{n}"));
+        if n >= 100_000 {
+            group.sample_size(10).measurement_time(Duration::from_secs(30));
+        } else {
+            group.sample_size(20);
+        }
+
+        // フル走査（1 体増減毎に払うコスト）
+        group.bench_function("full_scan", |b| {
+            b.iter(|| full_scan_count(&ssp_str).unwrap());
+        });
+
+        // Layer1 hit（無変更時の高速パス）。実 mtimes を保存して真の hit にする。
+        {
+            let conn = open_bench_db(&db_path).unwrap();
+            store_with_real_mtimes(&conn, "rk", &handle, &fp, &ssp_str).unwrap();
+            debug_assert!(layer1_hit(&conn, "rk", &ssp_str), "layer1 は hit のはず");
+            group.bench_function("layer1_hit", |b| {
+                b.iter(|| layer1_hit(&conn, "rk", &ssp_str));
+            });
+        }
+
+        // 初回 store（毎回空 DB に N INSERT）
+        group.bench_function("store_initial", |b| {
+            b.iter_batched(
+                || {
+                    let p = guard.path().join(format!("init_{}.db", fastrand_like()));
+                    let conn = open_bench_db(&p).unwrap();
+                    (conn, p)
+                },
+                |(conn, _p)| {
+                    store_handle(&conn, "rk", &handle, &fp).unwrap();
+                },
+                criterion::BatchSize::PerIteration,
+            );
+        });
+
+        // 差分ゼロ再 store（既存 N 行に同一 handle → 読み取り+比較オーバーヘッド）
+        {
+            let conn = open_bench_db(&guard.path().join("diff.db")).unwrap();
+            store_handle(&conn, "rk", &handle, &fp).unwrap();
+            group.bench_function("store_rescan_nodiff", |b| {
+                b.iter(|| store_handle(&conn, "rk", &handle, &fp).unwrap());
+            });
+        }
+
+        group.finish();
+    }
+}
+
+/// process id + 単調カウンタで一意なファイル名断片を作る（Math.random 不使用）。
+fn fastrand_like() -> u64 {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static C: AtomicU64 = AtomicU64::new(0);
+    C.fetch_add(1, Ordering::Relaxed)
+}
+
+fn main() {
+    let mut c = Criterion::default().configure_from_args();
+    bench_scan(&mut c);
+    c.final_summary();
+}

--- a/src-tauri/benches/search_bench.rs
+++ b/src-tauri/benches/search_bench.rs
@@ -1,0 +1,180 @@
+//! SQL 層(search/sort/OFFSET)の計測。cargo bench --features bench --bench search_bench
+
+use std::time::Duration;
+
+use criterion::{BenchmarkId, Criterion};
+use ghost_launcher_lib::bench_support::{
+    open_bench_db, order_by, search_where_prefixed, seed_ghosts_db, Q_COMMON, Q_NONE, Q_RARE,
+};
+use rusqlite::Connection;
+
+const RK: &str = "bench-rk";
+const LIMIT: i64 = 50;
+// 本番 GHOST_SELECT_COLUMNS_PREFIXED と同じ 18 列（materialize コストを再現）
+const SELECT_COLS: &str = "g.name, g.sakura_name, g.kero_name, g.craftman, g.craftmanw, \
+    g.directory_name, g.path, g.source, g.name_lower, g.sakura_name_lower, g.kero_name_lower, \
+    g.craftman_lower, g.craftmanw_lower, g.directory_name_lower, g.thumbnail_path, \
+    g.thumbnail_use_self_alpha, g.thumbnail_kind, g.ghost_identity_key";
+
+/// seed 済み一時 DB を本番読み取り PRAGMA で開き直して返す（seed 接続の書き込み PRAGMA を継がない）。
+/// tag は N ごとに一意化してディレクトリ名衝突を避ける。
+fn seeded_readonly_db(tag: &str, n: usize) -> (tempfile_dir::Guard, Connection) {
+    let guard = tempfile_dir::Guard::new(tag);
+    let path = guard.path().join("ghosts.db");
+    {
+        let seed_conn = open_bench_db(&path).unwrap();
+        seed_ghosts_db(&seed_conn, RK, n).unwrap();
+    } // seed 接続を閉じる
+    let read_conn = open_bench_db(&path).unwrap(); // 読み取り PRAGMA で開き直す
+    (guard, read_conn)
+}
+
+/// rusqlite の異種パラメータ配列問題を避けるため Params ジェネリックにする。
+/// 呼び出し側は rusqlite::params![..] を渡す。
+fn run_select<P: rusqlite::Params>(conn: &Connection, sql: &str, params: P) -> usize {
+    let mut stmt = conn.prepare_cached(sql).unwrap();
+    stmt.query_map(params, |_r| Ok(()))
+        .unwrap()
+        .filter_map(|r| r.ok())
+        .count()
+}
+
+fn dump_query_plans() {
+    let (_g, conn) = seeded_readonly_db("plan", 1000);
+    let where_c = search_where_prefixed();
+    // EXPLAIN QUERY PLAN は未束縛 ? を嫌うため、リテラル値で組む（プランは値非依存で SCAN/index が判る）。
+    let where_lit = where_c.replace("LIKE ?", "LIKE '%さくら%'");
+    let shapes: Vec<(&str, String)> = vec![
+        ("empty+name", format!("SELECT {SELECT_COLS} FROM ghosts g WHERE g.request_key='{RK}' ORDER BY {} LIMIT 50", order_by("name"))),
+        ("like+name", format!("SELECT {SELECT_COLS} FROM ghosts g WHERE g.request_key='{RK}' AND ({where_lit}) ORDER BY {} LIMIT 50", order_by("name"))),
+        ("empty+recent", format!("SELECT {SELECT_COLS} FROM ghosts g WHERE g.request_key='{RK}' ORDER BY {} LIMIT 50", order_by("recent"))),
+        ("empty+frequency", format!("SELECT {SELECT_COLS} FROM ghosts g WHERE g.request_key='{RK}' ORDER BY {} LIMIT 50", order_by("frequency"))),
+        ("empty+random", format!("SELECT {SELECT_COLS} FROM ghosts g WHERE g.request_key='{RK}' ORDER BY {} LIMIT 50", order_by("random"))),
+    ];
+    println!("\n===== EXPLAIN QUERY PLAN (n=1000) =====");
+    for (label, sql) in shapes {
+        println!("--- {label} ---");
+        let mut stmt = conn.prepare(&format!("EXPLAIN QUERY PLAN {sql}")).unwrap();
+        // EXPLAIN QUERY PLAN の detail 列は index 3
+        let mut rows = stmt.query([]).unwrap();
+        while let Some(row) = rows.next().unwrap() {
+            let detail: String = row.get(3).unwrap();
+            println!("  {detail}");
+        }
+    }
+    println!("=======================================\n");
+}
+
+fn bench_search(c: &mut Criterion) {
+    let where_c = search_where_prefixed();
+    // COUNT は本番 countGhostsByQuery と同形（前置きなし 6 列 OR）
+    let count_where = where_c.replace("g.", "");
+    for &n in &[1_000usize, 10_000, 100_000] {
+        let (_g, conn) = seeded_readonly_db(&format!("n{n}"), n);
+        let like_none = format!("%{Q_NONE}%");
+        let like_rare = format!("%{Q_RARE}%");
+        let like_common = format!("%{Q_COMMON}%");
+
+        let mut group = c.benchmark_group(format!("search_n{n}"));
+        if n >= 100_000 {
+            group.sample_size(20).measurement_time(Duration::from_secs(15));
+        }
+
+        // 空クエリ × 各ソート（無名 ? 統一。params: [rk, limit]）
+        for sort in ["name", "recent", "frequency", "random"] {
+            let sql = format!(
+                "SELECT {SELECT_COLS} FROM ghosts g WHERE g.request_key=? ORDER BY {} LIMIT ?",
+                order_by(sort)
+            );
+            group.bench_with_input(BenchmarkId::new("empty_sort", sort), &sql, |b, sql| {
+                b.iter(|| run_select(&conn, sql, rusqlite::params![RK, LIMIT]));
+            });
+        }
+
+        // LIKE 選択率 3 種（sort=name 固定。params: [rk, like×6, limit]）
+        for (label, like) in [("none", &like_none), ("rare", &like_rare), ("common", &like_common)] {
+            let sql = format!(
+                "SELECT {SELECT_COLS} FROM ghosts g WHERE g.request_key=? AND ({where_c}) \
+                 ORDER BY {} LIMIT ?",
+                order_by("name")
+            );
+            group.bench_with_input(BenchmarkId::new("like", label), &sql, |b, sql| {
+                b.iter(|| {
+                    run_select(
+                        &conn,
+                        sql,
+                        rusqlite::params![RK, like, like, like, like, like, like, LIMIT],
+                    )
+                });
+            });
+        }
+
+        // OFFSET 深度（空クエリ・sort=name。params: [rk, limit, offset]）
+        for (label, offset) in [("0", 0i64), ("mid", (n as i64) / 2), ("deep", (n as i64 - LIMIT).max(0))] {
+            let sql = format!(
+                "SELECT {SELECT_COLS} FROM ghosts g WHERE g.request_key=? ORDER BY {} LIMIT ? OFFSET ?",
+                order_by("name")
+            );
+            group.bench_with_input(BenchmarkId::new("offset", label), &offset, |b, &offset| {
+                b.iter(|| run_select(&conn, &sql, rusqlite::params![RK, LIMIT, offset]));
+            });
+        }
+
+        // COUNT + SELECT 併走（本番 1 検索の実コスト・common クエリ）
+        // count は前置きなし 6 列 OR（本番 countGhostsByQuery）、params: [rk, like×6]
+        let count_sql = format!(
+            "SELECT COUNT(*) FROM ghosts WHERE request_key=? AND ({count_where})"
+        );
+        // select は g. 前置き（本番 searchGhosts）、params: [rk, like×6, limit]
+        let select_sql = format!(
+            "SELECT {SELECT_COLS} FROM ghosts g WHERE g.request_key=? AND ({where_c}) \
+             ORDER BY {} LIMIT ?",
+            order_by("name")
+        );
+        group.bench_function("count_plus_select_common", |b| {
+            b.iter(|| {
+                let lc = &like_common;
+                let _c: i64 = conn
+                    .query_row(&count_sql, rusqlite::params![RK, lc, lc, lc, lc, lc, lc], |r| r.get(0))
+                    .unwrap();
+                run_select(
+                    &conn,
+                    &select_sql,
+                    rusqlite::params![RK, lc, lc, lc, lc, lc, lc, LIMIT],
+                );
+            });
+        });
+
+        group.finish();
+    }
+}
+
+// TempDirGuard は lib 内部（非 pub）なので、ベンチ用の最小 tmp ガードをローカルに持つ。
+mod tempfile_dir {
+    use std::path::{Path, PathBuf};
+    pub struct Guard(PathBuf);
+    impl Guard {
+        pub fn new(prefix: &str) -> Self {
+            // scratchpad ではなく OS 一時ディレクトリ配下。ベンチ終了時に削除。
+            let mut base = std::env::temp_dir();
+            base.push(format!("ghost_bench_{prefix}_{}", std::process::id()));
+            std::fs::create_dir_all(&base).unwrap();
+            Guard(base)
+        }
+        pub fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+}
+
+fn main() {
+    dump_query_plans();
+    let mut c = Criterion::default().configure_from_args();
+    bench_search(&mut c);
+    c.final_summary();
+}

--- a/src-tauri/src/bench_support.rs
+++ b/src-tauri/src/bench_support.rs
@@ -7,7 +7,9 @@ use std::path::{Path, PathBuf};
 use rusqlite::Connection;
 
 use crate::commands::ghost::store::{configure_connection, store_ghosts};
-use crate::commands::ghost::Ghost;
+use crate::commands::ghost::{
+    check_parent_mtimes_match, collect_parent_mtimes, scan_ghosts_with_fingerprint_internal, Ghost,
+};
 
 /// クレートルートから内部経路へ到達できることを確認するプレースホルダ。
 /// 後続タスクで seeder / generator / wrapper に置き換える。
@@ -176,6 +178,54 @@ pub fn generate_ghost_tree(ssp_root: &Path, n: usize) -> Result<PathBuf, String>
     Ok(ssp_root.to_path_buf())
 }
 
+/// スキャン結果の Ghost 群を外部ベンチに対して opaque に保持する。
+pub struct ScannedGhosts {
+    ghosts: Vec<Ghost>,
+}
+
+/// フル走査を 1 回行い、opaque ハンドルと fingerprint を返す。
+pub fn scan_to_handle(ssp_path: &str) -> Result<(ScannedGhosts, String), String> {
+    let (ghosts, fp) = scan_ghosts_with_fingerprint_internal(ssp_path, &[])?;
+    Ok((ScannedGhosts { ghosts }, fp))
+}
+
+/// ハンドルの Ghost 群を本番 store_ghosts で書き込む（差分 UPSERT）。
+pub fn store_handle(
+    conn: &Connection,
+    request_key: &str,
+    h: &ScannedGhosts,
+    fp: &str,
+) -> Result<usize, String> {
+    store_ghosts(conn, request_key, &h.ghosts, fp, "bench-mtimes")
+}
+
+/// ハンドルを実際の親 mtime 付きで書き込む。これを使うと後続の layer1_hit が真に成立する
+/// （store_handle は "bench-mtimes" 固定のため mtime 照合が必ず外れる）。
+pub fn store_with_real_mtimes(
+    conn: &Connection,
+    request_key: &str,
+    h: &ScannedGhosts,
+    fp: &str,
+    ssp_path: &str,
+) -> Result<usize, String> {
+    let mtimes = collect_parent_mtimes(ssp_path, &[]);
+    store_ghosts(conn, request_key, &h.ghosts, fp, &mtimes)
+}
+
+/// フル走査を行い体数だけ返す（walk+parse コスト計測用）。
+pub fn full_scan_count(ssp_path: &str) -> Result<usize, String> {
+    let (ghosts, _fp) = scan_ghosts_with_fingerprint_internal(ssp_path, &[])?;
+    Ok(ghosts.len())
+}
+
+/// Layer 1 高速パス（親 mtime 一致判定）を測る。事前に store_with_real_mtimes で
+/// 保存していれば true（hit）、store_handle で保存していれば false（miss）を返すが、
+/// 計測対象の「1 行 SELECT + 文字列比較」コストはどちらも同等。
+pub fn layer1_hit(conn: &Connection, request_key: &str, ssp_path: &str) -> bool {
+    let mtimes = collect_parent_mtimes(ssp_path, &[]);
+    check_parent_mtimes_match(conn, request_key, &mtimes)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -336,5 +386,29 @@ mod tests {
         )
         .unwrap();
         assert_eq!(ghosts.len(), 30);
+    }
+
+    #[test]
+    fn scan_to_handle_と_store_handle_が往復する() {
+        let tmp = TempDirGuard::new("bench_scan_store");
+        let ssp = tmp.path().join("ssp");
+        generate_ghost_tree(&ssp, 40).unwrap();
+
+        let (handle, fp) = scan_to_handle(&ssp.to_string_lossy()).unwrap();
+        let db = tmp.path().join("ghosts.db");
+        let conn = open_bench_db(&db).unwrap();
+        let stored = store_handle(&conn, "rk", &handle, &fp).unwrap();
+        assert_eq!(stored, 40);
+        // 2 回目は差分ゼロ（同一 handle）→ 行数不変
+        let stored2 = store_handle(&conn, "rk", &handle, &fp).unwrap();
+        assert_eq!(stored2, 40);
+    }
+
+    #[test]
+    fn full_scan_count_が体数を返す() {
+        let tmp = TempDirGuard::new("bench_full_scan");
+        let ssp = tmp.path().join("ssp");
+        generate_ghost_tree(&ssp, 25).unwrap();
+        assert_eq!(full_scan_count(&ssp.to_string_lossy()).unwrap(), 25);
     }
 }

--- a/src-tauri/src/bench_support.rs
+++ b/src-tauri/src/bench_support.rs
@@ -1,0 +1,36 @@
+//! 10万体規模の性能計測用フィクスチャ生成器と本番経路ラッパー。
+//! `bench` feature 有効時のみコンパイルされ、本番ビルドには含まれない。
+
+use rusqlite::Connection;
+
+/// クレートルートから内部経路へ到達できることを確認するプレースホルダ。
+/// 後続タスクで seeder / generator / wrapper に置き換える。
+#[doc(hidden)]
+pub fn __bench_support_linked() -> bool {
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bench_support_がリンクされる() {
+        assert!(__bench_support_linked());
+    }
+
+    #[test]
+    fn 内部型と関数へ到達できる() {
+        // 再エクスポート4種すべての疎通確認（import できてコンパイルが通れば可視性は正しい）。
+        // 全てに触れることで feature ビルドの unused 警告も防ぐ。
+        use crate::commands::ghost::{
+            check_parent_mtimes_match, collect_parent_mtimes,
+            scan_ghosts_with_fingerprint_internal, Ghost,
+        };
+        let _ = std::mem::size_of::<Ghost>();
+        let _ = collect_parent_mtimes as fn(&str, &[String]) -> String;
+        let _ = check_parent_mtimes_match as fn(&Connection, &str, &str) -> bool;
+        let _ = scan_ghosts_with_fingerprint_internal
+            as fn(&str, &[String]) -> Result<(Vec<Ghost>, String), String>;
+    }
+}

--- a/src-tauri/src/bench_support.rs
+++ b/src-tauri/src/bench_support.rs
@@ -22,7 +22,9 @@ mod tests {
     #[test]
     fn 内部型と関数へ到達できる() {
         // 再エクスポート4種すべての疎通確認（import できてコンパイルが通れば可視性は正しい）。
-        // 全てに触れることで feature ビルドの unused 警告も防ぐ。
+        // 注: この use は #[cfg(test)] 配下のため、feature 有効の非テストビルドでは
+        // 再エクスポートに消費者がなく unused 警告が出る（Task 6 が bench_support 関数で
+        // scan/fingerprint を消費した時点で解消。CI は --features bench をビルドしないため無害）。
         use crate::commands::ghost::{
             check_parent_mtimes_match, collect_parent_mtimes,
             scan_ghosts_with_fingerprint_internal, Ghost,

--- a/src-tauri/src/bench_support.rs
+++ b/src-tauri/src/bench_support.rs
@@ -1,13 +1,105 @@
 //! 10万体規模の性能計測用フィクスチャ生成器と本番経路ラッパー。
 //! `bench` feature 有効時のみコンパイルされ、本番ビルドには含まれない。
 
+use std::path::Path;
+
 use rusqlite::Connection;
+
+use crate::commands::ghost::store::{configure_connection, store_ghosts};
+use crate::commands::ghost::Ghost;
 
 /// クレートルートから内部経路へ到達できることを確認するプレースホルダ。
 /// 後続タスクで seeder / generator / wrapper に置き換える。
 #[doc(hidden)]
 pub fn __bench_support_linked() -> bool {
     true
+}
+
+/// どの行にもマッチしない語（0 件）
+pub const Q_NONE: &str = "該当なし_zzzq";
+/// 約 0.1% にマッチ（craftman が "作者777" の行 = i % 1000 == 777）
+pub const Q_RARE: &str = "作者777";
+/// 約 10% にマッチ（name が "さくら…" の行 = i % 10 == 0）
+pub const Q_COMMON: &str = "さくら";
+
+/// 本番読み取り接続（loadDb, ghostDatabase.ts）と同じ PRAGMA で一時 DB を開く。
+/// ghosts テーブルが未作成のときだけ migrations を適用する（同一ファイルへの
+/// 二度目の open で ALTER TABLE ADD COLUMN が "duplicate column" で落ちるのを防ぐ）。
+/// 書き込み用 configure_connection の大 cache は引かない。
+pub fn open_bench_db(path: &Path) -> Result<Connection, String> {
+    let conn = Connection::open(path).map_err(|e| format!("DB open: {e}"))?;
+    let has_schema: bool = conn
+        .query_row(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='ghosts'",
+            [],
+            |_| Ok(true),
+        )
+        .unwrap_or(false);
+    if !has_schema {
+        let mut ms = crate::migrations();
+        ms.sort_by_key(|m| m.version);
+        for m in &ms {
+            conn.execute_batch(m.sql)
+                .map_err(|e| format!("migration {}: {e}", m.version))?;
+        }
+    }
+    // 本番読み取り接続の PRAGMA（loadDb と同順）。大 cache/mmap は意図的に引かない。
+    // データ投入後の再 open では optimize=0x10002 の ANALYZE が本番同様に統計を作る。
+    conn.execute_batch(
+        "PRAGMA journal_mode=WAL;\
+         PRAGMA busy_timeout=5000;\
+         PRAGMA journal_size_limit=4194304;\
+         PRAGMA optimize=0x10002;",
+    )
+    .map_err(|e| format!("PRAGMA: {e}"))?;
+    Ok(conn)
+}
+
+/// 現実寄せ分布の合成ゴースト 1 件を生成する（決定的・index ベース）。
+fn synth_ghost(i: usize) -> Ghost {
+    let jp = ["さくら", "うにゅう", "ゴースト", "妖精", "式神"];
+    let en = ["Alice", "Bob", "Ghost", "Fairy", "Nova"];
+    // i % 10 == 0 の行だけ名前を "さくら…" にして Q_COMMON の選択率を ~10% に固定
+    let base = if i % 10 == 0 {
+        "さくら"
+    } else if i % 2 == 0 {
+        jp[i % jp.len()]
+    } else {
+        en[i % en.len()]
+    };
+    Ghost {
+        diff_fingerprint: format!("fp-{i}"),
+        name: format!("{base}{i}"),
+        sakura_name: if i % 3 == 0 { format!("{base}の精") } else { String::new() },
+        kero_name: if i % 5 == 0 { format!("相方{i}") } else { String::new() },
+        // i % 1000 == 777 の行だけ craftman が "作者777" → Q_RARE の選択率 ~0.1%
+        craftman: format!("作者{}", i % 1000),
+        craftmanw: String::new(),
+        directory_name: format!("dir_{i:06}"),
+        path: format!("C:/ghosts/dir_{i:06}"),
+        source: "ssp".to_string(),
+        thumbnail_path: String::new(),
+        thumbnail_use_self_alpha: false,
+        thumbnail_kind: String::new(),
+    }
+}
+
+/// N 行を本番の store_ghosts 経由で投入し、起動集計列を一部にばらけさせる。
+pub fn seed_ghosts_db(conn: &Connection, request_key: &str, n: usize) -> Result<(), String> {
+    configure_connection(conn)?; // 書き込みは本番と同じ PRAGMA で高速化（読み取り計測とは別接続想定）
+    let ghosts: Vec<Ghost> = (0..n).map(synth_ghost).collect();
+    store_ghosts(conn, request_key, &ghosts, "bench-fp", "bench-mtimes")?;
+
+    // recent/frequency ソートの現実性: 25% に last_launched、一部に launch_count を付与
+    conn.execute(
+        "UPDATE ghosts SET \
+           last_launched = datetime('now', '-' || (id % 30) || ' days'), \
+           launch_count = (id % 7) \
+         WHERE request_key = ?1 AND id % 4 = 0",
+        [request_key],
+    )
+    .map_err(|e| format!("sprinkle: {e}"))?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -34,5 +126,83 @@ mod tests {
         let _ = check_parent_mtimes_match as fn(&Connection, &str, &str) -> bool;
         let _ = scan_ghosts_with_fingerprint_internal
             as fn(&str, &[String]) -> Result<(Vec<Ghost>, String), String>;
+    }
+
+    use crate::testutil::TempDirGuard;
+
+    #[test]
+    fn seed_ghosts_db_が_n_行を投入する() {
+        let tmp = TempDirGuard::new("bench_seed_count");
+        let db = tmp.path().join("ghosts.db");
+        let conn = open_bench_db(&db).unwrap();
+        seed_ghosts_db(&conn, "rk", 500).unwrap();
+
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM ghosts WHERE request_key = ?1",
+                ["rk"],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 500);
+    }
+
+    #[test]
+    fn seed_ghosts_db_が_lower_列を正規化する() {
+        let tmp = TempDirGuard::new("bench_seed_lower");
+        let db = tmp.path().join("ghosts.db");
+        let conn = open_bench_db(&db).unwrap();
+        seed_ghosts_db(&conn, "rk", 50).unwrap();
+
+        // name_lower は全て小文字（NFKC + lower 済み）
+        let bad: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM ghosts WHERE request_key='rk' AND name_lower != lower(name_lower)",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(bad, 0);
+    }
+
+    #[test]
+    fn seed_ghosts_db_が起動集計列をばらけさせる() {
+        let tmp = TempDirGuard::new("bench_seed_launch");
+        let db = tmp.path().join("ghosts.db");
+        let conn = open_bench_db(&db).unwrap();
+        seed_ghosts_db(&conn, "rk", 400).unwrap();
+
+        let launched: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM ghosts WHERE request_key='rk' AND last_launched IS NOT NULL",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        // 一部のみ非 NULL（全 NULL でも全非 NULL でもない）
+        assert!(launched > 0 && launched < 400);
+    }
+
+    #[test]
+    fn クエリセットの選択率が意図の桁に収まる() {
+        let tmp = TempDirGuard::new("bench_seed_selectivity");
+        let db = tmp.path().join("ghosts.db");
+        let conn = open_bench_db(&db).unwrap();
+        seed_ghosts_db(&conn, "rk", 10_000).unwrap();
+
+        let count = |q: &str| -> i64 {
+            let like = format!("%{}%", q);
+            conn.query_row(
+                "SELECT COUNT(*) FROM ghosts WHERE request_key='rk' AND \
+                 (name_lower LIKE ?1 OR sakura_name_lower LIKE ?1 OR kero_name_lower LIKE ?1 \
+                  OR craftman_lower LIKE ?1 OR craftmanw_lower LIKE ?1 OR directory_name_lower LIKE ?1)",
+                [like],
+                |r| r.get(0),
+            )
+            .unwrap()
+        };
+        assert_eq!(count(Q_NONE), 0);
+        assert!(count(Q_RARE) > 0 && count(Q_RARE) < 100); // ~0.1% = ~10
+        assert!(count(Q_COMMON) > 500); // ~10% = ~1000
     }
 }

--- a/src-tauri/src/bench_support.rs
+++ b/src-tauri/src/bench_support.rs
@@ -102,6 +102,38 @@ pub fn seed_ghosts_db(conn: &Connection, request_key: &str, n: usize) -> Result<
     Ok(())
 }
 
+/// 検索対象の _lower 列（GHOST_SEARCH_LOWER_COLUMNS と一致）。真の権威は ghostDatabase.ts。
+pub const SEARCH_LOWER_COLUMNS: [&str; 6] = [
+    "name_lower",
+    "sakura_name_lower",
+    "kero_name_lower",
+    "craftman_lower",
+    "craftmanw_lower",
+    "directory_name_lower",
+];
+
+/// searchGhosts と同形の WHERE（g. 前置き・6 列 OR）。
+pub fn search_where_prefixed() -> String {
+    SEARCH_LOWER_COLUMNS
+        .iter()
+        .map(|c| format!("g.{c} LIKE ?"))
+        .collect::<Vec<_>>()
+        .join(" OR ")
+}
+
+/// buildOrderBy(ghostDatabase.ts:212) と同形の ORDER BY 式。
+/// random は固定シード/剰余で再現（本番は session シード）。
+pub fn order_by(sort: &str) -> String {
+    const RANDOM_SORT_MODULUS: u64 = 1000003;
+    const BENCH_SEED: u64 = 2654435761 % RANDOM_SORT_MODULUS;
+    match sort {
+        "random" => format!("(g.id * {BENCH_SEED}) % {RANDOM_SORT_MODULUS}, g.id"),
+        "recent" => "g.last_launched DESC NULLS LAST, g.name_lower ASC".to_string(),
+        "frequency" => "g.launch_count DESC, g.name_lower ASC".to_string(),
+        _ => "g.name_lower ASC".to_string(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -181,6 +213,31 @@ mod tests {
             .unwrap();
         // 一部のみ非 NULL（全 NULL でも全非 NULL でもない）
         assert!(launched > 0 && launched < 400);
+    }
+
+    #[test]
+    fn sql形状が共有fixtureと一致する() {
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../src/test/fixtures/search-sql-shapes.json"
+        );
+        let raw = std::fs::read_to_string(path).expect("fixture を読めること");
+        let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
+
+        let cols: Vec<String> = v["searchLowerColumns"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|x| x.as_str().unwrap().to_string())
+            .collect();
+        assert_eq!(SEARCH_LOWER_COLUMNS.to_vec(), cols);
+
+        assert_eq!(order_by("name"), v["orderBy"]["name"].as_str().unwrap());
+        assert_eq!(order_by("recent"), v["orderBy"]["recent"].as_str().unwrap());
+        assert_eq!(
+            order_by("frequency"),
+            v["orderBy"]["frequency"].as_str().unwrap()
+        );
     }
 
     #[test]

--- a/src-tauri/src/bench_support.rs
+++ b/src-tauri/src/bench_support.rs
@@ -203,6 +203,7 @@ mod tests {
         };
         assert_eq!(count(Q_NONE), 0);
         assert!(count(Q_RARE) > 0 && count(Q_RARE) < 100); // ~0.1% = ~10
-        assert!(count(Q_COMMON) > 500); // ~10% = ~1000
+        // 上限も縛る: 全一致(選択率100%)への劣化を検出する（Q_RARE と同じ両側境界）
+        assert!(count(Q_COMMON) > 500 && count(Q_COMMON) < 2000); // ~10% = ~1000
     }
 }

--- a/src-tauri/src/bench_support.rs
+++ b/src-tauri/src/bench_support.rs
@@ -411,4 +411,37 @@ mod tests {
         generate_ghost_tree(&ssp, 25).unwrap();
         assert_eq!(full_scan_count(&ssp.to_string_lossy()).unwrap(), 25);
     }
+
+    // ハーネス核心の不変条件を縛る（scan_bench の debug_assert! は bench プロファイルで no-op のため
+    // ここで cargo test（debug-assertions 有効）による回帰ガードを置く）。
+    #[test]
+    fn store_with_real_mtimes_後は_layer1_hit_が_true() {
+        let tmp = TempDirGuard::new("bench_layer1_hit");
+        let ssp = tmp.path().join("ssp");
+        generate_ghost_tree(&ssp, 10).unwrap();
+        let ssp_str = ssp.to_string_lossy().to_string();
+
+        let (handle, fp) = scan_to_handle(&ssp_str).unwrap();
+        let conn = open_bench_db(&tmp.path().join("ghosts.db")).unwrap();
+        store_with_real_mtimes(&conn, "rk", &handle, &fp, &ssp_str).unwrap();
+
+        // 実 mtimes を保存したので、無変更のまま再照合すれば hit（Layer 1 高速パス成立）
+        assert!(layer1_hit(&conn, "rk", &ssp_str), "実 mtimes 保存後は hit のはず");
+    }
+
+    #[test]
+    fn store_handle_後は_layer1_hit_が_false() {
+        let tmp = TempDirGuard::new("bench_layer1_miss");
+        let ssp = tmp.path().join("ssp");
+        generate_ghost_tree(&ssp, 10).unwrap();
+        let ssp_str = ssp.to_string_lossy().to_string();
+
+        let (handle, fp) = scan_to_handle(&ssp_str).unwrap();
+        let conn = open_bench_db(&tmp.path().join("ghosts.db")).unwrap();
+        store_handle(&conn, "rk", &handle, &fp).unwrap();
+
+        // store_handle は parent_mtimes を "bench-mtimes" 固定で保存するため、
+        // 実 mtimes（"path:nanos" 形式）とは決して一致せず miss になる
+        assert!(!layer1_hit(&conn, "rk", &ssp_str), "bench-mtimes 固定後は miss のはず");
+    }
 }

--- a/src-tauri/src/bench_support.rs
+++ b/src-tauri/src/bench_support.rs
@@ -1,7 +1,8 @@
 //! 10万体規模の性能計測用フィクスチャ生成器と本番経路ラッパー。
 //! `bench` feature 有効時のみコンパイルされ、本番ビルドには含まれない。
 
-use std::path::Path;
+use std::fs;
+use std::path::{Path, PathBuf};
 
 use rusqlite::Connection;
 
@@ -134,6 +135,47 @@ pub fn order_by(sort: &str) -> String {
     }
 }
 
+/// {ssp_root}/ghost 配下に N 体のゴーストツリーを生成する。
+/// - 全体に ghost/master/descript.txt（UTF-8、一部 Shift_JIS）
+/// - i % 3 == 0 に shell/master/surface0.png（thumbnail 解決経路）
+pub fn generate_ghost_tree(ssp_root: &Path, n: usize) -> Result<PathBuf, String> {
+    let ghost_dir = ssp_root.join("ghost");
+    fs::create_dir_all(&ghost_dir).map_err(|e| format!("mkdir ghost: {e}"))?;
+
+    for i in 0..n {
+        let g = synth_ghost(i);
+        let master = ghost_dir.join(&g.directory_name).join("ghost").join("master");
+        fs::create_dir_all(&master).map_err(|e| format!("mkdir master: {e}"))?;
+
+        let descript = format!(
+            "name,{}\nsakura.name,{}\nkero.name,{}\ncraftman,{}\n",
+            g.name,
+            if g.sakura_name.is_empty() { "" } else { &g.sakura_name },
+            if g.kero_name.is_empty() { "" } else { &g.kero_name },
+            g.craftman
+        );
+        let descript_path = master.join("descript.txt");
+        if i % 7 == 0 {
+            // Shift_JIS（charset 明示）で文字コード判定経路を踏む
+            let sjis_body = format!("charset,Shift_JIS\n{descript}");
+            let (bytes, _, _) = encoding_rs::SHIFT_JIS.encode(&sjis_body);
+            fs::write(&descript_path, bytes).map_err(|e| format!("write sjis: {e}"))?;
+        } else {
+            let utf8_body = format!("charset,UTF-8\n{descript}");
+            fs::write(&descript_path, utf8_body).map_err(|e| format!("write utf8: {e}"))?;
+        }
+
+        // 一部に surface0.png を置き thumbnail 解決を発生させる
+        if i % 3 == 0 {
+            let shell_master = ghost_dir.join(&g.directory_name).join("shell").join("master");
+            fs::create_dir_all(&shell_master).map_err(|e| format!("mkdir shell: {e}"))?;
+            fs::write(shell_master.join("surface0.png"), b"")
+                .map_err(|e| format!("write png: {e}"))?;
+        }
+    }
+    Ok(ssp_root.to_path_buf())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -262,5 +304,37 @@ mod tests {
         assert!(count(Q_RARE) > 0 && count(Q_RARE) < 100); // ~0.1% = ~10
         // 上限も縛る: 全一致(選択率100%)への劣化を検出する（Q_RARE と同じ両側境界）
         assert!(count(Q_COMMON) > 500 && count(Q_COMMON) < 2000); // ~10% = ~1000
+    }
+
+    #[test]
+    fn generate_ghost_tree_が_n_体を生成する() {
+        let tmp = TempDirGuard::new("bench_tree");
+        let ssp = tmp.path().join("ssp");
+        let returned = generate_ghost_tree(&ssp, 20).unwrap();
+        assert_eq!(returned, ssp);
+
+        let ghost_dir = ssp.join("ghost");
+        let count = std::fs::read_dir(&ghost_dir).unwrap().count();
+        assert_eq!(count, 20);
+
+        // 各体に descript.txt が存在する
+        for entry in std::fs::read_dir(&ghost_dir).unwrap() {
+            let d = entry.unwrap().path().join("ghost").join("master").join("descript.txt");
+            assert!(d.exists(), "descript missing: {}", d.display());
+        }
+    }
+
+    #[test]
+    fn generate_ghost_tree_を本番スキャンが読める() {
+        let tmp = TempDirGuard::new("bench_tree_scan");
+        let ssp = tmp.path().join("ssp");
+        generate_ghost_tree(&ssp, 30).unwrap();
+
+        let (ghosts, _fp) = crate::commands::ghost::scan_ghosts_with_fingerprint_internal(
+            &ssp.to_string_lossy(),
+            &[],
+        )
+        .unwrap();
+        assert_eq!(ghosts.len(), 30);
     }
 }

--- a/src-tauri/src/commands/ghost/mod.rs
+++ b/src-tauri/src/commands/ghost/mod.rs
@@ -5,6 +5,14 @@ mod scan;
 pub(crate) mod store;
 mod types;
 
+// ベンチ計測用の内部関数・型の最小露出。feature 無効時は一切影響しない。
+#[cfg(feature = "bench")]
+pub(crate) use fingerprint::{check_parent_mtimes_match, collect_parent_mtimes};
+#[cfg(feature = "bench")]
+pub(crate) use scan::scan_ghosts_with_fingerprint_internal;
+#[cfg(feature = "bench")]
+pub(crate) use types::Ghost;
+
 pub use types::ScanStoreResult;
 
 /// request_key が空なら Err を返す。JS 単一権威の信頼境界での最小防御。

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,8 @@ mod commands;
 mod db_path;
 #[cfg(test)]
 pub(crate) mod testutil;
+#[cfg(feature = "bench")]
+pub mod bench_support;
 
 // マイグレーション追加時の注意:
 //   ALTER TABLE ... ADD COLUMN ... DEFAULT <値> の <値> はリテラルのみ許容される。

--- a/src/lib/ghostDatabase.ts
+++ b/src/lib/ghostDatabase.ts
@@ -175,7 +175,7 @@ export const GHOST_VIEW_COLUMNS = [
 // 列挙漏れがあると never でなくなり、下の型注釈が never に解決されて代入が型エラーになる。
 type MissingGhostViewColumns = Exclude<keyof GhostView, (typeof GHOST_VIEW_COLUMNS)[number]>;
 
-const GHOST_SEARCH_LOWER_COLUMNS = [
+export const GHOST_SEARCH_LOWER_COLUMNS = [
   "name_lower",
   "sakura_name_lower",
   "kero_name_lower",

--- a/src/lib/searchSqlShapes.parity.test.ts
+++ b/src/lib/searchSqlShapes.parity.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import shapes from "../test/fixtures/search-sql-shapes.json";
+import { GHOST_SEARCH_LOWER_COLUMNS, buildOrderBy } from "./ghostDatabase";
+
+describe("検索 SQL 形状の言語間パリティ", () => {
+  it("検索対象列が fixture と一致する", () => {
+    expect([...GHOST_SEARCH_LOWER_COLUMNS]).toEqual(shapes.searchLowerColumns);
+  });
+
+  it("name/recent/frequency の ORDER BY が fixture と一致する", () => {
+    expect(buildOrderBy("name")).toBe(shapes.orderBy.name);
+    expect(buildOrderBy("recent")).toBe(shapes.orderBy.recent);
+    expect(buildOrderBy("frequency")).toBe(shapes.orderBy.frequency);
+  });
+});

--- a/src/test/fixtures/search-sql-shapes.json
+++ b/src/test/fixtures/search-sql-shapes.json
@@ -1,0 +1,15 @@
+{
+  "searchLowerColumns": [
+    "name_lower",
+    "sakura_name_lower",
+    "kero_name_lower",
+    "craftman_lower",
+    "craftmanw_lower",
+    "directory_name_lower"
+  ],
+  "orderBy": {
+    "name": "g.name_lower ASC",
+    "recent": "g.last_launched DESC NULLS LAST, g.name_lower ASC",
+    "frequency": "g.launch_count DESC, g.name_lower ASC"
+  }
+}


### PR DESCRIPTION
## Summary
- SQL層（search の `LIKE '%…%'` / 特殊sort / OFFSET）を計測する criterion ベンチ `search_bench` を追加
- FS走査層（scan/fingerprint/store）を計測する criterion ベンチ `scan_bench` を追加
- 共有フィクスチャ生成器・本番経路ラッパー（`src-tauri/src/bench_support.rs`、すべて `#[cfg(feature = "bench")]` ゲート下）と、検索SQL形状の Rust/TS 言語間パリティ fixture を追加
- 実測ベースライン `docs/perf/baseline-100k.md` を記録：**全走査は Layer1高速チェックの約259,800倍**（NTFS親mtime粒度ゆえ1体増減で全走査が蘇る）、**先頭ワイルドカードLIKEはindex経路の約3662倍**（COUNTは検索1回ごとの不可避コスト）、非indexソートは全件TEMP B-TREE、深いOFFSETは線形悪化
- **本番の振る舞い・API・可視性は一切変更なし**（露出はすべて bench feature ゲート下＋docs。`ghostDatabase.ts` の唯一の変更は const→export で値・利用箇所は不変）。修正（FTS5 / fingerprint粒度 / 複合index / keyset）は本数値を根拠に別サイクルで起票

設計/計画: `docs/superpowers/specs/2026-07-16-perf-benchmark-harness-design.md` / `docs/superpowers/plans/2026-07-16-perf-benchmark-harness.md`

## Test plan
- [x] `npm run build`
- [x] `npm test`（22 files / 176 tests）
- [x] `cargo test --workspace`（feature無効・本番非影響を確認）
- [x] `cargo test -p ghost-meta --features thumbnail,serde`
- [x] `cargo test --features bench bench_support`（13/13：パリティ / 選択率両側境界 / layer1 hit-miss ガード）
- [x] `cargo check`（feature無効でコンパイル・警告なしを確認）
- [x] 両ベンチの実走（`search_bench` / `scan_bench`）でベースライン数値を採取

🤖 Generated with [Claude Code](https://claude.com/claude-code)