### PR TITLE
test: 全走査スキャン粒度化の計測ハーネス拡張・設計・計画（#134 Phase1）

### DIFF
--- a/docs/perf/granular-scan-spectrum-100k.md
+++ b/docs/perf/granular-scan-spectrum-100k.md
@@ -1,86 +1,90 @@
 # walk スペクトラム計測（10万体規模・#134 Phase 1）
 
 - 計測日: 2026-07-16
-- 目的: Phase 2 の fidelity レベル（full/dir_mtime/name-set）を選ぶための walk/parse 内訳と、
+- 目的: Phase 2 の設計（fidelity レベル・walk 最適化）を選ぶための walk/parse 内訳と、
   「1体変更→再走査」の現行ベースライン。修正（Phase 2）は本数値を根拠に別サイクル。
 - 実行環境: Windows 11 Home 10.0.26200 / ワークスペースは SSD。`bench` プロファイル
   （`cargo bench --features bench`、release 最適化継承）。warm cache（ツリー生成直後・同一プロセス反復）。
-- **重要な環境注記**: 本実行の `full_scan`（n=100k）は **6.43s** で、`docs/perf/baseline-100k.md`（#133）の
-  **3.47s** の約 **1.85 倍**。計測セッション中のビルド／背景タスクによるコンテンションが主因と見られる
-  （同一 build 番号だが baseline は Pro 表記・本実行は Home 表記で環境差の可能性もある）。
-  **判断根拠は絶対値でなく、同一実行内の相対比率**とする（全 shape が同条件で走っているため比率は有効）。
+- **環境注記**: 本実行の `full_scan`（n=100k）は **6.18s** で、`docs/perf/baseline-100k.md`（#133）の
+  **3.47s** の約 1.8 倍。計測セッション中のビルド／背景タスクによるコンテンションが主因と見られる。
+  **判断根拠は絶対値でなく、同一実行内の相対比率**とする（全 shape が同条件のため比率は有効）。
 - 手順: `cargo bench --features bench --manifest-path src-tauri/Cargo.toml --bench scan_bench`
 
-## walk スペクトラムと parse 内訳（中央値）
+## 計測結果（中央値）
 
 | 形状 | n=1k | n=10k | n=100k |
 |---|---|---|---|
-| full_scan（walk+parse・本番） | 57.78 ms | 629.69 ms | 6.4300 s |
-| walk_full_fidelity_3stat（本番 walk・parse抜き・token+hash込み） | 37.40 ms | 382.79 ms | 3.3314 s |
-| walk_full_2stat_filetype（stat のみ・token/hash なし） | 7.31 ms | 69.35 ms | 897.00 ms |
-| walk_dir_mtime_1stat（stat のみ） | 3.75 ms | 36.87 ms | 476.04 ms |
-| walk_nameset_0stat（read_dir + file_type のみ） | 749.21 µs | 6.37 ms | 83.16 ms |
-| layer1_hit | 33.40 µs | 28.27 µs | 28.32 µs |
-| store_rescan_nodiff | 1.17 ms | 10.35 ms | 157.98 ms |
-| rescan_one_change（現行 1体変更→再走査） | 69.77 ms | 665.84 ms | 6.5097 s |
+| full_scan（walk+parse・本番） | 50.57 ms | 622.19 ms | 6.1760 s |
+| walk_full_fidelity_3stat（本番 walk・**逐次 is_dir 込み**・parse抜き） | 30.23 ms | 356.99 ms | 3.1899 s |
+| **walk_full_fidelity_filetype（同一 fingerprint・逐次 is_dir を file_type 化）** | 7.35 ms | 72.95 ms | **922.50 ms** |
+| walk_full_2stat_filetype（stat のみ・token/hash なし） | 6.83 ms | 68.38 ms | 857.94 ms |
+| walk_dir_mtime_1stat（stat のみ） | 3.61 ms | 36.66 ms | 458.76 ms |
+| walk_nameset_0stat（read_dir + file_type のみ） | 635.50 µs | 6.14 ms | 75.88 ms |
+| layer1_hit | 28.21 µs | 28.52 µs | 28.16 µs |
+| store_rescan_nodiff | 1.10 ms | 9.68 ms | 142.76 ms |
+| rescan_one_change（現行 1体変更→再走査） | 60.85 ms | 631.61 ms | 6.3397 s |
 
 （n=100k は sample_size=10 の indicative 値。criterion の中央値。）
 
-### 導出（n=100k・比率）
+## 内訳（n=100k・比率）
 
-- **parse コスト** = full_scan − walk_full_fidelity_3stat = 6.43 − 3.33 = **3.10 s（full_scan の約 48%）**。
-- **full-fidelity walk（token+hash 込み）** = **3.33 s（約 52%）**。
-- **→ parse と walk は拮抗。どちらも支配的でない。**
-- **walk の中身の内訳**（stat モデルは token/hash を含まない点に注意。下記 caveat）:
-  - 素の 2-stat（file_type）= 0.897 s。1-stat = 0.476 s。0-stat = 0.083 s。**stat 1 回 ≈ 0.4 s / 100k**。
-  - 本番 full-fidelity walk（3.33 s）と 2-stat モデル（0.897 s）の差 **2.43 s** は、is_dir stat（約 0.4 s）＋
-    **10万トークンの文字列生成・sort・SHA-256 ハッシュ＋構造体/文字列アロケーション**。
-  - つまり **walk コストの過半は stat ではなく「集約 fingerprint の生成」**。これは Phase 2 の設計を左右する
-    最重要の発見（後述）。
+`walk_full_fidelity_3stat` と `walk_full_fidelity_filetype` は**同一 fingerprint を返す**（同値をテストで固定）。
+唯一の差は、本番 `walk_parent` の **逐次** is_dir 判定（`scan.rs` の `.filter(|p| p.is_dir())`・
+100k 回の逐次 `metadata` syscall）を、キャッシュ済み find-data の `file_type()`（syscall ゼロ）に
+置換した点のみ。したがって両者の差 = **逐次 is_dir pass 単独のコスト**。
 
-> **caveat**: `walk_full_2stat_filetype`/`walk_dir_mtime_1stat`/`walk_nameset_0stat` は stat パターンの
-> コストモデルであり、**トークン文字列生成・集約 fingerprint ハッシュを含まない**（`fingerprint_only` =
-> `walk_full_fidelity_3stat` のみが本番同等に含む）。ゆえに安価レベルの数値は「その stat 数＋相応に安価な
-> 集約シグナル」を採る設計での walk 下限であり、実 Phase 2 は何らかの fingerprint コストを別途計上する。
+- **parse コスト** = full_scan − walk_full_fidelity_3stat = 6.176 − 3.190 = **2.99 s（full_scan の約 48%）**。
+- **逐次 is_dir pass** = walk_full_fidelity_3stat − walk_full_fidelity_filetype = 3.190 − 0.9225 =
+  **2.27 s（full-fidelity walk の 71%）**。← **walk コストの支配項はこれ**。
+- **token 生成 + 集約 fingerprint ハッシュ** = walk_full_fidelity_filetype − walk_full_2stat_filetype =
+  0.9225 − 0.858 = **≈ 0.065 s（約 2%・無視できる）**。
+- 2 並列 stat の内訳: descript stat = 0.858 − 0.459 = 0.40 s、dir stat = 0.459 − 0.076 = 0.38 s、
+  read_dir + file_type = 0.076 s。
+
+> **設計判断への含意（重要）**: walk コストの過半（71%）は**逐次 is_dir stat**であり、集約 fingerprint の
+> 生成（token+SHA-256）は約 2% に過ぎない。したがって Phase 2 の勝ち筋は「fingerprint の増分化」でも
+> 「fidelity を落とす」でもなく、**逐次 is_dir を file_type 化（＋既に並列の 2 stat）する fidelity 無傷の
+> 一手**である。これは F-04（descript_mtime 込み）を一切狭めない。
 
 ## キャッシュ mtime 信頼性（Task 5 所見）
 
-- 結果: **FAIL**（Windows 11 / NTFS）。ツリー変更後の**新しい read_dir 列挙**でも、`entry.metadata()`
-  （find-data 由来・syscall ゼロ）の mtime が `fs::metadata` と不一致（実測差 ~63ms、find-data キャッシュが陳腐化）。
-- 含意: **dir_mtime レベルは find-data mtime を無料利用できず、`fs::metadata` で 1 実 stat/子（≈0.4s/100k）が
-  必須**。0 syscall 化は不可。コードベースが `fs::metadata` を全面採用している判断（`scan.rs` の NTFS 陳腐化
-  回避）が実測で裏付けられた。テストは `#[ignore]` の回帰ガードとして残置（`cargo test --features bench --
-  -- --ignored` で再検証可）。
+- 結果: **FAIL**（Windows 11 / NTFS）。新しい read_dir 列挙でも `entry.metadata()`（find-data 由来）の
+  mtime が `fs::metadata` と不一致（実測差 ~63ms・find-data キャッシュが陳腐化）。
+- 含意: **mtime を要する stat（dir_mtime / descript）は `fs::metadata` が必須**で 0 syscall 化できない。
+  ただし `file_type()`（ディレクトリ属性ビット・陳腐化しない）は無料で使える——これが上記の is_dir 削減の
+  根拠。コードベースの `fs::metadata` 全面採用（`scan.rs` の NTFS 陳腐化回避）が実測で裏付けられた。
+  テストは `#[ignore]` の回帰ガードとして残置。
 
-## Phase 2 への含意（fidelity レベル選択）
+## Phase 2 への含意（設計判断）
 
-達成可能な「1体変更→再走査」コスト（walk ＋ 単体 parse ≈ walk 支配。現行ベースライン **6.51 s**）:
+達成可能な「1体変更→再走査」コスト（walk ＋ 変更子だけ parse。現行ベースライン **6.34 s**）:
 
-| レベル | 検知できる変更 | 再走査コスト目安(100k) | fingerprint(F-04) | Phase 3 要否 |
+| 案 | 検知できる変更 | 再走査コスト目安(100k) | fingerprint(F-04) | 妥協 |
 |---|---|---|---|---|
-| full-fidelity（現行トークン保持） | add/del/rename/**同名置換**/descript出現 | **~3.3 s** | 今日ちょうど維持 | **要**（多秒フリーズ残存） |
-| dir_mtime（1 stat・安価な集約） | add/del/rename/**同名置換** | **~0.5 s** | descript_mtime を落とし狭める | 恐らく不要（sub秒） |
-| name-set（0 stat） | add/del/rename のみ | **~0.08 s** | 名前集合派生に狭める | 不要（単体パース相当） |
+| **full fidelity + file_type（推奨）** | add/del/rename/**同名置換**/descript出現 | **~0.9 s** | **今日ちょうど維持** | **なし** |
+| dir_mtime + file_type | add/del/rename/**同名置換** | ~0.5 s | descript_mtime を落とし微縮小 | descript 出現の即時検知 |
+| name-set | add/del/rename のみ | ~0.08 s | 名前集合派生に縮小 | 同名置換検知 |
 
-### 決定的な結論
+### 決定的な結論（当初推論の訂正）
 
-1. **full-fidelity granular（parse だけ飛ばす）は不十分**: walk（token+hash 込み 3.33s）が残り、受け入れ基準の
-   「単体パース相当」に届かない。この道を選ぶなら Phase 3（非ブロッキング）が事実上必須。
-2. **walk コストの過半は集約 fingerprint の再計算**（token 生成＋SHA-256）。ゆえに Phase 2 の勝ち筋は
-   「parse を飛ばす」だけでなく **1体変更時に集約 fingerprint を全再計算せず増分更新する**こと。
-   これは設計書 §4.3（fingerprint は生キートークン集合から算出）を **増分ハッシュ or per-child 保持署名**へ
-   踏み込ませる含意を持つ。
-3. **fidelity ツマミの実費**: 同名置換検知（full/dir_mtime）を捨てて name-set に落とすと ~0.5s→~0.08s。
-   ただし SPEC §7.4/§9.1 が descript 編集を「再読込」に routing 済みで、descript 出現/編集は Layer1 ミス経路を
-   通らないため、name-set で実際に失うのは**同名置換（同 dir 名で削除→再作成）の自動検知の一点**。
-4. **無料削減（is_dir→file_type）**: 単独では約 0.4s/100k（stat 1 回分）。token/hash 削減と分離できていない
-   ため上限見積り。Phase 2 で walk を作り直す際に本番適用する。
+1. **当初の「walk コスト過半は fingerprint ハッシュ」は誤り**。実測で walk 支配項は**逐次 is_dir stat
+   （2.27s・71%）**、token+hash は約 65ms（2%）。判別は `walk_full_fidelity_3stat`（逐次 is_dir）vs
+   `walk_full_fidelity_filetype`（file_type・同一 fingerprint）の差で確定。
+2. **推奨: full fidelity のまま逐次 is_dir を file_type 化 ＋ 変更子だけ parse**。これで granular rescan は
+   **~0.9 s**（file_type walk 0.92s + 単体 parse ≈ 誤差）に落ち、現行 6.34s から約 7 倍改善。
+   **同名置換・descript_mtime・exact F-04 をすべて保持**し、fidelity 妥協ゼロ。
+3. **incremental fingerprint は不要**（token+hash が 65ms のため、1体変更で全再計算しても安い）。
+   設計書 §4.3（fingerprint は生キートークン集合から算出）はそのまま維持でよい。
+4. **Phase 3（非ブロッキング）は不要の見込み**。~0.9s は sub 秒で、6.34s の多秒フリーズとは体感が別物。
+   最終判断は Phase 2 実装後の再計測で確定する（設計書 §7 の測定条件付きゲートに合致）。
+5. **副次利得**: full_scan 自体も逐次 is_dir を含むため（6.18s のうち walk 3.19s）、file_type 化で
+   初回スキャン・再読込も 6.18s→~3.9s に短縮される（parse 2.99s は残る）。
 
-### 推奨（次サイクルの Phase 2 決定材料）
+### Phase 2 計画への申し送り
 
-- **第一候補: dir_mtime レベル ＋ 増分 fingerprint**。同名置換検知を保ちつつ ~0.5s（sub秒・Phase 3 不要見込み）。
-  F-04 は descript_mtime を落として微縮小（SPEC 同期が要る）。集約 fingerprint を全再計算せず per-child 署名の
-  増分で更新する設計が肝。
-- name-set レベルは「単体パース相当」を厳密に満たすが、同名置換検知の喪失と F-04 のさらなる縮小を伴う。
-  同名置換が運用上どれだけ起きるかを SPEC 判断に上げてから選ぶ。
-- いずれにせよ **集約 fingerprint の増分化**が walk 支配を崩す本丸。Phase 2 計画はこれを中心に据える。
+- 本丸は **`walk_parent` の逐次 is_dir を `entry.file_type()` へ置換**（`scan.rs:137-141`）。symlink は
+  `file_type()` が follow しないため、symlink→dir のゴーストを拾うには `file_type().is_dir()` 偽かつ
+  symlink のときだけ `fs::metadata` にフォールバックする分岐が要る（正しさ保持）。
+- その上で設計書 §4 の correctness 土台（格納先案A `ghost_scan_entries`・生キー差分・delta 正しさ規則・
+  変更子だけ parse）を実装し、granular rescan 版の `rescan_one_change` を bench で before(6.34s)/after(~0.9s)
+  比較する。fidelity は full を維持するため、同名置換の SPEC 判断は不要になった。

--- a/docs/perf/granular-scan-spectrum-100k.md
+++ b/docs/perf/granular-scan-spectrum-100k.md
@@ -1,0 +1,86 @@
+# walk スペクトラム計測（10万体規模・#134 Phase 1）
+
+- 計測日: 2026-07-16
+- 目的: Phase 2 の fidelity レベル（full/dir_mtime/name-set）を選ぶための walk/parse 内訳と、
+  「1体変更→再走査」の現行ベースライン。修正（Phase 2）は本数値を根拠に別サイクル。
+- 実行環境: Windows 11 Home 10.0.26200 / ワークスペースは SSD。`bench` プロファイル
+  （`cargo bench --features bench`、release 最適化継承）。warm cache（ツリー生成直後・同一プロセス反復）。
+- **重要な環境注記**: 本実行の `full_scan`（n=100k）は **6.43s** で、`docs/perf/baseline-100k.md`（#133）の
+  **3.47s** の約 **1.85 倍**。計測セッション中のビルド／背景タスクによるコンテンションが主因と見られる
+  （同一 build 番号だが baseline は Pro 表記・本実行は Home 表記で環境差の可能性もある）。
+  **判断根拠は絶対値でなく、同一実行内の相対比率**とする（全 shape が同条件で走っているため比率は有効）。
+- 手順: `cargo bench --features bench --manifest-path src-tauri/Cargo.toml --bench scan_bench`
+
+## walk スペクトラムと parse 内訳（中央値）
+
+| 形状 | n=1k | n=10k | n=100k |
+|---|---|---|---|
+| full_scan（walk+parse・本番） | 57.78 ms | 629.69 ms | 6.4300 s |
+| walk_full_fidelity_3stat（本番 walk・parse抜き・token+hash込み） | 37.40 ms | 382.79 ms | 3.3314 s |
+| walk_full_2stat_filetype（stat のみ・token/hash なし） | 7.31 ms | 69.35 ms | 897.00 ms |
+| walk_dir_mtime_1stat（stat のみ） | 3.75 ms | 36.87 ms | 476.04 ms |
+| walk_nameset_0stat（read_dir + file_type のみ） | 749.21 µs | 6.37 ms | 83.16 ms |
+| layer1_hit | 33.40 µs | 28.27 µs | 28.32 µs |
+| store_rescan_nodiff | 1.17 ms | 10.35 ms | 157.98 ms |
+| rescan_one_change（現行 1体変更→再走査） | 69.77 ms | 665.84 ms | 6.5097 s |
+
+（n=100k は sample_size=10 の indicative 値。criterion の中央値。）
+
+### 導出（n=100k・比率）
+
+- **parse コスト** = full_scan − walk_full_fidelity_3stat = 6.43 − 3.33 = **3.10 s（full_scan の約 48%）**。
+- **full-fidelity walk（token+hash 込み）** = **3.33 s（約 52%）**。
+- **→ parse と walk は拮抗。どちらも支配的でない。**
+- **walk の中身の内訳**（stat モデルは token/hash を含まない点に注意。下記 caveat）:
+  - 素の 2-stat（file_type）= 0.897 s。1-stat = 0.476 s。0-stat = 0.083 s。**stat 1 回 ≈ 0.4 s / 100k**。
+  - 本番 full-fidelity walk（3.33 s）と 2-stat モデル（0.897 s）の差 **2.43 s** は、is_dir stat（約 0.4 s）＋
+    **10万トークンの文字列生成・sort・SHA-256 ハッシュ＋構造体/文字列アロケーション**。
+  - つまり **walk コストの過半は stat ではなく「集約 fingerprint の生成」**。これは Phase 2 の設計を左右する
+    最重要の発見（後述）。
+
+> **caveat**: `walk_full_2stat_filetype`/`walk_dir_mtime_1stat`/`walk_nameset_0stat` は stat パターンの
+> コストモデルであり、**トークン文字列生成・集約 fingerprint ハッシュを含まない**（`fingerprint_only` =
+> `walk_full_fidelity_3stat` のみが本番同等に含む）。ゆえに安価レベルの数値は「その stat 数＋相応に安価な
+> 集約シグナル」を採る設計での walk 下限であり、実 Phase 2 は何らかの fingerprint コストを別途計上する。
+
+## キャッシュ mtime 信頼性（Task 5 所見）
+
+- 結果: **FAIL**（Windows 11 / NTFS）。ツリー変更後の**新しい read_dir 列挙**でも、`entry.metadata()`
+  （find-data 由来・syscall ゼロ）の mtime が `fs::metadata` と不一致（実測差 ~63ms、find-data キャッシュが陳腐化）。
+- 含意: **dir_mtime レベルは find-data mtime を無料利用できず、`fs::metadata` で 1 実 stat/子（≈0.4s/100k）が
+  必須**。0 syscall 化は不可。コードベースが `fs::metadata` を全面採用している判断（`scan.rs` の NTFS 陳腐化
+  回避）が実測で裏付けられた。テストは `#[ignore]` の回帰ガードとして残置（`cargo test --features bench --
+  -- --ignored` で再検証可）。
+
+## Phase 2 への含意（fidelity レベル選択）
+
+達成可能な「1体変更→再走査」コスト（walk ＋ 単体 parse ≈ walk 支配。現行ベースライン **6.51 s**）:
+
+| レベル | 検知できる変更 | 再走査コスト目安(100k) | fingerprint(F-04) | Phase 3 要否 |
+|---|---|---|---|---|
+| full-fidelity（現行トークン保持） | add/del/rename/**同名置換**/descript出現 | **~3.3 s** | 今日ちょうど維持 | **要**（多秒フリーズ残存） |
+| dir_mtime（1 stat・安価な集約） | add/del/rename/**同名置換** | **~0.5 s** | descript_mtime を落とし狭める | 恐らく不要（sub秒） |
+| name-set（0 stat） | add/del/rename のみ | **~0.08 s** | 名前集合派生に狭める | 不要（単体パース相当） |
+
+### 決定的な結論
+
+1. **full-fidelity granular（parse だけ飛ばす）は不十分**: walk（token+hash 込み 3.33s）が残り、受け入れ基準の
+   「単体パース相当」に届かない。この道を選ぶなら Phase 3（非ブロッキング）が事実上必須。
+2. **walk コストの過半は集約 fingerprint の再計算**（token 生成＋SHA-256）。ゆえに Phase 2 の勝ち筋は
+   「parse を飛ばす」だけでなく **1体変更時に集約 fingerprint を全再計算せず増分更新する**こと。
+   これは設計書 §4.3（fingerprint は生キートークン集合から算出）を **増分ハッシュ or per-child 保持署名**へ
+   踏み込ませる含意を持つ。
+3. **fidelity ツマミの実費**: 同名置換検知（full/dir_mtime）を捨てて name-set に落とすと ~0.5s→~0.08s。
+   ただし SPEC §7.4/§9.1 が descript 編集を「再読込」に routing 済みで、descript 出現/編集は Layer1 ミス経路を
+   通らないため、name-set で実際に失うのは**同名置換（同 dir 名で削除→再作成）の自動検知の一点**。
+4. **無料削減（is_dir→file_type）**: 単独では約 0.4s/100k（stat 1 回分）。token/hash 削減と分離できていない
+   ため上限見積り。Phase 2 で walk を作り直す際に本番適用する。
+
+### 推奨（次サイクルの Phase 2 決定材料）
+
+- **第一候補: dir_mtime レベル ＋ 増分 fingerprint**。同名置換検知を保ちつつ ~0.5s（sub秒・Phase 3 不要見込み）。
+  F-04 は descript_mtime を落として微縮小（SPEC 同期が要る）。集約 fingerprint を全再計算せず per-child 署名の
+  増分で更新する設計が肝。
+- name-set レベルは「単体パース相当」を厳密に満たすが、同名置換検知の喪失と F-04 のさらなる縮小を伴う。
+  同名置換が運用上どれだけ起きるかを SPEC 判断に上げてから選ぶ。
+- いずれにせよ **集約 fingerprint の増分化**が walk 支配を崩す本丸。Phase 2 計画はこれを中心に据える。

--- a/docs/perf/granular-scan-spectrum-100k.md
+++ b/docs/perf/granular-scan-spectrum-100k.md
@@ -59,24 +59,37 @@
 
 達成可能な「1体変更→再走査」コスト（walk ＋ 変更子だけ parse。現行ベースライン **6.34 s**）:
 
-| 案 | 検知できる変更 | 再走査コスト目安(100k) | fingerprint(F-04) | 妥協 |
+| 案 | 検知できる変更 | 再走査コスト目安(100k・warm) | fingerprint(F-04) | 妥協 |
 |---|---|---|---|---|
-| **full fidelity + file_type（推奨）** | add/del/rename/**同名置換**/descript出現 | **~0.9 s** | **今日ちょうど維持** | **なし** |
-| dir_mtime + file_type | add/del/rename/**同名置換** | ~0.5 s | descript_mtime を落とし微縮小 | descript 出現の即時検知 |
-| name-set | add/del/rename のみ | ~0.08 s | 名前集合派生に縮小 | 同名置換検知 |
+| **full fidelity + file_type（推奨）** | add/del/rename/**同名置換**/descript出現 | **~1.05 s** | **今日ちょうど維持** | **なし** |
+| dir_mtime + file_type | add/del/rename/**同名置換** | ~0.6 s | descript_mtime を落とし微縮小 | descript 出現の即時検知 |
+| name-set | add/del/rename のみ | ~0.22 s | 名前集合派生に縮小 | 同名置換検知 |
+
+（再走査コスト = walk（file_type）＋ **前回トークンマップの O(N) 読み** ≈ store_rescan_nodiff 相当
+142.76 ms/100k ＋ delta write ＋ 変更子の parse。full fidelity 案は 0.92s walk + ~0.14s 読み ≈ **~1.05s**。
+いずれも **warm cache** の見積り——後述の cold 注意を参照。）
 
 ### 決定的な結論（当初推論の訂正）
 
 1. **当初の「walk コスト過半は fingerprint ハッシュ」は誤り**。実測で walk 支配項は**逐次 is_dir stat
    （2.27s・71%）**、token+hash は約 65ms（2%）。判別は `walk_full_fidelity_3stat`（逐次 is_dir）vs
    `walk_full_fidelity_filetype`（file_type・同一 fingerprint）の差で確定。
-2. **推奨: full fidelity のまま逐次 is_dir を file_type 化 ＋ 変更子だけ parse**。これで granular rescan は
-   **~0.9 s**（file_type walk 0.92s + 単体 parse ≈ 誤差）に落ち、現行 6.34s から約 7 倍改善。
-   **同名置換・descript_mtime・exact F-04 をすべて保持**し、fidelity 妥協ゼロ。
+2. **Phase 2 は「delta 機構 ＋ file_type 化」の両方が必須**（どちらか一方では足りない）。二つの支配項を
+   別々に潰す:
+   - **parse-skip（delta 機構）** が節約は大きい（**2.99s**）。そしてこれは設計書 §4 の実装本体——
+     `ghost_scan_entries`（案A）・`store_ghosts_delta`・生キー差分・5レンズが挙げた correctness 規則の
+     すべて。**Phase 2 の作業量の大半はここ**。
+   - **逐次 is_dir → file_type**（節約 **2.27s**・fidelity 無傷・F-04 不変）が walk 側のもう一つの大塊を潰す。
+   - **片方だけでは不十分**: file_type 単独（delta なし）は walk 0.92s + parse 2.99s ≈ **3.9s** で依然多秒
+     フリーズ。delta 単独（逐次 is_dir 残置）は walk 3.19s + 読み ≈ **3.3s** で同様。両方揃って初めて ~1.05s。
 3. **incremental fingerprint は不要**（token+hash が 65ms のため、1体変更で全再計算しても安い）。
    設計書 §4.3（fingerprint は生キートークン集合から算出）はそのまま維持でよい。
-4. **Phase 3（非ブロッキング）は不要の見込み**。~0.9s は sub 秒で、6.34s の多秒フリーズとは体感が別物。
-   最終判断は Phase 2 実装後の再計測で確定する（設計書 §7 の測定条件付きゲートに合致）。
+4. **Phase 3（非ブロッキング）は「不要」でなく「cold-start 挙動の再計測まで保留（deferred）」**。上記
+   ~1.05s は **warm cache** の値。Layer 1 ミスは「ユーザーが外部でゴーストフォルダを追加・削除した直後」に
+   発火し、その初回スキャンは**セッション開始時＝cold cache**であることが多い。cold の 2-stat walk（10万件の
+   実 stat をディスクから）は warm 0.92s の数倍あり得て、多秒フリーズに戻りうる（本 issue の敵対的レビュー
+   前提3/5 が指摘済み）。**Phase 3 の要否は warm ベンチでなく cold-cache／実アプリ観測の Layer1 ミス walk で
+   判定する**。設計書 §7 の測定条件付きゲートに合致。
 5. **副次利得**: full_scan 自体も逐次 is_dir を含むため（6.18s のうち walk 3.19s）、file_type 化で
    初回スキャン・再読込も 6.18s→~3.9s に短縮される（parse 2.99s は残る）。
 
@@ -86,5 +99,7 @@
   `file_type()` が follow しないため、symlink→dir のゴーストを拾うには `file_type().is_dir()` 偽かつ
   symlink のときだけ `fs::metadata` にフォールバックする分岐が要る（正しさ保持）。
 - その上で設計書 §4 の correctness 土台（格納先案A `ghost_scan_entries`・生キー差分・delta 正しさ規則・
-  変更子だけ parse）を実装し、granular rescan 版の `rescan_one_change` を bench で before(6.34s)/after(~0.9s)
-  比較する。fidelity は full を維持するため、同名置換の SPEC 判断は不要になった。
+  変更子だけ parse）を実装し、granular rescan 版の `rescan_one_change` を bench で before(6.34s)/after(~1.05s
+  warm) 比較する。fidelity は full を維持するため、同名置換の SPEC 判断は不要になった。
+- **Phase 3 の判定材料として cold-cache の Layer1 ミス walk を別途計測する**（warm ベンチは ~1.05s を
+  再確認するだけで cold の体感を測れない）。実アプリでの外部フォルダ変更→初回スキャンの体感を観測するのが確実。

--- a/docs/superpowers/plans/2026-07-16-granular-scan-phase1-measurement.md
+++ b/docs/superpowers/plans/2026-07-16-granular-scan-phase1-measurement.md
@@ -1,0 +1,543 @@
+# 全走査スキャン粒度化 Phase 1（計測＝意思決定の計器）実装計画
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `scan_bench` に walk の各 fidelity レベル分解・`rescan_one_change` 形状・キャッシュ mtime 信頼性テストを追加し、3.47秒の walk/parse 内訳と各検知レベルの walk コストを数値で確定して、Phase 2 の fidelity レベルを選ぶ材料を作る。
+
+**Architecture:** 本番経路は一切変更しない。すべて `#[cfg(feature = "bench")]` ゲート下の計測専用コードを `src-tauri/src/bench_support.rs`・`src-tauri/benches/scan_bench.rs` に追加し、walk 単独コスト（parse 抜き）は本番 `walk_parent` を ghosts 収集なしで呼ぶ経路（scan.rs にベンチ専用内部関数を1本追加）で忠実計測する。各 fidelity レベル（full/dir_mtime/name-set）は bench_support 内の rayon 並列 walk モデルで見積もる。
+
+**Tech Stack:** Rust / criterion 0.5 / rayon / rusqlite 0.32。ベンチは `cargo bench --features bench --bench scan_bench`。
+
+## Global Constraints
+
+- **本番 API・振る舞い・可視性を一切変更しない**。露出はすべて `#[cfg(feature = "bench")]` ゲート下（`src-tauri/CLAUDE.md`・PR #133 の方針を踏襲）。
+- **CI は `--features bench` をビルドしない**ため、bench ゲート下の未使用警告は無害だが、`cargo test --features bench bench_support` は通ること。
+- **`Date.now()`/乱数を使わない**（決定性）。一意名は `std::process::id()` ＋単調カウンタ（既存 `fastrand_like` パターン）で作る。
+- **本計画は Phase 1 のみ**。Phase 2（差分検知＋変更子だけ parse・格納先案A・`store_ghosts_delta`）と Phase 3（非ブロッキング）の計画は、本 Phase の計測結果と「同名置換 fidelity を捨てるか」判断を得てから別途書き下ろす。migration は Phase 2 で追加（本 Phase では不要）。
+- 設計書: `docs/superpowers/specs/2026-07-16-granular-scan-fingerprint-design.md`。
+
+---
+
+## Task 1: walk 単独コスト（parse 抜き・本番忠実）を露出する
+
+full fidelity walk（read_dir + 3 stat/子 + トークン生成 + ハッシュ）を parse なしで測る。本番 `walk_parent` を ghosts 収集なしで呼ぶベンチ専用内部関数を scan.rs に1本追加し、`bench_support::fingerprint_only` として露出する。**parse コスト = full_scan − fingerprint_only** が判明する。
+
+**Files:**
+- Modify: `src-tauri/src/commands/ghost/scan.rs`（末尾にベンチ専用 `fingerprint_only_internal` を追加）
+- Modify: `src-tauri/src/commands/ghost/mod.rs:12`（bench 再露出に `fingerprint_only_internal` を追加）
+- Modify: `src-tauri/src/bench_support.rs`（`fingerprint_only` wrapper とテストを追加）
+
+**Interfaces:**
+- Consumes: 既存 `scan::walk_parent`, `scan::compute_fingerprint_hash`（`fingerprint.rs` からの再エクスポート）, `path_utils::unique_sorted_additional_folders`, 既存 `bench_support::{generate_ghost_tree, full_scan_count}`。
+- Produces: `pub fn fingerprint_only(ssp_path: &str) -> Result<String, String>`（bench_support）。同一ツリーに対し `scan_ghosts_with_fingerprint_internal(ssp, &[]).1` と同じ fingerprint を返す（parse は fingerprint に影響しないため）。
+
+- [ ] **Step 1: bench_support に失敗するテストを書く**
+
+`src-tauri/src/bench_support.rs` の `#[cfg(test)] mod tests` 内に追加:
+
+```rust
+    #[test]
+    fn fingerprint_only_がフルスキャンと同じfingerprintを返す() {
+        let tmp = TempDirGuard::new("bench_fp_only");
+        let ssp = tmp.path().join("ssp");
+        generate_ghost_tree(&ssp, 30).unwrap();
+        let ssp_str = ssp.to_string_lossy().to_string();
+
+        let (_ghosts, full_fp) =
+            crate::commands::ghost::scan_ghosts_with_fingerprint_internal(&ssp_str, &[]).unwrap();
+        let walk_fp = fingerprint_only(&ssp_str).unwrap();
+
+        // parse 抜き walk でも同一トークン集合 → 同一 fingerprint
+        assert_eq!(walk_fp, full_fp);
+    }
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+Run: `cargo test --features bench --manifest-path src-tauri/Cargo.toml bench_support::tests::fingerprint_only`
+Expected: FAIL（`fingerprint_only` 未定義でコンパイルエラー）
+
+- [ ] **Step 3: scan.rs にベンチ専用内部関数を追加**
+
+`src-tauri/src/commands/ghost/scan.rs` の末尾（`scan_ghosts_with_fingerprint_internal` の直後）に追加:
+
+```rust
+/// フル走査と同じトークンを生成するが Ghost を収集しない（parse を行わない）。
+/// walk 単独コスト（read_dir + stat + トークン生成 + ハッシュ）を parse 抜きで
+/// 計測するためのベンチ専用経路。本番からは呼ばれない。
+#[cfg(feature = "bench")]
+pub(crate) fn fingerprint_only_internal(
+    ssp_path: &str,
+    additional_folders: &[String],
+) -> Result<String, String> {
+    let ghost_dir = Path::new(ssp_path).join("ghost");
+    let mut tokens = vec!["fingerprint-version|1".to_string()];
+
+    walk_parent(&ghost_dir, "ssp", true, &mut tokens, None)?;
+    for (_source, folder_path, normalized_folder) in
+        unique_sorted_additional_folders(additional_folders)
+    {
+        walk_parent(&folder_path, &normalized_folder, false, &mut tokens, None)?;
+    }
+
+    Ok(compute_fingerprint_hash(&tokens))
+}
+```
+
+- [ ] **Step 4: mod.rs の bench 再露出に追加**
+
+`src-tauri/src/commands/ghost/mod.rs:12` を次のように変更:
+
+```rust
+#[cfg(feature = "bench")]
+pub(crate) use scan::{fingerprint_only_internal, scan_ghosts_with_fingerprint_internal};
+```
+
+- [ ] **Step 5: bench_support に wrapper を追加**
+
+`src-tauri/src/bench_support.rs` の `full_scan_count` の直後に追加:
+
+```rust
+/// フル fidelity walk を parse 抜きで実行し fingerprint を返す（walk_only 計測）。
+/// full_scan_count との差が parse コスト。
+pub fn fingerprint_only(ssp_path: &str) -> Result<String, String> {
+    crate::commands::ghost::fingerprint_only_internal(ssp_path, &[])
+}
+```
+
+- [ ] **Step 6: テストを実行して成功を確認**
+
+Run: `cargo test --features bench --manifest-path src-tauri/Cargo.toml bench_support::tests::fingerprint_only`
+Expected: PASS
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add src-tauri/src/commands/ghost/scan.rs src-tauri/src/commands/ghost/mod.rs src-tauri/src/bench_support.rs
+git commit -m "test: walk 単独コスト計測用 fingerprint_only をベンチ露出（#134 Phase1）
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: 各 fidelity レベルの walk コストモデルを追加する
+
+3 レベル（name-set=0 stat / dir_mtime=1 stat / full=2 stat・file_type 版）を bench_support 内の rayon 並列 walk モデルとして実装する。`fingerprint_only`（本番 3 stat・is_dir 版）との比較で、is_dir→file_type の無料削減効果（stat 1 回分）も見積もる。ベンチは常に additional_folders 空（既存 scan_bench と同じ前提）で `{ssp}/ghost` のみ walk する。
+
+**Files:**
+- Modify: `src-tauri/src/bench_support.rs`（`ghost_children` ヘルパー＋ 3 walk モデル＋テストを追加）
+
+**Interfaces:**
+- Consumes: 既存 `bench_support::{generate_ghost_tree, full_scan_count}`、`rayon::prelude`、std `fs`/`Path`。
+- Produces:
+  - `pub fn walk_nameset(ssp_path: &str) -> Result<usize, String>`（0 stat/子）
+  - `pub fn walk_dir_mtime(ssp_path: &str) -> Result<usize, String>`（1 stat/子）
+  - `pub fn walk_full(ssp_path: &str) -> Result<usize, String>`（2 stat/子・file_type で is_dir 判定）
+  - いずれも生成ツリーの子ディレクトリ数（= N）を返す。
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`src-tauri/src/bench_support.rs` の `#[cfg(test)] mod tests` 内に追加:
+
+```rust
+    #[test]
+    fn walk_モデル3種が全て子ディレクトリ数を返す() {
+        let tmp = TempDirGuard::new("bench_walk_levels");
+        let ssp = tmp.path().join("ssp");
+        generate_ghost_tree(&ssp, 50).unwrap();
+        let ssp_str = ssp.to_string_lossy().to_string();
+
+        assert_eq!(walk_nameset(&ssp_str).unwrap(), 50);
+        assert_eq!(walk_dir_mtime(&ssp_str).unwrap(), 50);
+        assert_eq!(walk_full(&ssp_str).unwrap(), 50);
+        // 本番フル走査の体数とも一致（全子に descript 有り）
+        assert_eq!(full_scan_count(&ssp_str).unwrap(), 50);
+    }
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+Run: `cargo test --features bench --manifest-path src-tauri/Cargo.toml bench_support::tests::walk_モデル3種`
+Expected: FAIL（`walk_nameset` 等が未定義でコンパイルエラー）
+
+- [ ] **Step 3: ヘルパーと 3 モデルを実装**
+
+`src-tauri/src/bench_support.rs` の `fingerprint_only`（Task 1 で追加）の直後に追加。ファイル冒頭の `use` に `use rayon::prelude::*;` が無ければ追加する:
+
+```rust
+/// {ssp}/ghost 直下の子ディレクトリパスを列挙する（is_dir 判定はキャッシュ済み
+/// find-data の file_type を使い syscall ゼロ）。本番 walk_parent の is_dir(stat)
+/// を file_type に置換したときの walk を模す計測用ヘルパー。
+fn ghost_children(ssp_path: &str) -> Result<Vec<PathBuf>, String> {
+    let ghost_dir = Path::new(ssp_path).join("ghost");
+    let entries = fs::read_dir(&ghost_dir).map_err(|e| format!("read_dir: {e}"))?;
+    Ok(entries
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
+        .map(|e| e.path())
+        .collect())
+}
+
+/// 名前集合レベル: 子1体あたり stat ゼロ（read_dir + file_type のみ）。
+/// add/del/rename は検知できるが同名置換は検知できない fidelity 下限。
+pub fn walk_nameset(ssp_path: &str) -> Result<usize, String> {
+    Ok(ghost_children(ssp_path)?.len())
+}
+
+/// dir_mtime レベル: 子1体あたり fs::metadata 1 回（dir mtime のみ、descript stat なし）。
+/// 同名置換まで検知できる。
+pub fn walk_dir_mtime(ssp_path: &str) -> Result<usize, String> {
+    let paths = ghost_children(ssp_path)?;
+    let count = paths.par_iter().filter(|p| fs::metadata(p).is_ok()).count();
+    Ok(count)
+}
+
+/// full fidelity レベル（file_type 版）: 子1体あたり 2 stat（dir mtime + descript）。
+/// 本番 walk_parent は is_dir(stat) を足して 3 stat のため、fingerprint_only との差が
+/// is_dir→file_type の無料削減効果。
+pub fn walk_full(ssp_path: &str) -> Result<usize, String> {
+    let paths = ghost_children(ssp_path)?;
+    let count = paths
+        .par_iter()
+        .filter(|p| {
+            let _dir = fs::metadata(p).is_ok(); // stat 1: dir mtime
+            let descript = p.join("ghost").join("master").join("descript.txt");
+            fs::metadata(&descript).is_ok() // stat 2: descript 有無/mtime（結果を使用）
+        })
+        .count();
+    Ok(count)
+}
+```
+
+- [ ] **Step 4: テストを実行して成功を確認**
+
+Run: `cargo test --features bench --manifest-path src-tauri/Cargo.toml bench_support::tests::walk_モデル3種`
+Expected: PASS
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src-tauri/src/bench_support.rs
+git commit -m "test: fidelity 3レベルの walk コストモデルを追加（#134 Phase1）
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: 1体変更→再走査（rescan_one_change）ベースライン形状
+
+現行コードの「1体増減→ Layer 1 ミス→再走査」end-to-end（フル walk+parse + store 差分1件）を測る。`iter_batched` の setup で**毎イテレーション一意名のゴースト1体を追加**し（`ghost/` mtime を bump → Layer 1 ミス相当、差分ちょうど1）、routine で本番の miss 経路（`scan_to_handle` + `store_handle`）を走らせる。Phase 2 の granular 版と直接比較する before 値。
+
+**Files:**
+- Modify: `src-tauri/src/bench_support.rs`（`add_one_ghost` ヘルパー＋テストを追加）
+- Modify: `src-tauri/benches/scan_bench.rs`（`rescan_one_change` bench 行を追加）
+
+**Interfaces:**
+- Consumes: 既存 `bench_support::{generate_ghost_tree, scan_to_handle, store_handle, store_with_real_mtimes, open_bench_db}`、scan_bench の `Guard`・`fastrand_like`。
+- Produces: `pub fn add_one_ghost(ssp_path: &str, tag: usize) -> Result<(), String>`（一意名 `dir_added_{tag:09}` のゴーストを追加。既存 mtime を bump）。
+
+- [ ] **Step 1: add_one_ghost の失敗するテストを書く**
+
+`src-tauri/src/bench_support.rs` の `#[cfg(test)] mod tests` 内に追加:
+
+```rust
+    #[test]
+    fn add_one_ghost_が体数を1増やしlayer1をミスさせる() {
+        let tmp = TempDirGuard::new("bench_add_one");
+        let ssp = tmp.path().join("ssp");
+        generate_ghost_tree(&ssp, 20).unwrap();
+        let ssp_str = ssp.to_string_lossy().to_string();
+
+        // 初期状態を real mtimes で保存 → layer1 hit する
+        let (handle, fp) = scan_to_handle(&ssp_str).unwrap();
+        let conn = open_bench_db(&tmp.path().join("ghosts.db")).unwrap();
+        store_with_real_mtimes(&conn, "rk", &handle, &fp, &ssp_str).unwrap();
+        assert!(layer1_hit(&conn, "rk", &ssp_str));
+
+        // 1 体追加 → 体数 +1、layer1 ミス
+        add_one_ghost(&ssp_str, 1).unwrap();
+        assert_eq!(full_scan_count(&ssp_str).unwrap(), 21);
+        assert!(!layer1_hit(&conn, "rk", &ssp_str), "追加で親 mtime が変わり miss のはず");
+    }
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+Run: `cargo test --features bench --manifest-path src-tauri/Cargo.toml bench_support::tests::add_one_ghost`
+Expected: FAIL（`add_one_ghost` 未定義）
+
+- [ ] **Step 3: add_one_ghost を実装**
+
+`src-tauri/src/bench_support.rs` の `generate_ghost_tree` の直後に追加:
+
+```rust
+/// 既存ツリーに一意名（dir_added_{tag}）のゴースト1体を追加する。
+/// 親 {ssp}/ghost の mtime を bump するため、以後の layer1 判定はミスする。
+pub fn add_one_ghost(ssp_path: &str, tag: usize) -> Result<(), String> {
+    let master = Path::new(ssp_path)
+        .join("ghost")
+        .join(format!("dir_added_{tag:09}"))
+        .join("ghost")
+        .join("master");
+    fs::create_dir_all(&master).map_err(|e| format!("mkdir added: {e}"))?;
+    fs::write(
+        master.join("descript.txt"),
+        format!("charset,UTF-8\nname,追加{tag}\n"),
+    )
+    .map_err(|e| format!("write added: {e}"))
+}
+```
+
+- [ ] **Step 4: テストを実行して成功を確認**
+
+Run: `cargo test --features bench --manifest-path src-tauri/Cargo.toml bench_support::tests::add_one_ghost`
+Expected: PASS
+
+- [ ] **Step 5: scan_bench に rescan_one_change 行を追加**
+
+`src-tauri/benches/scan_bench.rs` の import に `add_one_ghost` を追加し、`store_rescan_nodiff` ブロックの直後（`group.finish()` の前）に追加:
+
+```rust
+        // 1体変更→再走査（現行ベースライン）: setup で 1 体追加し Layer1 ミス+差分1を強制、
+        // routine でフル walk+parse + store 差分（現行の miss 経路）を測る。
+        {
+            let conn = open_bench_db(&guard.path().join("rescan.db")).unwrap();
+            store_with_real_mtimes(&conn, "rk", &handle, &fp, &ssp_str).unwrap();
+            group.bench_function("rescan_one_change", |b| {
+                b.iter_batched(
+                    || {
+                        let tag = fastrand_like() as usize;
+                        add_one_ghost(&ssp_str, tag).unwrap();
+                    },
+                    |_| {
+                        let (h, f) = scan_to_handle(&ssp_str).unwrap();
+                        store_handle(&conn, "rk", &h, &f).unwrap();
+                    },
+                    criterion::BatchSize::PerIteration,
+                );
+            });
+        }
+```
+
+`use ghost_launcher_lib::bench_support::{...}` の列に `add_one_ghost` を加える。
+
+- [ ] **Step 6: ベンチがコンパイル・小規模で走ることを確認**
+
+Run: `cargo bench --features bench --manifest-path src-tauri/Cargo.toml --bench scan_bench -- scan_n1000/rescan_one_change --quick`
+Expected: コンパイル成功し `scan_n1000/rescan_one_change` の計測が出力される（値の妥当性は Task 6 で確認）
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add src-tauri/src/bench_support.rs src-tauri/benches/scan_bench.rs
+git commit -m "test: rescan_one_change ベースライン形状を scan_bench に追加（#134 Phase1）
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: walk レベル 3 種を scan_bench に組み込む
+
+Task 2 の 3 モデルと Task 1 の `fingerprint_only` を、既存 `scan_n{N}` グループに bench 行として追加する。これでスペクトラム（full/dir_mtime/name-set の walk コスト）が N=1k/10k/100k で採れる。
+
+**Files:**
+- Modify: `src-tauri/benches/scan_bench.rs`（4 bench 行を追加・import 拡張）
+
+**Interfaces:**
+- Consumes: `bench_support::{fingerprint_only, walk_full, walk_dir_mtime, walk_nameset}`（Task 1・2）。
+- Produces: なし（bench 出力のみ）。
+
+- [ ] **Step 1: import を拡張し 4 行を追加**
+
+`src-tauri/benches/scan_bench.rs` の `use ghost_launcher_lib::bench_support::{...}` に
+`fingerprint_only, walk_full, walk_dir_mtime, walk_nameset` を追加。既存 `full_scan` bench 行の直後に追加:
+
+```rust
+        // walk スペクトラム（parse 抜き・各 fidelity レベル）
+        group.bench_function("walk_full_fidelity_3stat", |b| {
+            b.iter(|| fingerprint_only(&ssp_str).unwrap());
+        });
+        group.bench_function("walk_full_2stat_filetype", |b| {
+            b.iter(|| walk_full(&ssp_str).unwrap());
+        });
+        group.bench_function("walk_dir_mtime_1stat", |b| {
+            b.iter(|| walk_dir_mtime(&ssp_str).unwrap());
+        });
+        group.bench_function("walk_nameset_0stat", |b| {
+            b.iter(|| walk_nameset(&ssp_str).unwrap());
+        });
+```
+
+- [ ] **Step 2: 小規模で走ることを確認**
+
+Run: `cargo bench --features bench --manifest-path src-tauri/Cargo.toml --bench scan_bench -- scan_n1000/walk --quick`
+Expected: `walk_full_fidelity_3stat` / `walk_full_2stat_filetype` / `walk_dir_mtime_1stat` / `walk_nameset_0stat` の 4 行が計測される
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add src-tauri/benches/scan_bench.rs
+git commit -m "test: walk スペクトラム4行を scan_bench に組み込み（#134 Phase1）
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: キャッシュ mtime 信頼性テスト
+
+`entry.metadata()`（キャッシュ済み find-data 由来・syscall ゼロ）の mtime が、ツリー変更後の**新しい read_dir 列挙**で `fs::metadata` と一致するかを検証する。一致すれば dir_mtime レベルを 0 syscall で実現でき、dir_mtime レベルがほぼ無料化しうる。**このテストの合否そのものが所見**（無理に pass させず、失敗したら Task 6 に「dir_mtime は find-data mtime を使えない」と記録する）。
+
+**Files:**
+- Modify: `src-tauri/src/bench_support.rs`（`#[cfg(test)]` にテストを追加）
+
+**Interfaces:**
+- Consumes: `bench_support::{generate_ghost_tree}`、`TempDirGuard`、std `fs`。
+- Produces: なし（テストの合否が所見）。
+
+- [ ] **Step 1: 信頼性テストを書く**
+
+`src-tauri/src/bench_support.rs` の `#[cfg(test)] mod tests` 内に追加:
+
+```rust
+    #[test]
+    fn キャッシュmtimeが新しい列挙で更新を反映する() {
+        use std::time::Duration;
+        let tmp = TempDirGuard::new("bench_mtime_reliability");
+        let ssp = tmp.path().join("ssp");
+        generate_ghost_tree(&ssp, 5).unwrap();
+        let ghost_dir = ssp.join("ghost");
+
+        // 対象の子ディレクトリを1つ選ぶ
+        let target = ghost_dir.join("dir_000000");
+
+        // mtime を確実に前進させるため、少し待ってから中身を更新する
+        std::thread::sleep(Duration::from_millis(50));
+        fs::write(
+            target.join("ghost").join("master").join("descript.txt"),
+            "charset,UTF-8\nname,更新後\n",
+        )
+        .unwrap();
+        // ディレクトリ自身の mtime を bump するためファイルを1つ足す
+        fs::write(target.join("touch.tmp"), b"x").unwrap();
+
+        // 変更後に「新しい read_dir 列挙」で entry.metadata() と fs::metadata を比較
+        let mut cached = None;
+        for entry in fs::read_dir(&ghost_dir).unwrap() {
+            let entry = entry.unwrap();
+            if entry.path() == target {
+                cached = entry.metadata().ok().and_then(|m| m.modified().ok());
+            }
+        }
+        let fresh = fs::metadata(&target).ok().and_then(|m| m.modified().ok());
+
+        // 新しい列挙のキャッシュ mtime が fs::metadata と一致するか（所見）。
+        // 一致するなら dir_mtime レベルは find-data mtime で 0 syscall 化できる。
+        assert_eq!(
+            cached, fresh,
+            "新しい read_dir 列挙の entry.metadata() mtime が fs::metadata と不一致。\
+             dir_mtime レベルは find-data mtime を使えない（fs::metadata で 1 stat 必要）。"
+        );
+    }
+```
+
+- [ ] **Step 2: テストを実行して合否を記録**
+
+Run: `cargo test --features bench --manifest-path src-tauri/Cargo.toml bench_support::tests::キャッシュmtime`
+Expected: PASS または FAIL。**どちらでも所見**。FAIL なら「find-data mtime は新しい列挙でも陳腐化しうる → dir_mtime は fs::metadata 必須」を Task 6 に記録し、テストを `#[ignore]` にして所見コメントを添える（削除しない）。PASS なら「find-data mtime は新しい列挙で信頼できる → dir_mtime は 0 syscall 化可能」を記録する。
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add src-tauri/src/bench_support.rs
+git commit -m "test: キャッシュ mtime 信頼性テストを追加（#134 Phase1）
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: 全ベンチ実走と所見の記録
+
+拡張した `scan_bench` を N=1k/10k/100k で実走し、walk スペクトラム・rescan_one_change・parse 内訳を `docs/perf/granular-scan-spectrum-100k.md` に記録する。Task 5 の信頼性所見も併記する。**この数値が Phase 2 の fidelity レベル決定の材料**。
+
+**Files:**
+- Create: `docs/perf/granular-scan-spectrum-100k.md`
+
+**Interfaces:**
+- Consumes: 拡張済み `scan_bench`。
+- Produces: 計測記録 doc（Phase 2 計画の入力）。
+
+- [ ] **Step 1: フル回帰（feature 無効・本番非影響）を確認**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml`
+Expected: PASS（bench feature 無効で本番テストが崩れていないこと）
+
+Run: `cargo test --features bench --manifest-path src-tauri/Cargo.toml bench_support`
+Expected: PASS（Task 5 が `#[ignore]` の場合はその1件が ignored 表示）
+
+- [ ] **Step 2: scan_bench を実走**
+
+Run: `cargo bench --features bench --manifest-path src-tauri/Cargo.toml --bench scan_bench`
+Expected: `scan_n1000` / `scan_n10000` / `scan_n100000` の各グループで、既存行（full_scan/layer1_hit/store_*）＋新規行（walk_full_fidelity_3stat / walk_full_2stat_filetype / walk_dir_mtime_1stat / walk_nameset_0stat / rescan_one_change）の中央値が出力される。100k は sample_size=10 の indicative 値（数分かかる）。
+
+- [ ] **Step 3: 所見 doc を作成**
+
+`docs/perf/granular-scan-spectrum-100k.md` を作成。`docs/perf/baseline-100k.md` の書式に倣い、以下を埋める（数値は Step 2 の実測で置換）:
+
+```markdown
+# walk スペクトラム計測（10万体規模・#134 Phase 1）
+
+- 計測日: <実走日>
+- 目的: Phase 2 の fidelity レベル（full/dir_mtime/name-set）を選ぶための walk/parse 内訳。
+- 実行環境: <docs/perf/baseline-100k.md と同一環境なら参照。異なれば明記>
+- 手順: `cargo bench --features bench --bench scan_bench`
+
+## walk スペクトラムと parse 内訳
+
+| 形状 | n=1k | n=10k | n=100k(indicative) |
+|---|---|---|---|
+| full_scan（walk+parse） | | | |
+| walk_full_fidelity_3stat（本番 walk・parse抜き） | | | |
+| walk_full_2stat_filetype（is_dir→file_type） | | | |
+| walk_dir_mtime_1stat | | | |
+| walk_nameset_0stat | | | |
+| rescan_one_change（現行 1体変更→再走査） | | | |
+
+- **parse コスト** = full_scan − walk_full_fidelity_3stat = <値>（parse 支配か walk 支配かの判定）
+- **is_dir→file_type の無料削減** = walk_full_fidelity_3stat − walk_full_2stat_filetype = <値>
+- **fidelity ツマミの幅** = walk_full_2stat_filetype − walk_nameset_0stat = <値>
+
+## キャッシュ mtime 信頼性（Task 5 所見）
+
+- 結果: PASS / FAIL（<新しい列挙の find-data mtime が fs::metadata と一致したか>）
+- 含意: dir_mtime レベルを 0 syscall 化できるか / fs::metadata が必須か
+
+## Phase 2 への含意（fidelity レベル選択）
+
+- parse 支配なら: full fidelity granular で rescan は walk_full 相当（<値>）に落ち、体感フリーズ<有無>。同名置換 fidelity を保てる。
+- walk 支配なら: name-set レベル（<値>）でないと単体パース相当に届かない。同名置換検知を失う（§2.2）。
+- Phase 3（非ブロッキング）の要否: 選んだレベルの walk 残余（<値>）が体感フリーズ閾値を<超える/超えない>。
+```
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add docs/perf/granular-scan-spectrum-100k.md
+git commit -m "docs: walk スペクトラム計測結果を記録（#134 Phase1）
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Phase 1 完了後の次アクション（本計画外）
+
+計測 doc（Task 6）を根拠に:
+1. **fidelity レベルを決定**（full/dir_mtime/name-set。争点は「同名置換検知を捨てるか」§2.2）。
+2. **Phase 3 の要否を判定**（選んだレベルの walk 残余が体感フリーズを起こすか）。
+3. 上記を踏まえ **Phase 2 の実装計画を別途書き下ろす**（格納先案A `ghost_scan_entries` migration・`store_ghosts_delta`・生キー差分・delta 正しさ規則 §4.4・is_dir→file_type の本番適用）。
+```

--- a/docs/superpowers/specs/2026-07-16-granular-scan-fingerprint-design.md
+++ b/docs/superpowers/specs/2026-07-16-granular-scan-fingerprint-design.md
@@ -1,0 +1,218 @@
+# 設計書: 全走査スキャンの粒度化（issue #134）
+
+- 日付: 2026-07-16
+- issue: #134 「perf: 全走査スキャンの粒度化（1体増減で10万体を再走査しない）」
+- 前提: PR #133（性能計測ハーネス `scan_bench`/`search_bench`/`bench_support`）は main にマージ済み
+- マルチパースペクティブレビュー済み（cache整合・IPC契約・SQLite・エンコーディング・敵対的correctness の5レンズ）
+
+## 1. 問題
+
+10万体規模で `full_scan`（全走査 = walk + parse）が **3.4693 秒/回**。`layer1_hit`（無変更時の高速パス）は
+13.357 µs（`docs/perf/baseline-100k.md`）。NTFS の親ディレクトリ mtime は「配下の何かが変わった」ことしか
+示さない粒度のため、ゴースト1体の追加・削除のたびに Layer 1（親 mtime 一致判定）がミスし、10万体全件の
+walk+parse が走る（数秒の UI フリーズ）。全計測中で最大の絶対レイテンシ。
+
+## 2. 中核の洞察: walk コストは fidelity のツマミである
+
+現行 `scan_ghosts_with_fingerprint_internal`（`scan.rs`）は Layer 1 ミス時に全子を walk（read_dir + stat）
+し、`descript.txt` を持つ子を**全て** `read_ghost()` で parse する。案1（fingerprint 粒度細分化）は「変わった
+子だけ parse」に置換するが、**「どの子が変わったか」を知るための walk（O(N) stat）は消せない**。
+
+決定的な事実: **walk コスト ＝ 保存する変更検知シグナルの計算コスト ＝ トークンの中身**。この三者は同一の
+ダイヤルである。
+
+| 検知レベル | 子1体あたり stat | 検知できる変更 | form-1（単体パース相当・O(1)） |
+|---|---|---|---|
+| 現行トークン（dir_mtime＋descript_state＋descript_mtime） | 約2〜3 | add/del/rename/**同名置換**/descript出現 | **不可**（O(N) walk 残存） |
+| dir_mtime のみ | 1 | add/del/rename/**同名置換** | 不可 |
+| 名前集合のみ（read_dir の名前だけ） | **0** | add/del/rename のみ | **到達可** |
+
+**帰結**: 案1（現行トークン保持）は parse しか削れず O(N) walk が構造的に残るため、issue 受け入れ基準の
+第一形「単体パース相当」には**設計上届かない**。到達できるのは名前集合レベル（fidelity 最低）のみ。
+fidelity と速度は 10万体規模で二律背反であり、**どの点を選ぶかは計測（Phase 1）と fidelity 判断で決める**。
+
+### 2.1 fingerprint と walk の緊張（隠さず明示する）
+
+集約 fingerprint（F-04「ディレクトリ構成・**更新時刻**のハッシュ」）を今日ちょうどの値で保つには、
+full-fidelity の stat walk が要る。walk を削れば fingerprint の算出源（＝トークン中身）が変わり、F-04 を
+狭める。したがって **fidelity レベルの選択と fingerprint 定義は一つの決定**である。本設計はこの決定を
+Phase 1 の後段に置き、それまで先取り確定しない。
+
+### 2.2 実際に争点となる fidelity はただ一つ
+
+SPEC §7.4/§9.1 は既に「既存ゴースト内の descript.txt 編集は Layer 1 で検出せず『再読込』の強制フルスキャンで
+対応」と routing 済み。しかも descript の出現・編集は `ghost/`（親）の mtime を bump せず**この Layer1 ミス経路を
+そもそも通らない**。ゆえに安価な端（名前集合レベル）で実際に失う fidelity は——**同名置換（同じ dir 名で
+削除→再作成）の検知**、この一点のみ。これが名前集合レベルと dir_mtime レベルを分かつ唯一の discriminator。
+
+## 3. スコープと非スコープ
+
+- スコープ: Layer 1 ミス時の Layer 2 を「全 parse」から「差分検知 + 変更子だけ parse」へ置換し、
+  1体増減の再走査コストを削減する。計測ハーネスの拡張。
+- 非スコープ（今回やらない）: filesystem watcher / USN journal（issue の2案外・大掛かり）。
+  Phase 3（非ブロッキング UI）は測定条件付き（§6）。
+
+## 4. correctness 土台（fidelity に依らず確定採用）
+
+レビューが実コード根拠で突いた、fidelity レベルに依らず正しい修正。Phase 2 のどの検知レベルを選んでも共通。
+
+### 4.1 格納先＝案A（per-row テーブル）
+
+新テーブル `ghost_scan_entries`。案C（`ghost_fingerprints` に blob 列）は 1体増減でも約10MB を全書換し
+（WAL churn・overflow ページ）、削減した parse コストを書き込み側に転嫁して O(変更数) 目標に自己矛盾する。
+案A は変更行だけ UPSERT＝真の O(変更数)。
+
+```sql
+CREATE TABLE IF NOT EXISTS ghost_scan_entries (
+  request_key TEXT NOT NULL,
+  scan_key    TEXT NOT NULL,
+  token       TEXT NOT NULL,
+  PRIMARY KEY (request_key, scan_key)
+) WITHOUT ROWID;
+```
+
+- `WITHOUT ROWID` により `(request_key, scan_key, token)` が単一 B-tree のカバリング構成になり、既存
+  `ghosts` のカバリング index パターン（`lib.rs`）と一貫。前回状態の読み取りは
+  `SELECT scan_key, token FROM ghost_scan_entries WHERE request_key = ?1`（カバリング）。
+- 新 migration（version 14 以降）として追加。既存 migration の SQL は一切編集しない（SHA-384 チェックサム
+  不変性）。複数文は `\n` 明示（`src-tauri/CLAUDE.md`）。`NOT NULL` 列に DEFAULT は付けない（INSERT 時に常に
+  値を渡す。付けるならリテラルのみ）。
+- 揮発キャッシュ（`ghosts` と運命共有）。寿命管理（`cleanupOldGhostCaches`）と同一 `request_key` で
+  一括削除する対象に含める（SPEC §8.1 の削除経路に追加）。
+
+### 4.2 差分マップのキー＝生の物理キー
+
+`scan_key` は生の物理識別子（`normalized_parent` ＋ セパレータ ＋ **生** `directory_name`）とする。
+`ghost_identity_key`（＝ NFKC(source)+\x1f+NFKC(dir_name)）を差分キーに使うと、全角/半角・半角カナ・互換
+文字・合成/分解の NFKC 畳み込みで**物理的に別のディレクトリが同一キーに衝突**し、HashMap 上で後勝ち上書き
+され、**「ラウドな UNIQUE エラー」が「サイレントなゴースト消失＋ path 振動（run ごとに勝者が入れ替わり
+誤ったゴーストを起動）」に退行**する。生キーなら物理ディレクトリごとに別エントリを保ち、UPSERT 段で
+`ghost_identity_key` に畳んだとき既存の UNIQUE index が衝突を loud に弾く現挙動を維持する。
+
+- `scan_key` の生キーは走査差分専用。`ghosts` への UPSERT/DELETE では従来どおり `ghost_identity_key` を使う。
+- DELETE 対象（前回 scan_key にあり今回 walk に無い子）の `ghosts` 行を消すには `ghost_identity_key` が要る。
+  `scan_key` から source と dir_name を復元して算出するか、`ghost_scan_entries` に補助情報を持たせる
+  （実装計画で確定。設計上は「生キーで差分し、identity_key で ghosts を操作する」二層を保つことが要件）。
+- セパレータは制御文字（`\x1f`/`\x1e` 等）を用い、Windows ファイル名規則（制御文字不可）に暗黙依存する旨を
+  コメント明記。パースは防御的に（`splitn` で過剰分割防止）。
+
+### 4.3 集約 fingerprint は生キートークン集合から決定的に算出
+
+fingerprint は畳み込み identity マップからではなく、**生キーのトークン集合**（＋親トークン＋version ヘッダ）
+から `compute_fingerprint_hash` 相当で算出する。畳み込みマップから算出すると (1) 親トークン・version が欠落し
+情報不足、(2) NFKC 衝突と HashMap 反復順序で**非決定的**になり、Layer 2 等値判定（`mod.rs`）と
+`getCachedFingerprint` 往復契約（`ScanStoreResult.fingerprint`）が壊れる。マップと fingerprint は同一 walk から
+導かれる2つの派生物であり、同一トランザクションで原子的に共に書く。
+
+### 4.4 delta 適用の正しさ規則
+
+- **変更子（新規＋トークン変化）は parse を試みる。Ghost が得られたら UPSERT、得られなければ（descript
+  missing でも parse 失敗＝内容破損でも）その `ghost_identity_key` の `ghosts` 行を DELETE**。現行 `store_ghosts`
+  は集合差で「スキャン結果に無いキー」を DELETE するため破損子が消える挙動を持つ。delta もこれに収束させる。
+- **削除子（前回 scan_key にあり今回 walk に無い）は DELETE**。
+- **不変子（トークン一致）は一切触らない**（parse も DB 書込もしない）。
+- **`total` は delta 適用後の `SELECT COUNT(*) FROM ghosts WHERE request_key = ?1` を返す**。`upserts.len()` を
+  流用しない（`dbMonitor.ts` の `ALERT_GHOST_COUNT`＝10万閾値監視が壊れる）。`cache_hit=true` なら従来どおり
+  `total=0`。この不変条件をテストで固定。
+- **`store_ghosts_delta` は `last_launched`/`launch_count` 集計列に触れない**（現行 `store_ghosts` の UPDATE 列
+  規律を踏襲）。`scan_and_store` は delta 経路でも commit 後に `backfill_launch_aggregates` を必ず呼ぶ
+  （`/symmetry-check` 対象）。
+- **子変更0でも `fingerprint`＋`parent_mtimes`（＋不変の scan_entries）を必ず書く**。「親 mtime だけ変化・子
+  集合同一」は fingerprint が親トークンを含むため cache_hit=false で delta 経路に入り、parse0/書込0 だが
+  fingerprint と parent_mtimes の更新が要る（書き忘れると以後 Layer 1 が毎回ミス＝性能退行）。
+- **初回スキャン（前回 scan_entries 不在）はフォールバックでフル walk+parse し、scan_entries を必ず seed する**。
+  seed を怠ると delta 経路に永遠に到達しない。フォールバックが既存 `store_ghosts` を通る場合、
+  `ghost_fingerprints` の `INSERT OR REPLACE` が scan_entries と別テーブルである点で案C の blob 破壊問題は
+  回避される（案A採用の副次的利点）。
+
+### 4.5 無料の walk 削減（is_dir のみ・mtime には及ばない）
+
+`scan.rs` の `p.is_dir()`（full-path stat）を `read_dir` の `DirEntry::file_type().is_dir()`（キャッシュ済み
+find-data 参照・syscall ゼロ）に置換する。ディレクトリ属性ビットは陳腐化しないため正しさ不変。これは
+fidelity に依らない純粋な削減。
+
+**ただし mtime には及ばない**: Windows の find-data はキャッシュ mtime を無料で持つが、それは本コードベースが
+`fs::metadata` で意図的に避けている陳腐化シグナル。「そのキャッシュ mtime が**スキャン間**の検知に足るか」は
+不確実であり、**仮定せず Phase 1 の明示的テスト項目とする**（§5）。足りるなら dir_mtime レベルがほぼ無料化し
+うる。
+
+## 5. Phase 1 — 意思決定の計器（受け入れ基準の一部・ゲート）
+
+単なる計測でなく、Phase 2 の検知レベルを決める計器。`bench_support.rs` に本番経路ラッパーを露出し、
+`scan_bench.rs` に形状を追加する（すべて `#[cfg(feature = "bench")]` ゲート下）。
+
+1. **walk を各 fidelity レベルで測る**:
+   - full-fidelity walk（現行トークン・約2〜3 stat）＝ 既存 `full_scan` から parse を除いた `walk_only`
+     （`scan_ghosts_with_fingerprint_internal` を ghosts 収集なしで呼ぶ `fingerprint_only(ssp)`）
+   - dir_mtime のみ（1 stat）
+   - 名前集合のみ（0 per-child stat・read_dir 名前のみ）
+   これで **parse コスト = full_scan − walk_only**、および各レベルの walk コストが判明。スペクトラム上の
+   どの点が「体感フリーズしない」に入るかを数値で確定する。
+2. **`rescan_one_change` 形状**: 「1体増減→ Layer 1 ミス→再走査」の end-to-end。`iter_batched` で**毎イテレーション
+   Layer1 ミス＋差分ちょうど1を強制**する（素朴実装だと変異後に Layer1 hit=13µs や差分ゼロ全 walk を誤計測する）。
+   現行コードの baseline と、Phase 2 の granular 版を直接比較する。
+3. **無料削減の効果測定**: `is_dir`→`file_type` 化前後の walk 差。
+4. **キャッシュ mtime 信頼性テスト**: `entry.metadata()` のキャッシュ mtime が、スキャン間（ツリー変異後の
+   別プロセス/別 read_dir）で `fs::metadata` と一致し検知に足るかを検証するテスト。dir_mtime レベルの
+   実現可否を左右する。
+
+**Phase 1 の出力＝「スペクトラム上のどの点を選ぶか」の材料**（form-1 の可否ではなく、fidelity×速度の選択）。
+
+## 6. Phase 2 — 差分検知 + 変更子だけ parse（トークン機構は Phase 1 で確定）
+
+correctness 土台（§4）は先に固定。**トークン中身（＝walk コスト＝fidelity レベル）だけ Phase 1 の計測と
+同名置換 fidelity 判断で確定**する。データフロー（Layer 1 ミス時、レベル非依存の骨格）:
+
+1. 全親を walk → `{scan_key → token}` マップ構築（token 中身はレベル依存、parse なし）
+2. 前回の `{scan_key → token}` を `ghost_scan_entries` から読む
+3. マップ差分 → 新規/変更（parse 対象）・削除（DELETE 対象）・不変（触らない）
+4. 変更分だけ `read_ghost()` parse → Ghost 群
+5. 1 トランザクションで: `ghosts` の UPSERT/DELETE（§4.4）＋ `ghost_scan_entries` の UPSERT/DELETE ＋
+   `ghost_fingerprints`（fingerprint＋parent_mtimes）更新。commit 後 backfill。
+
+新設: `store_ghosts_delta(conn, request_key, upserts: &[Ghost], deletes: &[identity_key],
+scan_entry_upserts, scan_entry_deletes, fingerprint, parent_mtimes)`（対象行だけ操作・全行読み取り不要）。
+既存 `store_ghosts` は初回フォールバック用に維持。
+
+**IPC 契約は不変**: `scan_and_store` の引数・戻り値型は変えない。前回 scan_entries は DB 由来でフロントに
+露出しない。`Ghost`/`ScanStoreResult` に scan_key/token を混入させない（IPC を渡らない内部表現を保つ）。
+
+## 7. Phase 3 — 非ブロッキング化（測定条件付き・YAGNI ゲート）
+
+Phase 1+2 の実測で、選んだ fidelity レベルの walk 残余が体感フリーズを起こす場合にのみ着手。streaming/
+進捗 UI。fidelity を保ちつつ walk が大きい場合は事実上必須化しうる。着手時に IPC 面（event/channel の
+ペイロード型を ts-rs 生成にするか）を別途決める。**本設計では前方非互換を生む変更をしない**（Phase 2 の
+同期 `Result<ScanStoreResult>` 契約に加算的にイベントを併設できる）。
+
+## 8. 受け入れ基準（正直に再定義）
+
+issue の第一形「単体パース相当」は案1（walk 保持）では原理不可。到達可能な形で再定義する:
+
+- **Phase 1**: `scan_bench` に walk の各 fidelity レベル分解＋`rescan_one_change` 形状が追加され、
+  3.47秒の walk/parse 内訳と各レベルの walk コストが数値で確定する。
+- **Phase 2**: 選んだ fidelity レベルで、1体増減の再走査コストが `full_scan`（3.47s）から
+  **walk_only(そのレベル) + 単体 parse 相当**へ落ちる（名前集合レベルを選べば「単体パース相当」に到達、
+  現行トークンレベルを選べば「full-fidelity walk + 単体 parse」）。granular bench 数値で before/after を実証。
+- **Phase 3（条件付き）**: 着手した場合、走査中に UI がブロックしない。
+
+## 9. レビューで捕捉した主要リスク（実装計画への申し送り）
+
+| # | リスク | 対策（本設計での扱い） |
+|---|---|---|
+| C1 | 案C blob が `INSERT OR REPLACE` で消え delta 経路に永遠に到達しない | 案A採用で回避（§4.1） |
+| C2 | fingerprint を畳み込みマップから算出すると非決定的 | 生キー集合から算出（§4.3） |
+| H1 | mtime は内容変化の完全なプロキシでない（mtime保存編集・サムネイル変更を取りこぼす） | SPEC §7.4 の「再読込」contract に整合。Phase1 で取りこぼしを計測項目化。§2.2 |
+| H2 | 変更→parse失敗子の DELETE 漏れ | delta 規則で missing/破損とも DELETE（§4.4） |
+| H3 | identity_key 衝突でサイレント消失＋path振動 | 生キー差分＋UNIQUE loud failure 維持（§4.2） |
+| IPC | `total` が変更数に化け10万監視が壊れる | `SELECT COUNT(*)` を返す（§4.4） |
+| M3 | 起動集計列の消失・backfill 欠落 | 集計列不可侵＋delta 経路でも backfill（§4.4） |
+
+## 10. 検証方針
+
+- Rust: `cargo test`（store_ghosts_delta の差分適用・DELETE 分岐・total=COUNT・0変更 fingerprint 書込・
+  NFKC 衝突の loud failure 維持・scan_key 生キー性）。`cargo test --features bench bench_support`。
+- ベンチ: `cargo bench --features bench --bench scan_bench`（各 fidelity レベル・rescan_one_change）。
+- 回帰: `cargo test`（feature 無効・本番非影響）・`npm test`・`npm run build`・`cargo check`。
+- `/cache-check`・`/ipc-check`・`/symmetry-check` の観点で最終監査。
+- SPEC.md §7.4 の Layer2 記述を granular 化に合わせて同期（F-04 の fidelity レベルを明記）。
+```

--- a/src-tauri/benches/scan_bench.rs
+++ b/src-tauri/benches/scan_bench.rs
@@ -5,8 +5,8 @@ use std::time::Duration;
 
 use criterion::Criterion;
 use ghost_launcher_lib::bench_support::{
-    full_scan_count, generate_ghost_tree, layer1_hit, open_bench_db, scan_to_handle, store_handle,
-    store_with_real_mtimes,
+    add_one_ghost, full_scan_count, generate_ghost_tree, layer1_hit, open_bench_db, scan_to_handle,
+    store_handle, store_with_real_mtimes,
 };
 
 /// ベンチ用の一時ディレクトリガード（lib 内部 TempDirGuard は非 pub のためローカルに持つ）。
@@ -83,6 +83,26 @@ fn bench_scan(c: &mut Criterion) {
             store_handle(&conn, "rk", &handle, &fp).unwrap();
             group.bench_function("store_rescan_nodiff", |b| {
                 b.iter(|| store_handle(&conn, "rk", &handle, &fp).unwrap());
+            });
+        }
+
+        // 1体変更→再走査（現行ベースライン）: setup で 1 体追加し Layer1 ミス+差分1を強制、
+        // routine でフル walk+parse + store 差分（現行の miss 経路）を測る。
+        {
+            let conn = open_bench_db(&guard.path().join("rescan.db")).unwrap();
+            store_with_real_mtimes(&conn, "rk", &handle, &fp, &ssp_str).unwrap();
+            group.bench_function("rescan_one_change", |b| {
+                b.iter_batched(
+                    || {
+                        let tag = fastrand_like() as usize;
+                        add_one_ghost(&ssp_str, tag).unwrap();
+                    },
+                    |_| {
+                        let (h, f) = scan_to_handle(&ssp_str).unwrap();
+                        store_handle(&conn, "rk", &h, &f).unwrap();
+                    },
+                    criterion::BatchSize::PerIteration,
+                );
             });
         }
 

--- a/src-tauri/benches/scan_bench.rs
+++ b/src-tauri/benches/scan_bench.rs
@@ -5,8 +5,9 @@ use std::time::Duration;
 
 use criterion::Criterion;
 use ghost_launcher_lib::bench_support::{
-    add_one_ghost, full_scan_count, generate_ghost_tree, layer1_hit, open_bench_db, scan_to_handle,
-    store_handle, store_with_real_mtimes,
+    add_one_ghost, fingerprint_only, full_scan_count, generate_ghost_tree, layer1_hit,
+    open_bench_db, scan_to_handle, store_handle, store_with_real_mtimes, walk_dir_mtime, walk_full,
+    walk_nameset,
 };
 
 /// ベンチ用の一時ディレクトリガード（lib 内部 TempDirGuard は非 pub のためローカルに持つ）。
@@ -50,6 +51,20 @@ fn bench_scan(c: &mut Criterion) {
         // フル走査（1 体増減毎に払うコスト）
         group.bench_function("full_scan", |b| {
             b.iter(|| full_scan_count(&ssp_str).unwrap());
+        });
+
+        // walk スペクトラム（parse 抜き・各 fidelity レベル）
+        group.bench_function("walk_full_fidelity_3stat", |b| {
+            b.iter(|| fingerprint_only(&ssp_str).unwrap());
+        });
+        group.bench_function("walk_full_2stat_filetype", |b| {
+            b.iter(|| walk_full(&ssp_str).unwrap());
+        });
+        group.bench_function("walk_dir_mtime_1stat", |b| {
+            b.iter(|| walk_dir_mtime(&ssp_str).unwrap());
+        });
+        group.bench_function("walk_nameset_0stat", |b| {
+            b.iter(|| walk_nameset(&ssp_str).unwrap());
         });
 
         // Layer1 hit（無変更時の高速パス）。実 mtimes を保存して真の hit にする。

--- a/src-tauri/benches/scan_bench.rs
+++ b/src-tauri/benches/scan_bench.rs
@@ -5,9 +5,9 @@ use std::time::Duration;
 
 use criterion::Criterion;
 use ghost_launcher_lib::bench_support::{
-    add_one_ghost, fingerprint_only, full_scan_count, generate_ghost_tree, layer1_hit,
-    open_bench_db, scan_to_handle, store_handle, store_with_real_mtimes, walk_dir_mtime, walk_full,
-    walk_nameset,
+    add_one_ghost, fingerprint_only, fingerprint_only_filetype, full_scan_count,
+    generate_ghost_tree, layer1_hit, open_bench_db, scan_to_handle, store_handle,
+    store_with_real_mtimes, walk_dir_mtime, walk_full, walk_nameset,
 };
 
 /// ベンチ用の一時ディレクトリガード（lib 内部 TempDirGuard は非 pub のためローカルに持つ）。
@@ -56,6 +56,11 @@ fn bench_scan(c: &mut Criterion) {
         // walk スペクトラム（parse 抜き・各 fidelity レベル）
         group.bench_function("walk_full_fidelity_3stat", |b| {
             b.iter(|| fingerprint_only(&ssp_str).unwrap());
+        });
+        // full fidelity のまま逐次 is_dir を file_type に置換（同一 fingerprint・F-04 不変）。
+        // walk_full_fidelity_3stat との差 = 逐次 is_dir pass 単独のコスト。
+        group.bench_function("walk_full_fidelity_filetype", |b| {
+            b.iter(|| fingerprint_only_filetype(&ssp_str).unwrap());
         });
         group.bench_function("walk_full_2stat_filetype", |b| {
             b.iter(|| walk_full(&ssp_str).unwrap());

--- a/src-tauri/src/bench_support.rs
+++ b/src-tauri/src/bench_support.rs
@@ -218,6 +218,12 @@ pub fn full_scan_count(ssp_path: &str) -> Result<usize, String> {
     Ok(ghosts.len())
 }
 
+/// フル fidelity walk を parse 抜きで実行し fingerprint を返す（walk_only 計測）。
+/// full_scan_count との差が parse コスト。
+pub fn fingerprint_only(ssp_path: &str) -> Result<String, String> {
+    crate::commands::ghost::fingerprint_only_internal(ssp_path, &[])
+}
+
 /// Layer 1 高速パス（親 mtime 一致判定）を測る。事前に store_with_real_mtimes で
 /// 保存していれば true（hit）、store_handle で保存していれば false（miss）を返すが、
 /// 計測対象の「1 行 SELECT + 文字列比較」コストはどちらも同等。
@@ -410,6 +416,21 @@ mod tests {
         let ssp = tmp.path().join("ssp");
         generate_ghost_tree(&ssp, 25).unwrap();
         assert_eq!(full_scan_count(&ssp.to_string_lossy()).unwrap(), 25);
+    }
+
+    #[test]
+    fn fingerprint_only_がフルスキャンと同じfingerprintを返す() {
+        let tmp = TempDirGuard::new("bench_fp_only");
+        let ssp = tmp.path().join("ssp");
+        generate_ghost_tree(&ssp, 30).unwrap();
+        let ssp_str = ssp.to_string_lossy().to_string();
+
+        let (_ghosts, full_fp) =
+            crate::commands::ghost::scan_ghosts_with_fingerprint_internal(&ssp_str, &[]).unwrap();
+        let walk_fp = fingerprint_only(&ssp_str).unwrap();
+
+        // parse 抜き walk でも同一トークン集合 → 同一 fingerprint
+        assert_eq!(walk_fp, full_fp);
     }
 
     // ハーネス核心の不変条件を縛る（scan_bench の debug_assert! は bench プロファイルで no-op のため

--- a/src-tauri/src/bench_support.rs
+++ b/src-tauri/src/bench_support.rs
@@ -4,6 +4,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use rayon::prelude::*;
 use rusqlite::Connection;
 
 use crate::commands::ghost::store::{configure_connection, store_ghosts};
@@ -224,6 +225,49 @@ pub fn fingerprint_only(ssp_path: &str) -> Result<String, String> {
     crate::commands::ghost::fingerprint_only_internal(ssp_path, &[])
 }
 
+/// {ssp}/ghost 直下の子ディレクトリパスを列挙する（is_dir 判定はキャッシュ済み
+/// find-data の file_type を使い syscall ゼロ）。本番 walk_parent の is_dir(stat)
+/// を file_type に置換したときの walk を模す計測用ヘルパー。
+fn ghost_children(ssp_path: &str) -> Result<Vec<PathBuf>, String> {
+    let ghost_dir = Path::new(ssp_path).join("ghost");
+    let entries = fs::read_dir(&ghost_dir).map_err(|e| format!("read_dir: {e}"))?;
+    Ok(entries
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
+        .map(|e| e.path())
+        .collect())
+}
+
+/// 名前集合レベル: 子1体あたり stat ゼロ（read_dir + file_type のみ）。
+/// add/del/rename は検知できるが同名置換は検知できない fidelity 下限。
+pub fn walk_nameset(ssp_path: &str) -> Result<usize, String> {
+    Ok(ghost_children(ssp_path)?.len())
+}
+
+/// dir_mtime レベル: 子1体あたり fs::metadata 1 回（dir mtime のみ、descript stat なし）。
+/// 同名置換まで検知できる。
+pub fn walk_dir_mtime(ssp_path: &str) -> Result<usize, String> {
+    let paths = ghost_children(ssp_path)?;
+    let count = paths.par_iter().filter(|p| fs::metadata(p).is_ok()).count();
+    Ok(count)
+}
+
+/// full fidelity レベル（file_type 版）: 子1体あたり 2 stat（dir mtime + descript）。
+/// 本番 walk_parent は is_dir(stat) を足して 3 stat のため、fingerprint_only との差が
+/// is_dir→file_type の無料削減効果。
+pub fn walk_full(ssp_path: &str) -> Result<usize, String> {
+    let paths = ghost_children(ssp_path)?;
+    let count = paths
+        .par_iter()
+        .filter(|p| {
+            let _dir = fs::metadata(p).is_ok(); // stat 1: dir mtime
+            let descript = p.join("ghost").join("master").join("descript.txt");
+            fs::metadata(&descript).is_ok() // stat 2: descript 有無/mtime（結果を使用）
+        })
+        .count();
+    Ok(count)
+}
+
 /// Layer 1 高速パス（親 mtime 一致判定）を測る。事前に store_with_real_mtimes で
 /// 保存していれば true（hit）、store_handle で保存していれば false（miss）を返すが、
 /// 計測対象の「1 行 SELECT + 文字列比較」コストはどちらも同等。
@@ -431,6 +475,20 @@ mod tests {
 
         // parse 抜き walk でも同一トークン集合 → 同一 fingerprint
         assert_eq!(walk_fp, full_fp);
+    }
+
+    #[test]
+    fn walk_モデル3種が全て子ディレクトリ数を返す() {
+        let tmp = TempDirGuard::new("bench_walk_levels");
+        let ssp = tmp.path().join("ssp");
+        generate_ghost_tree(&ssp, 50).unwrap();
+        let ssp_str = ssp.to_string_lossy().to_string();
+
+        assert_eq!(walk_nameset(&ssp_str).unwrap(), 50);
+        assert_eq!(walk_dir_mtime(&ssp_str).unwrap(), 50);
+        assert_eq!(walk_full(&ssp_str).unwrap(), 50);
+        // 本番フル走査の体数とも一致（全子に descript 有り）
+        assert_eq!(full_scan_count(&ssp_str).unwrap(), 50);
     }
 
     // ハーネス核心の不変条件を縛る（scan_bench の debug_assert! は bench プロファイルで no-op のため

--- a/src-tauri/src/bench_support.rs
+++ b/src-tauri/src/bench_support.rs
@@ -526,6 +526,59 @@ mod tests {
         assert!(!layer1_hit(&conn, "rk", &ssp_str), "追加で親 mtime が変わり miss のはず");
     }
 
+    // キャッシュ mtime 信頼性テスト（Task 5）: entry.metadata()（find-data 由来・syscall
+    // ゼロ）の mtime が、ツリー変更後の「新しい read_dir 列挙」で fs::metadata と一致するか。
+    //
+    // 所見（2026-07-16 実測・Windows 11 / NTFS）: FAIL。新しい read_dir 列挙でも
+    // entry.metadata() の mtime は fs::metadata と不一致（実測差 ~63ms、find-data
+    // キャッシュが陳腐化）。→ dir_mtime レベルは find-data mtime を無料利用できず、
+    // fs::metadata で 1 実 stat/子 が必須。真に安価な walk は name-set（0 stat）のみで、
+    // それは同名置換検知を失う。コードベースが fs::metadata を全面採用している判断
+    // （scan.rs の NTFS 陳腐化回避コメント）が実測で裏付けられた。
+    //
+    // #[ignore]: 上記所見を記録した回帰ガードとして残す。プラットフォーム挙動が変われば
+    // 手動実行（cargo test --features bench -- --ignored キャッシュmtime）で再検証する。
+    #[test]
+    #[ignore = "所見: Windows では find-data mtime が新しい列挙でも陳腐化する（dir_mtime は fs::metadata 必須）"]
+    fn キャッシュmtimeが新しい列挙で更新を反映する() {
+        use std::time::Duration;
+        let tmp = TempDirGuard::new("bench_mtime_reliability");
+        let ssp = tmp.path().join("ssp");
+        generate_ghost_tree(&ssp, 5).unwrap();
+        let ghost_dir = ssp.join("ghost");
+
+        // 対象の子ディレクトリを1つ選ぶ
+        let target = ghost_dir.join("dir_000000");
+
+        // mtime を確実に前進させるため、少し待ってから中身を更新する
+        std::thread::sleep(Duration::from_millis(50));
+        fs::write(
+            target.join("ghost").join("master").join("descript.txt"),
+            "charset,UTF-8\nname,更新後\n",
+        )
+        .unwrap();
+        // ディレクトリ自身の mtime を bump するためファイルを1つ足す
+        fs::write(target.join("touch.tmp"), b"x").unwrap();
+
+        // 変更後に「新しい read_dir 列挙」で entry.metadata() と fs::metadata を比較
+        let mut cached = None;
+        for entry in fs::read_dir(&ghost_dir).unwrap() {
+            let entry = entry.unwrap();
+            if entry.path() == target {
+                cached = entry.metadata().ok().and_then(|m| m.modified().ok());
+            }
+        }
+        let fresh = fs::metadata(&target).ok().and_then(|m| m.modified().ok());
+
+        // 新しい列挙のキャッシュ mtime が fs::metadata と一致するか（所見）。
+        // 一致するなら dir_mtime レベルは find-data mtime で 0 syscall 化できる。
+        assert_eq!(
+            cached, fresh,
+            "新しい read_dir 列挙の entry.metadata() mtime が fs::metadata と不一致。\
+             dir_mtime レベルは find-data mtime を使えない（fs::metadata で 1 stat 必要）。"
+        );
+    }
+
     // ハーネス核心の不変条件を縛る（scan_bench の debug_assert! は bench プロファイルで no-op のため
     // ここで cargo test（debug-assertions 有効）による回帰ガードを置く）。
     #[test]

--- a/src-tauri/src/bench_support.rs
+++ b/src-tauri/src/bench_support.rs
@@ -241,6 +241,12 @@ pub fn fingerprint_only(ssp_path: &str) -> Result<String, String> {
     crate::commands::ghost::fingerprint_only_internal(ssp_path, &[])
 }
 
+/// fingerprint_only と同一 fingerprint を返すが、逐次 is_dir を file_type に置換した版。
+/// fingerprint_only との差 = 逐次 is_dir pass 単独のコスト（token/hash と分離）。
+pub fn fingerprint_only_filetype(ssp_path: &str) -> Result<String, String> {
+    crate::commands::ghost::fingerprint_only_filetype_internal(ssp_path)
+}
+
 /// {ssp}/ghost 直下の子ディレクトリパスを列挙する（is_dir 判定はキャッシュ済み
 /// find-data の file_type を使い syscall ゼロ）。本番 walk_parent の is_dir(stat)
 /// を file_type に置換したときの walk を模す計測用ヘルパー。
@@ -491,6 +497,69 @@ mod tests {
 
         // parse 抜き walk でも同一トークン集合 → 同一 fingerprint
         assert_eq!(walk_fp, full_fp);
+    }
+
+    #[test]
+    fn fingerprint_only_filetype_が同一fingerprintを返す() {
+        let tmp = TempDirGuard::new("bench_fp_filetype");
+        let ssp = tmp.path().join("ssp");
+        generate_ghost_tree(&ssp, 30).unwrap();
+        let ssp_str = ssp.to_string_lossy().to_string();
+
+        // 逐次 is_dir を file_type に置換しても同一トークン集合 → 同一 fingerprint
+        assert_eq!(
+            fingerprint_only_filetype(&ssp_str).unwrap(),
+            fingerprint_only(&ssp_str).unwrap()
+        );
+    }
+
+    // 判別計測（Task 6 追補）: fingerprint_only（逐次 is_dir 込み）と
+    // fingerprint_only_filetype（file_type・逐次 is_dir なし）を同一ツリーで時間比較する。
+    // 両者の差 = 逐次 is_dir pass 単独のコスト。これで「walk コストの過半が逐次 is_dir か
+    // token/hash か」を切り分ける。#[ignore]（診断・手動実行）。
+    // 実行: cargo test --features bench -- --ignored --nocapture 逐次is_dir
+    #[test]
+    #[ignore = "診断: 逐次 is_dir vs token/hash の切り分け計測（手動・--nocapture）"]
+    fn 逐次is_dirとfiletypeの時間差を計測する() {
+        use std::time::Instant;
+        const N: usize = 30_000;
+        const ITERS: u32 = 5;
+
+        let tmp = TempDirGuard::new("bench_isdir_discriminate");
+        let ssp = tmp.path().join("ssp");
+        generate_ghost_tree(&ssp, N).unwrap();
+        let ssp_str = ssp.to_string_lossy().to_string();
+
+        // warm up（OS キャッシュ）
+        let _ = fingerprint_only(&ssp_str).unwrap();
+        let _ = fingerprint_only_filetype(&ssp_str).unwrap();
+
+        let mut best_seq = f64::MAX;
+        let mut best_ft = f64::MAX;
+        for _ in 0..ITERS {
+            let t0 = Instant::now();
+            let _ = fingerprint_only(&ssp_str).unwrap();
+            best_seq = best_seq.min(t0.elapsed().as_secs_f64());
+
+            let t1 = Instant::now();
+            let _ = fingerprint_only_filetype(&ssp_str).unwrap();
+            best_ft = best_ft.min(t1.elapsed().as_secs_f64());
+        }
+
+        println!(
+            "\n[判別計測 N={N}] fingerprint_only(逐次is_dir込み)={:.1}ms  \
+             fingerprint_only_filetype(is_dirなし)={:.1}ms  \
+             逐次is_dir単独≈{:.1}ms（差 {:.0}%）",
+            best_seq * 1000.0,
+            best_ft * 1000.0,
+            (best_seq - best_ft) * 1000.0,
+            (best_seq - best_ft) / best_seq * 100.0,
+        );
+        // 同値であることも確認
+        assert_eq!(
+            fingerprint_only_filetype(&ssp_str).unwrap(),
+            fingerprint_only(&ssp_str).unwrap()
+        );
     }
 
     #[test]

--- a/src-tauri/src/bench_support.rs
+++ b/src-tauri/src/bench_support.rs
@@ -179,6 +179,22 @@ pub fn generate_ghost_tree(ssp_root: &Path, n: usize) -> Result<PathBuf, String>
     Ok(ssp_root.to_path_buf())
 }
 
+/// 既存ツリーに一意名（dir_added_{tag}）のゴースト1体を追加する。
+/// 親 {ssp}/ghost の mtime を bump するため、以後の layer1 判定はミスする。
+pub fn add_one_ghost(ssp_path: &str, tag: usize) -> Result<(), String> {
+    let master = Path::new(ssp_path)
+        .join("ghost")
+        .join(format!("dir_added_{tag:09}"))
+        .join("ghost")
+        .join("master");
+    fs::create_dir_all(&master).map_err(|e| format!("mkdir added: {e}"))?;
+    fs::write(
+        master.join("descript.txt"),
+        format!("charset,UTF-8\nname,追加{tag}\n"),
+    )
+    .map_err(|e| format!("write added: {e}"))
+}
+
 /// スキャン結果の Ghost 群を外部ベンチに対して opaque に保持する。
 pub struct ScannedGhosts {
     ghosts: Vec<Ghost>,
@@ -489,6 +505,25 @@ mod tests {
         assert_eq!(walk_full(&ssp_str).unwrap(), 50);
         // 本番フル走査の体数とも一致（全子に descript 有り）
         assert_eq!(full_scan_count(&ssp_str).unwrap(), 50);
+    }
+
+    #[test]
+    fn add_one_ghost_が体数を1増やしlayer1をミスさせる() {
+        let tmp = TempDirGuard::new("bench_add_one");
+        let ssp = tmp.path().join("ssp");
+        generate_ghost_tree(&ssp, 20).unwrap();
+        let ssp_str = ssp.to_string_lossy().to_string();
+
+        // 初期状態を real mtimes で保存 → layer1 hit する
+        let (handle, fp) = scan_to_handle(&ssp_str).unwrap();
+        let conn = open_bench_db(&tmp.path().join("ghosts.db")).unwrap();
+        store_with_real_mtimes(&conn, "rk", &handle, &fp, &ssp_str).unwrap();
+        assert!(layer1_hit(&conn, "rk", &ssp_str));
+
+        // 1 体追加 → 体数 +1、layer1 ミス
+        add_one_ghost(&ssp_str, 1).unwrap();
+        assert_eq!(full_scan_count(&ssp_str).unwrap(), 21);
+        assert!(!layer1_hit(&conn, "rk", &ssp_str), "追加で親 mtime が変わり miss のはず");
     }
 
     // ハーネス核心の不変条件を縛る（scan_bench の debug_assert! は bench プロファイルで no-op のため

--- a/src-tauri/src/commands/ghost/mod.rs
+++ b/src-tauri/src/commands/ghost/mod.rs
@@ -9,7 +9,7 @@ mod types;
 #[cfg(feature = "bench")]
 pub(crate) use fingerprint::{check_parent_mtimes_match, collect_parent_mtimes};
 #[cfg(feature = "bench")]
-pub(crate) use scan::scan_ghosts_with_fingerprint_internal;
+pub(crate) use scan::{fingerprint_only_internal, scan_ghosts_with_fingerprint_internal};
 #[cfg(feature = "bench")]
 pub(crate) use types::Ghost;
 

--- a/src-tauri/src/commands/ghost/mod.rs
+++ b/src-tauri/src/commands/ghost/mod.rs
@@ -9,7 +9,10 @@ mod types;
 #[cfg(feature = "bench")]
 pub(crate) use fingerprint::{check_parent_mtimes_match, collect_parent_mtimes};
 #[cfg(feature = "bench")]
-pub(crate) use scan::{fingerprint_only_internal, scan_ghosts_with_fingerprint_internal};
+pub(crate) use scan::{
+    fingerprint_only_filetype_internal, fingerprint_only_internal,
+    scan_ghosts_with_fingerprint_internal,
+};
 #[cfg(feature = "bench")]
 pub(crate) use types::Ghost;
 

--- a/src-tauri/src/commands/ghost/scan.rs
+++ b/src-tauri/src/commands/ghost/scan.rs
@@ -233,3 +233,51 @@ pub(crate) fn fingerprint_only_internal(
 
     Ok(compute_fingerprint_hash(&tokens))
 }
+
+/// `fingerprint_only_internal`（ssp のみ）と同一トークン・同一 fingerprint を生成するが、
+/// 逐次 is_dir 判定（walk_parent の `.filter(|p| p.is_dir())`・100k 逐次 stat）を
+/// キャッシュ済み find-data の `file_type()`（syscall ゼロ）に置換した版。
+/// 両者の差 = 逐次 is_dir pass 単独のコスト（is_dir→file_type の無料削減効果を、
+/// token 生成・ハッシュコストと分離して計測する判別用）。ベンチ専用・本番非呼出。
+#[cfg(feature = "bench")]
+pub(crate) fn fingerprint_only_filetype_internal(ssp_path: &str) -> Result<String, String> {
+    let ghost_dir = Path::new(ssp_path).join("ghost");
+    let normalized_parent = normalize_path(&ghost_dir);
+    let mut tokens = vec!["fingerprint-version|1".to_string()];
+
+    // 親トークン（walk_parent と同一形式）
+    let parent_modified = fs::metadata(&ghost_dir)
+        .as_ref()
+        .map(metadata_modified_string)
+        .unwrap_or_else(|_| "unreadable".to_string());
+    tokens.push(format!("parent|ssp|{}|{}", normalized_parent, parent_modified));
+
+    // is_dir(stat) の代わりに file_type()（find-data 参照・syscall ゼロ）で子を絞る
+    let entries = fs::read_dir(&ghost_dir).map_err(|e| format!("read_dir: {e}"))?;
+    let paths: Vec<PathBuf> = entries
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
+        .map(|e| e.path())
+        .collect();
+
+    // 以降は walk_parent と同一（par_iter で fs::metadata + descript stat + build_entry_token）
+    let mut entry_tokens: Vec<String> = paths
+        .par_iter()
+        .filter_map(|path| {
+            let entry_meta = fs::metadata(path).ok()?;
+            let directory_name = path.file_name()?.to_str()?.to_string();
+            let descript_path = path.join("ghost").join("master").join("descript.txt");
+            let (token, _state) = build_entry_token(
+                "ssp",
+                &normalized_parent,
+                &directory_name,
+                &entry_meta,
+                &descript_path,
+            );
+            Some(token)
+        })
+        .collect();
+    tokens.append(&mut entry_tokens);
+
+    Ok(compute_fingerprint_hash(&tokens))
+}

--- a/src-tauri/src/commands/ghost/scan.rs
+++ b/src-tauri/src/commands/ghost/scan.rs
@@ -212,3 +212,24 @@ pub(crate) fn scan_ghosts_with_fingerprint_internal(
 
     Ok((ghosts, compute_fingerprint_hash(&tokens)))
 }
+
+/// フル走査と同じトークンを生成するが Ghost を収集しない（parse を行わない）。
+/// walk 単独コスト（read_dir + stat + トークン生成 + ハッシュ）を parse 抜きで
+/// 計測するためのベンチ専用経路。本番からは呼ばれない。
+#[cfg(feature = "bench")]
+pub(crate) fn fingerprint_only_internal(
+    ssp_path: &str,
+    additional_folders: &[String],
+) -> Result<String, String> {
+    let ghost_dir = Path::new(ssp_path).join("ghost");
+    let mut tokens = vec!["fingerprint-version|1".to_string()];
+
+    walk_parent(&ghost_dir, "ssp", true, &mut tokens, None)?;
+    for (_source, folder_path, normalized_folder) in
+        unique_sorted_additional_folders(additional_folders)
+    {
+        walk_parent(&folder_path, &normalized_folder, false, &mut tokens, None)?;
+    }
+
+    Ok(compute_fingerprint_hash(&tokens))
+}


### PR DESCRIPTION
## Summary

issue #134「全走査スキャンの粒度化」の **Phase 1（計測＝意思決定の計器）**。Phase 2（差分検知＋変更子だけ parse の実装）の設計判断に必要な walk/parse 内訳を実測で確定する。**すべて `#[cfg(feature="bench")]` ゲート下・本番 API/振る舞い/可視性は不変**（CI は `--features bench` をビルドしない）。

- **計測ハーネス拡張**（`bench_support.rs` / `benches/scan_bench.rs`）:
  - `fingerprint_only`（本番 walk を parse 抜きで実行・walk 単独コスト）
  - walk 各 fidelity レベルのコストモデル（`walk_full_2stat_filetype` / `walk_dir_mtime_1stat` / `walk_nameset_0stat`）
  - `rescan_one_change`（「1体変更→再走査」形状・`iter_batched` で Layer1 ミス＋差分1を強制。issue の受け入れ基準）
  - `fingerprint_only_filetype`（`fingerprint_only` と**同一 fingerprint** を返すが逐次 is_dir を `file_type` に置換した判別用。同値をテストで固定）
  - キャッシュ mtime 信頼性テスト（`#[ignore]` 所見）
- **設計・計画・所見 docs**: `docs/superpowers/specs/…-granular-scan-fingerprint-design.md`（マルチパースペクティブレビュー済み設計）、`docs/superpowers/plans/…-granular-scan-phase1-measurement.md`、`docs/perf/granular-scan-spectrum-100k.md`（実測結果）

## 主要な発見（Phase 2 の方針を確定）

- **walk 支配項は逐次 is_dir stat（n=100k で 2.27s・walk の71%）**。集約 fingerprint の生成（token+SHA-256）は約 65ms（2%）に過ぎず、「walk は fingerprint ハッシュ支配」という当初推論を実測で反証。判別は同一 fingerprint を返す `file_type` 版との差で確定。
- **Phase 2 は delta 機構（parse-skip・節約 2.99s）＋ 逐次 is_dir→file_type（節約 2.27s・fidelity 無傷）の両方が必須**。片方では 3.9s で依然多秒フリーズ。両方揃って granular rescan は **~1.05s warm**（現行 6.34s の約6倍）。full fidelity を維持し fidelity 妥協・incremental fingerprint とも不要。
- **Phase 3（非ブロッキング）は「不要」でなく「cold-start 挙動の再計測まで保留」**（Layer1 ミスはセッション開始時 cold で発火しがち・~1.05s は warm 値）。
- キャッシュ mtime 信頼性テスト FAIL → mtime を要する stat は `fs::metadata` 必須、`file_type()` のみ無料。

Phase 2（格納先案A `ghost_scan_entries`・`store_ghosts_delta`・生キー差分・is_dir→file_type 本番適用）と Phase 3 は後続。本 PR は自己完結の計測ハーネス拡張＋設計ドキュメントで、#134 は close しない。

## Test plan

- [x] `npm run build`
- [x] `npm test`（22 files / 176 tests）
- [x] `npm run check:ui-guidelines`（6/6）
- [x] `npm run test:ui-guidelines-check`（pass 6 / fail 0）
- [x] `cargo test --workspace`（feature 無効・本番非影響）
- [x] `cargo test -p ghost-meta --features thumbnail,serde`
- [x] `cargo test --features bench bench_support`（16 passed / 1 ignored＝mtime 所見）
- [x] `cargo bench --features bench --bench scan_bench`（全 shape 実走・数値採取）
- [x] 生成型ドリフトなし（`git status --porcelain src/types/generated/` 空）

🤖 Generated with [Claude Code](https://claude.com/claude-code)