### PR TITLE
feat: 再スキャン中のスキャン中インジケータ（軽量・非確定バー）

### DIFF
--- a/docs/locale-customization.md
+++ b/docs/locale-customization.md
@@ -80,6 +80,7 @@ locales/
 | `content.noSspPath` | SSP 未設定時のメッセージ | — |
 | `content.openSettings` | 設定を開くリンク | — |
 | `list.loading` | ゴーストリスト読み込み中 | — |
+| `list.scanning` | スキャン中インジケータの aria-label | — |
 | `list.empty` | ゴーストが 0 件のときの表示 | — |
 | `list.emptySearch` | 検索で 0 件のときの表示 | `{{query}}` |
 | `list.clearSearch` | 検索0件表示の「検索をクリア」ボタン | — |
@@ -188,6 +189,7 @@ locales/
 | `content.noSspPath` | Message shown when SSP path is not set | — |
 | `content.openSettings` | Open settings link | — |
 | `list.loading` | Ghost list loading state | — |
+| `list.scanning` | Aria-label for scanning indicator | — |
 | `list.empty` | Shown when no ghosts are found | — |
 | `list.emptySearch` | Shown when a search returns no matches | `{{query}}` |
 | `list.clearSearch` | "Clear search" button in the no-match state | — |

--- a/docs/superpowers/plans/2026-07-16-scan-progress-indicator.md
+++ b/docs/superpowers/plans/2026-07-16-scan-progress-indicator.md
@@ -1,0 +1,399 @@
+# スキャン中インジケータ Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 再スキャン中（既に一覧が見えている状態）に「背景で走査中」と分かる軽量な非確定バーを、既存 `loading` 状態のみで表示する。
+
+**Architecture:** ちらつき防止の遅延しきい値ロジックを純フック `useScanIndicator` に隔離し、表示専用の `ScanProgressBar`（Fluent `ProgressBar`）を App が `AppHeader` 直下に差す。可視条件は「`ghostsLoading` かつ既に一覧あり（`hasCachedDisplay`）」。backend・IPC・DB は無変更。
+
+**Tech Stack:** React 19 / TypeScript / Fluent UI v9（`@fluentui/react-components`）/ react-i18next / vitest + @testing-library/react（+ jest-dom matchers・fake timers）。
+
+## Global Constraints
+
+- backend・IPC・Rust・DB は無変更（純フロントエンド）。
+- 一覧は覆わず操作可能なまま（`2868e29` 一覧非破壊化に整合）。
+- バーの出現/消滅で**レイアウトシフトを起こさない**（常に 2px のトラック高を確保）。
+- 初回スキャン（一覧なし）は既存の全画面スピナー（`GhostList.tsx` の `t("list.loading")`）に委ね、二重表示しない。
+- i18n はフラットキー。翻訳リソースは 6 ロケール（`ja` / `en` / `zh-CN` / `zh-TW` / `ko` / `ru`）を必ず揃える。
+- 遅延しきい値は `SCAN_INDICATOR_DELAY_MS = 300`（ms）。
+- テスト: フックは `renderHook`（`src/hooks/*.test.ts`）、コンポーネントは `render`（`src/components/*.test.tsx`）。jest-dom matcher は `src/test/setup.ts` で設定済み。
+- 設計書: `docs/superpowers/specs/2026-07-16-scan-progress-indicator-design.md`。
+
+---
+
+### Task 1: `useScanIndicator` フック（遅延しきい値ロジック）
+
+**Files:**
+- Create: `src/hooks/useScanIndicator.ts`
+- Test: `src/hooks/useScanIndicator.test.ts`
+
+**Interfaces:**
+- Produces: `export const SCAN_INDICATOR_DELAY_MS = 300;` / `export function useScanIndicator(active: boolean): boolean`
+  — `active` が `SCAN_INDICATOR_DELAY_MS` 以上継続したときだけ `true`。`active` が false になった瞬間は即 `false`。
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`src/hooks/useScanIndicator.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useScanIndicator, SCAN_INDICATOR_DELAY_MS } from "./useScanIndicator";
+
+describe("useScanIndicator", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("active が しきい値未満で解除されると一度も true にならない（ちらつき防止）", () => {
+    const { result, rerender } = renderHook(
+      ({ active }: { active: boolean }) => useScanIndicator(active),
+      { initialProps: { active: true } },
+    );
+    act(() => { vi.advanceTimersByTime(SCAN_INDICATOR_DELAY_MS - 1); });
+    expect(result.current).toBe(false);
+    rerender({ active: false });
+    act(() => { vi.advanceTimersByTime(10); });
+    expect(result.current).toBe(false);
+  });
+
+  it("active が しきい値以上継続で true になる", () => {
+    const { result } = renderHook(
+      ({ active }: { active: boolean }) => useScanIndicator(active),
+      { initialProps: { active: true } },
+    );
+    act(() => { vi.advanceTimersByTime(SCAN_INDICATOR_DELAY_MS); });
+    expect(result.current).toBe(true);
+  });
+
+  it("true の後に active=false で即 false に戻る", () => {
+    const { result, rerender } = renderHook(
+      ({ active }: { active: boolean }) => useScanIndicator(active),
+      { initialProps: { active: true } },
+    );
+    act(() => { vi.advanceTimersByTime(SCAN_INDICATOR_DELAY_MS); });
+    expect(result.current).toBe(true);
+    rerender({ active: false });
+    expect(result.current).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: テストを実行し失敗を確認**
+
+Run: `npx vitest run src/hooks/useScanIndicator.test.ts`
+Expected: FAIL（`useScanIndicator` が存在しない＝解決エラー）
+
+- [ ] **Step 3: 最小実装を書く**
+
+`src/hooks/useScanIndicator.ts`:
+
+```ts
+import { useEffect, useState } from "react";
+
+/** スキャン中インジケータを表示し始めるまでの遅延（ちらつき防止）。 */
+export const SCAN_INDICATOR_DELAY_MS = 300;
+
+/**
+ * `active` が SCAN_INDICATOR_DELAY_MS 以上継続したときだけ true を返す。
+ * `active` が false になった瞬間は即 false（保留中タイマーは解除）。
+ * Layer 1 ヒットや warm な瞬間再スキャンでバーが点滅するのを防ぐ。
+ */
+export function useScanIndicator(active: boolean): boolean {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (!active) {
+      setVisible(false);
+      return;
+    }
+    const timer = setTimeout(() => setVisible(true), SCAN_INDICATOR_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, [active]);
+
+  return visible;
+}
+```
+
+- [ ] **Step 4: テストを実行し成功を確認**
+
+Run: `npx vitest run src/hooks/useScanIndicator.test.ts`
+Expected: PASS（3 tests）
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/hooks/useScanIndicator.ts src/hooks/useScanIndicator.test.ts
+git commit -m "feat: スキャン中インジケータの遅延しきい値フック useScanIndicator"
+```
+
+---
+
+### Task 2: `ScanProgressBar` コンポーネント（表示専用）
+
+**Files:**
+- Create: `src/components/ScanProgressBar.tsx`
+- Test: `src/components/ScanProgressBar.test.tsx`
+
+**Interfaces:**
+- Consumes: `t("list.scanning")`（Task 3 で全ロケールへ追加。本タスクのテストは `t` をキー返しスタブでモックするため未追加でも通る）
+- Produces: `export function ScanProgressBar(props: { visible: boolean }): JSX.Element`
+  — 常に 2px トラック（`data-testid="scan-progress-track"`）を描画し、`visible` のとき内側に Fluent `ProgressBar`（非確定・`aria-label`）を描画。
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`src/components/ScanProgressBar.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ScanProgressBar } from "./ScanProgressBar";
+
+// t はキーをそのまま返すスタブ（App.test と同方針）
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe("ScanProgressBar", () => {
+  it("visible=true で progressbar を aria-label 付きで描画する", () => {
+    render(<ScanProgressBar visible={true} />);
+    const bar = screen.getByRole("progressbar");
+    expect(bar).toBeInTheDocument();
+    expect(bar).toHaveAttribute("aria-label", "list.scanning");
+  });
+
+  it("visible=false ではトラックのみで progressbar を描画しない（レイアウトシフト回避）", () => {
+    render(<ScanProgressBar visible={false} />);
+    expect(screen.queryByRole("progressbar")).toBeNull();
+    expect(screen.getByTestId("scan-progress-track")).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: テストを実行し失敗を確認**
+
+Run: `npx vitest run src/components/ScanProgressBar.test.tsx`
+Expected: FAIL（`ScanProgressBar` が存在しない）
+
+- [ ] **Step 3: 最小実装を書く**
+
+`src/components/ScanProgressBar.tsx`:
+
+```tsx
+import { useTranslation } from "react-i18next";
+import { ProgressBar, makeStyles } from "@fluentui/react-components";
+
+interface Props {
+  visible: boolean;
+}
+
+const useStyles = makeStyles({
+  // レイアウトシフト回避: 常に 2px のトラック高を確保し、idle 時は空（透明）にする
+  track: {
+    height: "2px",
+  },
+});
+
+/**
+ * 再スキャン中の非確定インジケータ（AppHeader 直下の細いバー）。表示専用。
+ * value を渡さないため Fluent ProgressBar は非確定（indeterminate）として描画される。
+ * visible=false でも 2px のトラックを保持し、出現/消滅でレイアウトが揺れないようにする。
+ */
+export function ScanProgressBar({ visible }: Props) {
+  const styles = useStyles();
+  const { t } = useTranslation();
+  return (
+    <div className={styles.track} data-testid="scan-progress-track">
+      {visible && <ProgressBar aria-label={t("list.scanning")} />}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: テストを実行し成功を確認**
+
+Run: `npx vitest run src/components/ScanProgressBar.test.tsx`
+Expected: PASS（2 tests）
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/components/ScanProgressBar.tsx src/components/ScanProgressBar.test.tsx
+git commit -m "feat: 非確定スキャンバー ScanProgressBar（表示専用・レイアウトシフト回避）"
+```
+
+---
+
+### Task 3: i18n キー `list.scanning` を 6 ロケールへ追加 ＋ ドキュメント同期
+
+**Files:**
+- Modify: `src/locales/ja.json` / `src/locales/en.json` / `src/locales/zh-CN.json` / `src/locales/zh-TW.json` / `src/locales/ko.json` / `src/locales/ru.json`
+- Modify: `docs/locale-customization.md`（キー一覧の同期）
+- Test: `src/lib/i18n.test.ts`（各ロケールで `list.scanning` が引けることを追加）
+
+**Interfaces:**
+- Produces: 全ロケールで `t("list.scanning")` が非空文字列を返す。
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`src/lib/i18n.test.ts` の `describe("i18n", …)` 内、`it("list.count の補間が…")` の直後に追加:
+
+```ts
+  it.each([
+    ["ja",    "スキャン中..."],
+    ["en",    "Scanning..."],
+    ["zh-CN", "扫描中..."],
+    ["zh-TW", "掃描中..."],
+    ["ko",    "스캔 중..."],
+    ["ru",    "Сканирование..."],
+  ])("%s で list.scanning が返る", async (lang, expected) => {
+    await i18n.changeLanguage(lang);
+    expect(i18n.t("list.scanning")).toBe(expected);
+  });
+```
+
+- [ ] **Step 2: テストを実行し失敗を確認**
+
+Run: `npx vitest run src/lib/i18n.test.ts`
+Expected: FAIL（`list.scanning` が各ロケールで未定義＝キーがそのまま返り期待値と不一致）
+
+- [ ] **Step 3: 各ロケールにキーを追加**
+
+各 `src/locales/<lang>.json` で、既存の `"list.loading": …,` 行の直後に以下を 1 行追加する（フラットキー・末尾カンマに注意）:
+
+- `ja.json`: `"list.scanning": "スキャン中...",`
+- `en.json`: `"list.scanning": "Scanning...",`
+- `zh-CN.json`: `"list.scanning": "扫描中...",`
+- `zh-TW.json`: `"list.scanning": "掃描中...",`
+- `ko.json`: `"list.scanning": "스캔 중...",`
+- `ru.json`: `"list.scanning": "Сканирование...",`
+
+- [ ] **Step 4: テストを実行し成功を確認**
+
+Run: `npx vitest run src/lib/i18n.test.ts`
+Expected: PASS（`list.scanning` の 6 ケース含む）
+
+- [ ] **Step 5: ドキュメント同期**
+
+`docs/locale-customization.md` のキー一覧（翻訳キーの表/リスト）に `list.scanning`（用途: スキャン中インジケータの aria-label）を追加する。既存の `list.*` キーが列挙されている箇所に合わせて 1 行加える。
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/locales/ja.json src/locales/en.json src/locales/zh-CN.json src/locales/zh-TW.json src/locales/ko.json src/locales/ru.json src/lib/i18n.test.ts docs/locale-customization.md
+git commit -m "feat: i18n キー list.scanning を 6 ロケールへ追加（スキャンバー aria 用）"
+```
+
+---
+
+### Task 4: `App.tsx` へ結線 ＋ 統合テスト ＋ 検証
+
+**Files:**
+- Modify: `src/App.tsx`（import 追加・`showScanBar` 導出・JSX に `<ScanProgressBar/>` 挿入）
+- Test: `src/App.test.tsx`（loading×一覧あり→300ms後にバー表示 / 初回（一覧なし）→非表示）
+
+**Interfaces:**
+- Consumes: `useScanIndicator`（Task 1）・`ScanProgressBar`（Task 2）・既存 `App.tsx` の `ghostsLoading`・`hasCachedDisplay`（`App.tsx:162`）。
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`src/App.test.tsx` の import に `screen` を追加（`import { render, act, screen } from "@testing-library/react";`）。ファイル末尾（最後の `describe` の後）に追加:
+
+```tsx
+describe("App - スキャン中インジケータ（再スキャン時のみ）", () => {
+  it("再スキャン中（loading かつ 一覧あり）は 300ms 後に scan バーを表示する", () => {
+    vi.useFakeTimers();
+    try {
+      mocks.ghostsState = { loading: true, error: null, refresh: () => {} };
+      mocks.searchState = {
+        ghosts: [makeGhost("Reimu")],
+        total: 1,
+        loadedStart: 0,
+        loading: false,
+        dbError: null,
+      };
+      render(<App />);
+      // 300ms 未満は出ない（ちらつき防止）
+      expect(screen.queryByRole("progressbar")).toBeNull();
+      act(() => { vi.advanceTimersByTime(300); });
+      expect(screen.getByRole("progressbar")).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("初回スキャン（一覧なし）では scan バーを出さない（全画面スピナーに委ねる）", () => {
+    vi.useFakeTimers();
+    try {
+      mocks.ghostsState = { loading: true, error: null, refresh: () => {} };
+      mocks.searchState = { ghosts: [], total: 0, loadedStart: 0, loading: false, dbError: null };
+      render(<App />);
+      act(() => { vi.advanceTimersByTime(300); });
+      expect(screen.queryByRole("progressbar")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+```
+
+- [ ] **Step 2: テストを実行し失敗を確認**
+
+Run: `npx vitest run src/App.test.tsx`
+Expected: FAIL（`ScanProgressBar` 未結線＝progressbar が見つからない）
+
+- [ ] **Step 3: App.tsx に結線する**
+
+`src/App.tsx` の import ブロック（`import { GhostContent } …` 付近）に追加:
+
+```tsx
+import { useScanIndicator } from "./hooks/useScanIndicator";
+import { ScanProgressBar } from "./components/ScanProgressBar";
+```
+
+`const scanError = hasCachedDisplay ? null : error;`（`App.tsx:163`）の直後、`if (settingsLoading) {` の**前**に追加（フックは早期 return より前で呼ぶ）:
+
+```tsx
+  // 再スキャン中（既に一覧が見えている状態）のみ非確定バーを出す。初回（一覧なし）は
+  // 全画面スピナー（GhostList）に委ねるため hasCachedDisplay で排他にする。
+  const showScanBar = useScanIndicator(ghostsLoading && hasCachedDisplay);
+```
+
+JSX の `<AppHeader … />` と `<GhostContent … />` の間（`App.tsx:181` 直後）に挿入:
+
+```tsx
+        <ScanProgressBar visible={showScanBar} />
+```
+
+- [ ] **Step 4: テストを実行し成功を確認**
+
+Run: `npx vitest run src/App.test.tsx`
+Expected: PASS（追加 2 tests 含め全 App テスト）
+
+- [ ] **Step 5: 全体検証**
+
+```bash
+npm test
+npm run build
+npm run check:ui-guidelines
+npm run test:ui-guidelines-check
+```
+Expected: すべて成功（新規テスト含む）。
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/App.tsx src/App.test.tsx
+git commit -m "feat: 再スキャン中に非確定スキャンバーを表示（App 結線）"
+```
+
+- [ ] **Step 7: 手動検証（/verify 推奨・任意）**
+
+`npm run tauri dev` で起動し、一覧表示後に「再読込」またはフォルダ追加で再スキャンを発火し、cold・大量フォルダで上部バーが現れること、warm な瞬間再スキャンでは点滅しないこと、一覧が覆われず操作できることを目視確認する。UI ガイドライン準拠は `ux-reviewer` サブエージェントで確認してもよい。
+
+---
+
+## Self-Review
+
+- **Spec coverage**: §3 上部バー→Task 2/4、§4 コンポーネント（useScanIndicator/ScanProgressBar/App 結線）→Task 1/2/4、§5 可視条件＋しきい値→Task 1/4、§6 レイアウトシフト回避（2px トラック）→Task 2、§7 a11y（aria-label・aria-busy なし）＋i18n（6 ロケール）→Task 2/3、§8 テスト→各タスク。カバー漏れなし。
+- **Placeholder scan**: 「適切に」等の曖昧表現なし。全ステップに実コード/実コマンド。
+- **Type consistency**: `useScanIndicator(active: boolean): boolean`（Task 1）と App の `useScanIndicator(ghostsLoading && hasCachedDisplay)`（Task 4）一致。`ScanProgressBar({ visible })`（Task 2）と `<ScanProgressBar visible={showScanBar} />`（Task 4）一致。`SCAN_INDICATOR_DELAY_MS=300` と App テストの `advanceTimersByTime(300)` 一致。`list.scanning`（Task 2 aria / Task 3 定義）一致。

--- a/docs/superpowers/specs/2026-07-16-scan-progress-indicator-design.md
+++ b/docs/superpowers/specs/2026-07-16-scan-progress-indicator-design.md
@@ -1,0 +1,89 @@
+# 設計書: スキャン中インジケータ（軽量・非確定・上部バー）
+
+- 日付: 2026-07-16
+- 関連: issue #134 Phase 3（非ブロッキング化）の軽量版。フル進捗（streaming/イベント）は本設計の非スコープ。
+- 種別: フロントエンドのみ（Rust・IPC・DB は無変更）
+
+## 1. 問題
+
+`scan_and_store`（再スキャン）の実行中、**既に一覧が表示されている状態**ではユーザーへの可視フィードバックが無い。
+現状の loading 表現は 2 つだけ:
+
+- **初回スキャン（キャッシュ空）**: `GhostList.tsx:145` が `(loading || searchLoading) && total===0 && ghosts.length===0` のとき
+  全画面スピナー（`t("list.loading")`）を出す。→ カバー済み。
+- **再スキャン（一覧あり）**: reload・フォルダ追加・設定変更後。`useGhosts` の `loading=true` だが、上記スピナー条件を
+  満たさず何も描かれない。可視の変化は `AppHeader` の refresh ボタンが `disabled` になるのみ（`AppHeader.tsx:61`）。
+
+warm 再スキャンは delta 化（PR #143）で ~1.40s に短縮されたが、cold cache・大量フォルダでは数秒に達しうる。
+その間「固まった？」と誤解させる体感の穴が実在する。
+
+## 2. スコープ / 非スコープ
+
+- **スコープ**: 再スキャン中に「背景で走査中」と分かる**非確定（indeterminate）**の軽量インジケータ。既存の `loading`
+  状態のみを用い、backend は無変更。一覧は覆わず操作可能なまま（`2868e29`「一覧非破壊化」に整合）。
+- **非スコープ**: 進捗（X/N 体）の確定表示。Rust→JS のイベント配信（channel＋ts-rs 型）と IPC 拡張を要するため
+  issue #134 Phase 3 本体として別途扱う。初回スキャンの全画面スピナー（既存・変更しない）。
+
+## 3. 採用アプローチ
+
+**AppHeader 直下に 2px の非確定 ProgressBar（Fluent `ProgressBar`・value 省略）** を、再スキャン中のみ表示する。
+VS Code 風の「背景作業中」表現で、主張は最小限。テーマ追従のブランド色。
+
+代替案と不採用理由:
+- ツールバーの小 Spinner: 視線の先だが、ツールバー行のレイアウトに影響しやすい。バーの方が非侵襲。
+- ヘッダーの状態文字: 文言 i18n が増え、タイトル周辺が賑やかになる。
+- 一覧オーバーレイ: 一覧非破壊化の思想に反する。
+
+## 4. コンポーネント構成（SRP）
+
+- **`useScanIndicator(active: boolean): boolean`**（`src/hooks/`）— ちらつき防止の遅延しきい値ロジックを隔離。
+  `active` が **`SCAN_INDICATOR_DELAY_MS`（=300ms）以上継続したときだけ** `true` を返す。`active` が false に
+  なった瞬間は即 `false`（保留中タイマーは解除）。純ロジックで fake timers によりテスト可能。
+- **`ScanProgressBar`（`src/components/`）** — `visible: boolean` を受け、2px の非確定 `ProgressBar` を描画/非描画する
+  だけの表示専用コンポーネント。可視判定・しきい値は持たない。
+- **`App.tsx`** — 既に持つ `ghostsLoading` と `hasCachedDisplay`（`App.tsx:162` の再利用）から
+  `const showScanBar = useScanIndicator(ghostsLoading && hasCachedDisplay);` を導出し、`<AppHeader/>` と
+  `<GhostContent/>` の間に `<ScanProgressBar visible={showScanBar} />` を差す。
+
+依存関係: `ScanProgressBar` は Fluent の `ProgressBar` のみに依存。`useScanIndicator` は React（timers）のみ。App が両者を配線。
+
+## 5. 表示ロジック
+
+- **可視条件（active）**: `ghostsLoading === true` かつ `hasCachedDisplay === true`（＝一覧が既に見えている再スキャン）。
+  初回（`total===0 && ghosts.length===0`）は `hasCachedDisplay` が false のためバーは出ず、既存の全画面スピナーに委ねる
+  （二重表示しない・排他が構造的に保証される）。
+- **遅延しきい値（ちらつき防止）**: `useScanIndicator` が active の 300ms 継続を待ってから可視化する。Layer 1 ヒット
+  （~1ms）や warm な瞬間再スキャンではバーは一切現れず、cold・大量フォルダの数秒スキャンでのみ現れる。
+- **消滅**: active が false になれば即時に非表示（最小表示時間は設けない。数秒スキャンでのみ出るため点滅しない）。
+
+## 6. レイアウト（シフト回避）
+
+バーの出現/消滅で一覧が縦に揺れないよう、**レイアウトシフトを起こさない**配置とする。具体策（実装計画で確定）:
+常に 2px のトラック高を確保し idle 時は背景を透明にする、または AppHeader の `borderBottom` 直下にトラックを重ねる。
+いずれも「出た瞬間に下の一覧が 2px 下がる」現象を避けることを要件とする。
+
+## 7. アクセシビリティ / i18n
+
+- バーに `aria-label={t("list.scanning")}`。Fluent `ProgressBar` は `role="progressbar"` を付与する。value 省略で
+  非確定（`aria-valuenow` なし）。
+- 一覧は非ブロッキングのため `aria-busy` は**付けない**（操作を妨げないことを明示）。
+- i18n: フラットキー `list.scanning`（例: 日本語「スキャン中...」）を 6 ロケール（ja/en/zh-CN/zh-TW/ko/ru）へ追加。
+  バー自体はテキストを表示しない（aria 専用）。`docs/locale-customization.md` のキー一覧も同期。既存 `list.loading` は
+  初回スピナーが使用中のため流用しない。
+
+## 8. テスト方針
+
+- **`useScanIndicator`**（`src/hooks/useScanIndicator.test.ts`・`renderHook` + fake timers）:
+  - active=true が 300ms 未満で false に戻ると一度も true にならない（ちらつき防止）。
+  - active=true が 300ms 継続で true になる。
+  - true の後 active=false で即 false。
+- **`ScanProgressBar`**（`src/components/ScanProgressBar.test.tsx`・`render`）: `visible=true` で `role="progressbar"` が
+  存在し `aria-label` が付く／`visible=false` で描画されない（またはトラックのみで progressbar が無い）。
+- 既存回帰: 初回スピナー（`GhostList`）とバーが排他であること（`hasCachedDisplay` による）を既存テストで担保、
+  必要なら App レベルの結線テストを追加。
+
+## 9. 検証
+
+`npm test`・`npm run build`・`npm run check:ui-guidelines`・`npm run test:ui-guidelines-check`。新規 UI のため
+UI ガイドライン（`docs/ui-guidelines.md`）準拠を `ux-reviewer` で確認。backend 無変更のため Rust テスト・
+生成型は不変（`/ipc-check` は非該当）。

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, act } from "@testing-library/react";
+import { render, act, screen } from "@testing-library/react";
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({ t: (key: string) => key }),
@@ -192,5 +192,41 @@ describe("App - ランダム起動のフィードバック（トースト・一�
 
     expect(mocks.launcherToasts.notifyWarning).toHaveBeenCalledWith("header.randomLaunch.empty");
     expect(mocks.launchGhostSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("App - スキャン中インジケータ（再スキャン時のみ）", () => {
+  it("再スキャン中（loading かつ 一覧あり）は 300ms 後に scan バーを表示する", () => {
+    vi.useFakeTimers();
+    try {
+      mocks.ghostsState = { loading: true, error: null, refresh: () => {} };
+      mocks.searchState = {
+        ghosts: [makeGhost("Reimu")],
+        total: 1,
+        loadedStart: 0,
+        loading: false,
+        dbError: null,
+      };
+      render(<App />);
+      // 300ms 未満は出ない（ちらつき防止）
+      expect(screen.queryByRole("progressbar")).toBeNull();
+      act(() => { vi.advanceTimersByTime(300); });
+      expect(screen.getByRole("progressbar")).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("初回スキャン（一覧なし）では scan バーを出さない（全画面スピナーに委ねる）", () => {
+    vi.useFakeTimers();
+    try {
+      mocks.ghostsState = { loading: true, error: null, refresh: () => {} };
+      mocks.searchState = { ghosts: [], total: 0, loadedStart: 0, loading: false, dbError: null };
+      render(<App />);
+      act(() => { vi.advanceTimersByTime(300); });
+      expect(screen.queryByRole("progressbar")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,8 +18,10 @@ import { useSearch } from "./hooks/useSearch";
 import { useAppShellState } from "./hooks/useAppShellState";
 import { useLauncherToasts } from "./hooks/useLauncherToasts";
 import { useGhostLauncher } from "./hooks/useGhostLauncher";
+import { useScanIndicator } from "./hooks/useScanIndicator";
 import { AppHeader } from "./components/AppHeader";
 import { GhostContent } from "./components/GhostContent";
+import { ScanProgressBar } from "./components/ScanProgressBar";
 import { SettingsPanel } from "./components/SettingsPanel";
 import { requestKeyFromSettings, formatErrorDetail } from "./lib/ghostScanUtils";
 import { getRandomGhost, reseedRandomSort } from "./lib/ghostDatabase";
@@ -162,6 +164,10 @@ function App() {
   const hasCachedDisplay = searchResultGhosts.length > 0 || searchTotal > 0;
   const scanError = hasCachedDisplay ? null : error;
 
+  // 再スキャン中（既に一覧が見えている状態）のみ非確定バーを出す。初回（一覧なし）は
+  // 全画面スピナー（GhostList）に委ねるため hasCachedDisplay で排他にする。
+  const showScanBar = useScanIndicator(ghostsLoading && hasCachedDisplay);
+
   if (settingsLoading) {
     return (
       <div className={styles.loading}>
@@ -179,6 +185,7 @@ function App() {
           onRefresh={handleRefresh}
           onOpenSettings={handleOpenSettings}
         />
+        <ScanProgressBar visible={showScanBar} />
         <GhostContent
           ghosts={searchResultGhosts}
           total={searchTotal}

--- a/src/components/ScanProgressBar.test.tsx
+++ b/src/components/ScanProgressBar.test.tsx
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ScanProgressBar } from "./ScanProgressBar";
+
+// t はキーをそのまま返すスタブ（App.test と同方針）
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe("ScanProgressBar", () => {
+  it("visible=true で progressbar を aria-label 付きで描画する", () => {
+    render(<ScanProgressBar visible={true} />);
+    const bar = screen.getByRole("progressbar");
+    expect(bar).toBeInTheDocument();
+    expect(bar).toHaveAttribute("aria-label", "list.scanning");
+  });
+
+  it("visible=false ではトラックのみで progressbar を描画しない（レイアウトシフト回避）", () => {
+    render(<ScanProgressBar visible={false} />);
+    expect(screen.queryByRole("progressbar")).toBeNull();
+    expect(screen.getByTestId("scan-progress-track")).toBeInTheDocument();
+  });
+});

--- a/src/components/ScanProgressBar.tsx
+++ b/src/components/ScanProgressBar.tsx
@@ -1,0 +1,28 @@
+import { useTranslation } from "react-i18next";
+import { ProgressBar, makeStyles } from "@fluentui/react-components";
+
+interface Props {
+  visible: boolean;
+}
+
+const useStyles = makeStyles({
+  // レイアウトシフト回避: 常に 2px のトラック高を確保し、idle 時は空（透明）にする
+  track: {
+    height: "2px",
+  },
+});
+
+/**
+ * 再スキャン中の非確定インジケータ（AppHeader 直下の細いバー）。表示専用。
+ * value を渡さないため Fluent ProgressBar は非確定（indeterminate）として描画される。
+ * visible=false でも 2px のトラックを保持し、出現/消滅でレイアウトが揺れないようにする。
+ */
+export function ScanProgressBar({ visible }: Props) {
+  const styles = useStyles();
+  const { t } = useTranslation();
+  return (
+    <div className={styles.track} data-testid="scan-progress-track">
+      {visible && <ProgressBar aria-label={t("list.scanning")} />}
+    </div>
+  );
+}

--- a/src/hooks/useScanIndicator.test.ts
+++ b/src/hooks/useScanIndicator.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useScanIndicator, SCAN_INDICATOR_DELAY_MS } from "./useScanIndicator";
+
+describe("useScanIndicator", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("active が しきい値未満で解除されると一度も true にならない（ちらつき防止）", () => {
+    const { result, rerender } = renderHook(
+      ({ active }: { active: boolean }) => useScanIndicator(active),
+      { initialProps: { active: true } },
+    );
+    act(() => { vi.advanceTimersByTime(SCAN_INDICATOR_DELAY_MS - 1); });
+    expect(result.current).toBe(false);
+    rerender({ active: false });
+    act(() => { vi.advanceTimersByTime(10); });
+    expect(result.current).toBe(false);
+  });
+
+  it("active が しきい値以上継続で true になる", () => {
+    const { result } = renderHook(
+      ({ active }: { active: boolean }) => useScanIndicator(active),
+      { initialProps: { active: true } },
+    );
+    act(() => { vi.advanceTimersByTime(SCAN_INDICATOR_DELAY_MS); });
+    expect(result.current).toBe(true);
+  });
+
+  it("true の後に active=false で即 false に戻る", () => {
+    const { result, rerender } = renderHook(
+      ({ active }: { active: boolean }) => useScanIndicator(active),
+      { initialProps: { active: true } },
+    );
+    act(() => { vi.advanceTimersByTime(SCAN_INDICATOR_DELAY_MS); });
+    expect(result.current).toBe(true);
+    rerender({ active: false });
+    expect(result.current).toBe(false);
+  });
+});

--- a/src/hooks/useScanIndicator.ts
+++ b/src/hooks/useScanIndicator.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from "react";
+
+/** スキャン中インジケータを表示し始めるまでの遅延（ちらつき防止）。 */
+export const SCAN_INDICATOR_DELAY_MS = 300;
+
+/**
+ * `active` が SCAN_INDICATOR_DELAY_MS 以上継続したときだけ true を返す。
+ * `active` が false になった瞬間は即 false（保留中タイマーは解除）。
+ * Layer 1 ヒットや warm な瞬間再スキャンでバーが点滅するのを防ぐ。
+ */
+export function useScanIndicator(active: boolean): boolean {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (!active) {
+      setVisible(false);
+      return;
+    }
+    const timer = setTimeout(() => setVisible(true), SCAN_INDICATOR_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, [active]);
+
+  return visible;
+}

--- a/src/lib/i18n.test.ts
+++ b/src/lib/i18n.test.ts
@@ -53,6 +53,18 @@ describe("i18n", () => {
     expect(i18n.t("list.count", { count: 5 })).toBe("5 ghosts");
   });
 
+  it.each([
+    ["ja",    "スキャン中..."],
+    ["en",    "Scanning..."],
+    ["zh-CN", "扫描中..."],
+    ["zh-TW", "掃描中..."],
+    ["ko",    "스캔 중..."],
+    ["ru",    "Сканирование..."],
+  ])("%s で list.scanning が返る", async (lang, expected) => {
+    await i18n.changeLanguage(lang);
+    expect(i18n.t("list.scanning")).toBe(expected);
+  });
+
   it("card.launchError の補間が正しく動作する", async () => {
     await i18n.changeLanguage("ja");
     const msg = i18n.t("card.launchError", { detail: " (error)" });

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -29,6 +29,7 @@
   "content.noSspPath": "Please select an SSP folder",
   "content.openSettings": "Open settings",
   "list.loading": "Loading...",
+  "list.scanning": "Scanning...",
   "list.empty": "No ghosts found",
   "list.emptySearch": "No ghosts match \"{{query}}\"",
   "list.clearSearch": "Clear search",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -29,6 +29,7 @@
   "content.noSspPath": "SSPフォルダを選択してください",
   "content.openSettings": "設定を開く",
   "list.loading": "読み込み中...",
+  "list.scanning": "スキャン中...",
   "list.empty": "ゴーストが見つかりません",
   "list.emptySearch": "「{{query}}」に一致するゴーストがありません",
   "list.clearSearch": "検索をクリア",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -29,6 +29,7 @@
   "content.noSspPath": "SSP 폴더를 선택해주세요",
   "content.openSettings": "설정 열기",
   "list.loading": "로드 중...",
+  "list.scanning": "스캔 중...",
   "list.empty": "고스트를 찾을 수 없습니다",
   "list.emptySearch": "'{{query}}' 검색 결과가 없습니다",
   "list.clearSearch": "검색 지우기",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -29,6 +29,7 @@
   "content.noSspPath": "Пожалуйста, выберите папку SSP",
   "content.openSettings": "Открыть настройки",
   "list.loading": "Загрузка...",
+  "list.scanning": "Сканирование...",
   "list.empty": "Духи не найдены",
   "list.emptySearch": "Нет духов по запросу «{{query}}»",
   "list.clearSearch": "Очистить поиск",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -29,6 +29,7 @@
   "content.noSspPath": "请选择SSP文件夹",
   "content.openSettings": "打开设置",
   "list.loading": "加载中...",
+  "list.scanning": "扫描中...",
   "list.empty": "未找到幽灵",
   "list.emptySearch": "未找到与「{{query}}」匹配的幽灵",
   "list.clearSearch": "清除搜索",

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -29,6 +29,7 @@
   "content.noSspPath": "請選擇SSP資料夾",
   "content.openSettings": "開啟設定",
   "list.loading": "載入中...",
+  "list.scanning": "掃描中...",
   "list.empty": "找不到幽靈",
   "list.emptySearch": "找不到與「{{query}}」相符的幽靈",
   "list.clearSearch": "清除搜尋",


### PR DESCRIPTION
## Summary

再スキャン中（既に一覧が見えている状態）に可視フィードバックが無い穴を、既存 `loading` 状態のみで埋める軽量な非確定バー。純フロントエンド（backend・IPC・Rust・DB 無変更・生成型不変）。issue #134 Phase 3（非ブロッキング化）の軽量版で、フル進捗（X/N 体・Rust streaming）は非スコープ。

- **穴**: 初回スキャン（キャッシュ空）は既に全画面スピナーが出るが、reload・フォルダ追加・設定変更後の**再スキャン**は `loading=true` でも何も描かれず、`AppHeader` の refresh ボタンが `disabled` になるのみ。cold・大量フォルダでは数秒フリーズしたように見える。
- **対処**: `AppHeader` 直下に 2px の非確定 Fluent `ProgressBar`。VS Code 風の「背景作業中」表示で主張は最小限。一覧は覆わず操作可能なまま（`2868e29`「一覧非破壊化」に整合）。

## 設計

- **`useScanIndicator(active)`**: ちらつき防止の遅延しきい値（`SCAN_INDICATOR_DELAY_MS = 300`）。`active` が 300ms 以上継続したときだけ true、false になった瞬間は即 false。Layer 1 ヒットや warm な瞬間再スキャンではバーを一切出さず、cold・大量フォルダの数秒スキャンでのみ現れる。
- **`ScanProgressBar({ visible })`**: 表示専用。常に 2px のトラックを確保し、出現/消滅でレイアウトが揺れない（構造的にシフトゼロ）。
- **可視条件 `ghostsLoading && hasCachedDisplay`**: 再スキャン時のみ。初回（一覧なし）は全画面スピナー（`GhostList`）に委ね、`hasCachedDisplay` の論理否定で**構造的に排他**（二重表示なし）。
- **i18n**: `list.scanning` を 6 ロケール（ja/en/zh-CN/zh-TW/ko/ru）へ追加＋`docs/locale-customization.md` 同期。aria-label 専用（バー自体はテキストなし・非ブロッキングゆえ `aria-busy` は付けない）。

設計書 `docs/superpowers/specs/2026-07-16-scan-progress-indicator-design.md`・実装計画 `docs/superpowers/plans/2026-07-16-scan-progress-indicator.md`。

## 実装・レビュー

Subagent 駆動開発で 4 タスクを TDD 実装（useScanIndicator → ScanProgressBar → i18n → App 結線）。タスクごとに spec 準拠＋コード品質のレビューを通し、最後にブランチ全体レビュー（最上位モデル）を実施。debounce の正しさ・スピナー/バーの厳密な排他（論理否定）・レイアウトシフト皆無・実コラボレータでの統合テストを確認し、**Ready to merge: Yes**（Critical/Important ゼロ）。

## Test plan

- [x] `npm test`（189 passed・24 files。内訳: useScanIndicator 3 / ScanProgressBar 2 / i18n `list.scanning` 6 / App 統合 2）
- [x] `npm run build`
- [x] `npm run check:ui-guidelines` / `npm run test:ui-guidelines-check`
- [x] 生成型 `src/types/generated/` 不変（IPC 無変更）
- [ ] 手動 E2E（`npm run tauri dev` で一覧表示後に再スキャンを発火し上部バーを目視。デスクトップ実行環境が無いため未実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
