### PR TITLE
chore: #146 フォローアップ（clippy ガード拡張・テスト補強・設計書注記）

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -2,3 +2,11 @@
 [[disallowed-methods]]
 path = "rusqlite::Connection::open"
 reason = "ghosts.db/user-data.db の接続は actor::bootstrap と spawn_actor 経由のみ。テストは #[allow(clippy::disallowed_methods)] を付ける"
+
+[[disallowed-methods]]
+path = "rusqlite::Connection::open_with_flags"
+reason = "同上（actor 経由のみ）"
+
+[[disallowed-methods]]
+path = "rusqlite::Connection::open_with_flags_and_vfs"
+reason = "同上（actor 経由のみ）"

--- a/docs/superpowers/specs/2026-07-16-ghost-db-actor-design.md
+++ b/docs/superpowers/specs/2026-07-16-ghost-db-actor-design.md
@@ -249,6 +249,8 @@ fn ensure_cache_schema(conn: &rusqlite::Connection) -> Result<(), String> {
   - 旧 migration 合成との一致（§8 の二段構え）
   - user_version 不一致 → リビルド／一致 → データ保持
   - **リビルド実行中の並行 reader が「no such table」を観測しない**（単一 tx の検証）
+    ※実装検証は省略: `ensure_cache_schema` は webview ロード前にしか走らず並行 reader が
+    構造的に存在しないため（単一 tx は防御的保証に留まる・issue #148）
   - **legacy 移送 → リビルドの順序**: 旧世代 DB（migration 11 相当＋履歴あり）からの
     起動シーケンスで、リビルド後も user-data.db に履歴が残る（issue #93 回帰ガードの拡張。
     現行 `アップグレードとリセットを通じて…` テストを新方式へ改修）

--- a/src-tauri/src/actor/mod.rs
+++ b/src-tauri/src/actor/mod.rs
@@ -229,10 +229,12 @@ mod tests {
     use crate::testutil::TempDirGuard;
 
     /// 一時ファイル上に (ghosts, user-data) を初期化してアクターを起動する。
+    /// ghosts には identity "sspg" の行を seed する（record_launch の集計列 bump 観測用）。
     fn spawn_test_actor(dir: &TempDirGuard) -> ActorHandle {
         let ghosts = rusqlite::Connection::open(dir.path().join("ghosts.db")).unwrap();
         crate::commands::ghost::store::configure_connection(&ghosts).unwrap();
         crate::testutil::apply_cache_schema(&ghosts);
+        crate::testutil::insert_ghost_row(&ghosts, "sspg");
         let user = rusqlite::Connection::open(dir.path().join("user-data.db")).unwrap();
         crate::commands::launch_history::ensure_schema(&user).unwrap();
         spawn_actor(ghosts, user)
@@ -257,6 +259,12 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM ghost_launches WHERE ghost_identity_key='sspg'", [], |r| r.get(0))
             .unwrap();
         assert_eq!(n, 1);
+        // ghosts 側の集計列 bump も観測する（テスト名「両db」の約束を実態と一致させる）
+        let ghosts = rusqlite::Connection::open(dir.path().join("ghosts.db")).unwrap();
+        let count: i64 = ghosts
+            .query_row("SELECT launch_count FROM ghosts WHERE ghost_identity_key='sspg'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1, "ghosts.db 側の launch_count が bump されているはず");
     }
 
     #[test]
@@ -288,6 +296,7 @@ mod tests {
 
     /// scan_and_store_blocking 相当の実ジョブを 2 本並行送信しても、単一 writer により
     /// 最終状態が「後勝ちの 1 状態」に収束する（旧 scan_lock配下の並行delta テストの後継）。
+    /// 旧テストと違い同期バリアは不要: 単一消費者キューでは interleaving が構造的に不可能なため。
     #[test]
     fn 並行scanジョブが直列化され整合状態に収束する() {
         use std::fs;

--- a/src-tauri/src/commands/launch_history.rs
+++ b/src-tauri/src/commands/launch_history.rs
@@ -119,15 +119,12 @@ pub async fn record_launch(
 #[allow(clippy::disallowed_methods)]
 mod tests {
     use super::*;
+    use crate::testutil::insert_ghost_row;
 
     fn ghosts_conn_with_row(identity_key: &str) -> Connection {
         let conn = Connection::open_in_memory().unwrap();
         crate::testutil::apply_cache_schema(&conn);
-        conn.execute(
-            "INSERT INTO ghosts (request_key, ghost_identity_key, row_fingerprint, name, sakura_name, kero_name, craftman, craftmanw, directory_name, path, source, name_lower, sakura_name_lower, kero_name_lower, craftman_lower, craftmanw_lower, directory_name_lower, thumbnail_path, thumbnail_use_self_alpha, thumbnail_kind, updated_at) VALUES ('rk1', ?1, '', 'G', '', '', '', '', 'g', '/g', 'ssp', 'g', '', '', '', '', 'g', '', 0, '', '')",
-            rusqlite::params![identity_key],
-        )
-        .unwrap();
+        insert_ghost_row(&conn, identity_key);
         conn
     }
 
@@ -239,14 +236,6 @@ mod tests {
             .collect();
         assert!(cols.contains(&"ghost_identity_key".to_string()));
         assert!(cols.contains(&"launched_at".to_string()));
-    }
-
-    fn insert_ghost_row(conn: &Connection, identity_key: &str) {
-        conn.execute(
-            "INSERT INTO ghosts (request_key, ghost_identity_key, row_fingerprint, name, sakura_name, kero_name, craftman, craftmanw, directory_name, path, source, name_lower, sakura_name_lower, kero_name_lower, craftman_lower, craftmanw_lower, directory_name_lower, thumbnail_path, thumbnail_use_self_alpha, thumbnail_kind, updated_at) VALUES ('rk1', ?1, '', 'G', '', '', '', '', 'g', '/g', 'ssp', 'g', '', '', '', '', 'g', '', 0, '', '')",
-            rusqlite::params![identity_key],
-        )
-        .unwrap();
     }
 
     // 旧世代（migration 1..=11 の ghosts.db・履歴同居）からのアップグレードで、

--- a/src-tauri/src/testutil.rs
+++ b/src-tauri/src/testutil.rs
@@ -5,6 +5,15 @@ pub(crate) fn apply_cache_schema(conn: &rusqlite::Connection) {
         .unwrap_or_else(|e| panic!("cache schema の適用に失敗: {e}"));
 }
 
+/// ghosts テーブルへ最小構成の 1 行を seed する（集計列 bump 観測などのテスト用）。
+pub(crate) fn insert_ghost_row(conn: &rusqlite::Connection, identity_key: &str) {
+    conn.execute(
+        "INSERT INTO ghosts (request_key, ghost_identity_key, row_fingerprint, name, sakura_name, kero_name, craftman, craftmanw, directory_name, path, source, name_lower, sakura_name_lower, kero_name_lower, craftman_lower, craftmanw_lower, directory_name_lower, thumbnail_path, thumbnail_use_self_alpha, thumbnail_kind, updated_at) VALUES ('rk1', ?1, '', 'G', '', '', '', '', 'g', '/g', 'ssp', 'g', '', '', '', '', 'g', '', 0, '', '')",
+        rusqlite::params![identity_key],
+    )
+    .unwrap();
+}
+
 /// テスト用の一時ディレクトリ。Drop 時に自動削除される。
 pub(crate) struct TempDirGuard {
     path: std::path::PathBuf,


### PR DESCRIPTION
Closes #148

## Summary
- `clippy.toml` の `disallowed-methods` に `Connection::open_with_flags` / `open_with_flags_and_vfs` を追加し、設計書 §2.3「writer 混入の構造的封鎖」の抜け道を閉じた（違反プローブを一時挿入し lint が捕捉することを検証済み）
- actor の `record_launchジョブが両dbへ書き込み応答を返す` テストに ghosts.db 側 `launch_count` bump の assert を追加し、テスト名の約束と観測範囲を一致させた。seed 用 INSERT が 3 箇所目の重複となったため `testutil::insert_ghost_row` へ抽出（既存 2 箇所も置換）
- 並行 scan テストに「単一消費者キューでは interleaving が構造的に不可能なため同期バリア不要」の意図コメントを追記
- 設計書 §9 の並行 reader 項に「構造的に reader 不在のため実装検証は省略（単一 tx は防御的保証）」を注記し spec と実装の乖離を解消

## Test plan
- [x] `npm run build`
- [x] `npm test`（174 件）
- [x] `npm run check:ui-guidelines` / `npm run test:ui-guidelines-check`
- [x] `cargo test --workspace`（97 件）
- [x] `cargo test -p ghost-meta --features thumbnail,serde`
- [x] `cargo clippy --all-targets -- -A clippy::all -D clippy::disallowed-methods`（clean・違反プローブ挿入時は fail することも確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)