### PR TITLE
test: E2E の tauri-driver ポートを harness ごとに一意化し ECONNRESET flake を解消

### DIFF
--- a/e2e/helpers/harness.ts
+++ b/e2e/helpers/harness.ts
@@ -12,7 +12,20 @@ export type Harness = {
   tauriDriver: ChildProcessWithoutNullStreams;
 };
 
-const WD_SERVER = "http://127.0.0.1:4444/";
+// tauri-driver の --port/--native-port は既定 4444/4445 の固定値。全テストで共有すると、
+// Windows では kill() が子プロセス（msedgedriver）を道連れにしないため、前テストの
+// 孤児 msedgedriver に次テストが相乗りし、孤児の遅延死で ECONNRESET になる（issue #153）。
+// harness ごとに空きポートを取得して干渉を断つ。
+async function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.listen(0, "127.0.0.1", () => {
+      const { port } = srv.address() as net.AddressInfo;
+      srv.close(() => resolve(port));
+    });
+    srv.once("error", reject);
+  });
+}
 
 async function fileExists(targetPath: string): Promise<boolean> {
   try {
@@ -58,7 +71,7 @@ async function waitForPort(port: number, timeoutMs: number): Promise<void> {
   throw new Error(`Timed out waiting for port ${port}`);
 }
 
-async function spawnTauriDriver(): Promise<ChildProcessWithoutNullStreams> {
+async function spawnTauriDriver(port: number, nativePort: number): Promise<ChildProcessWithoutNullStreams> {
   const tauriDriverPath = getTauriDriverPath();
   if (!(await fileExists(tauriDriverPath))) {
     throw new Error(
@@ -74,17 +87,19 @@ async function spawnTauriDriver(): Promise<ChildProcessWithoutNullStreams> {
     ? path.join(os.tmpdir(), `edgedriver-${pinnedVersion}`)
     : undefined;
   const nativeDriverPath = await downloadEdgeDriver(pinnedVersion, cacheDir);
-  const proc = spawn(tauriDriverPath, ["--native-driver", nativeDriverPath], {
-    stdio: "pipe",
-  });
+  const proc = spawn(
+    tauriDriverPath,
+    ["--native-driver", nativeDriverPath, "--port", String(port), "--native-port", String(nativePort)],
+    { stdio: "pipe" },
+  );
   proc.on("error", () => {
     // ポートタイムアウトまたはセッション作成エラーで処理
   });
-  await waitForPort(4444, 12_000);
+  await waitForPort(port, 12_000);
   return proc;
 }
 
-async function createWebDriverSession(): Promise<WebDriver> {
+async function createWebDriverSession(port: number): Promise<WebDriver> {
   const appBinary = getAppBinaryPath();
   if (!(await fileExists(appBinary))) {
     throw new Error(
@@ -93,7 +108,7 @@ async function createWebDriverSession(): Promise<WebDriver> {
   }
 
   return new Builder()
-    .usingServer(WD_SERVER)
+    .usingServer(`http://127.0.0.1:${port}/`)
     .withCapabilities({
       browserName: "wry",
       "tauri:options": {
@@ -107,8 +122,10 @@ export async function createHarness(): Promise<Harness> {
   let tauriDriver: ChildProcessWithoutNullStreams | undefined;
   let driver: WebDriver | undefined;
   try {
-    tauriDriver = await spawnTauriDriver();
-    driver = await createWebDriverSession();
+    const port = await getFreePort();
+    const nativePort = await getFreePort();
+    tauriDriver = await spawnTauriDriver(port, nativePort);
+    driver = await createWebDriverSession(port);
     return { driver, tauriDriver };
   } catch (e) {
     if (driver) {


### PR DESCRIPTION
Closes #153

## Summary

- **根本原因**: tauri-driver の `--port`/`--native-port` は既定 4444/4445 の固定値で全テストが共有していた。Windows の `kill()` は子プロセス（msedgedriver）を道連れにしないため、前テストの孤児 msedgedriver がポート 4445 を握ったまま残り、次テストの tauri-driver がそれに相乗り → 孤児の遅延死の瞬間に実行中のテストが `ECONNRESET` で落ちる（失敗テストのローテートは「孤児の死とどのテストが重なるか」のくじ引き）
- **証拠**: harness に一時診断ログを入れて再現させ、前テスト cleanup（SIGTERM）の約 190ms 後に現行テストの tauri-driver が上流断（os error 10054 → 10061 connection refused）を吐くことを実測。tauri-driver 自体のクラッシュは無し（exit はすべて正常 kill の SIGTERM のみ）
- **修正**: harness 生成ごとに `net` の listen(0) で空きポートを 2 つ取得し、`--port`/`--native-port` へ明示指定してテスト間干渉を構造的に断つ

## Test plan

- [x] 修正前ベースライン: 全体実行 5/5 回で 1〜2 件が ECONNRESET 失敗（対象はローテート・単独再実行は pass）
- [x] 修正後: 全体実行 **4 連続で 10 passed / 1 skipped**（正常水準）・tauri-driver エラーログゼロ
- [x] `npm run build` / `npm test`（174 件）/ UI ガイドライン 2 種
- [x] `cargo test --workspace`（97 件）/ ghost-meta features / clippy writer ガード
- [x] 生成型 porcelain clean
- 間欠 flake のため決定的 Red テストは書けず、統計的再現（5/5 失敗 → 4/4 クリーン）を検証とする

🤖 Generated with [Claude Code](https://claude.com/claude-code)