### PR TITLE
test: bench ハーネスを CI ガード下に置き SELECT_COLS を fixture 連動化（Phase 0）

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -40,6 +40,8 @@ cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -A clippy::al
 
 グループ A とグループ B は互いに独立しているため並列実行してよい（グループ B 内は target ディレクトリのロック競合を避けるため順次）。
 
+> **CI のみのゲート（意図的非対称）**: bench ハーネス系（`cargo check --features bench --benches`・`cargo test --features bench --lib bench_support`）は CI 専用で、本チェックリストには含めない（bench コードの変更頻度が低く、毎コミットのローカル実行コストに見合わないため）。bench 関連ファイルを変更したときのみ手動で実行する。
+
 ### 追加の確認事項
 
 - **新規テストファイルを追加した場合**: `ci-build.yml` で実行されるか・`tsconfig.json` の `exclude` に追加が必要か・`vitest.config.ts` の `include` が検出するかを確認する

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -57,5 +57,11 @@ jobs:
       - name: Test ghost-meta with optional features
         run: cargo test -p ghost-meta --features thumbnail,serde
 
+      - name: Check bench harness compiles (signature drift guard)
+        run: cargo check --manifest-path src-tauri/Cargo.toml --features bench --benches
+
+      - name: Test bench_support guards
+        run: cargo test --manifest-path src-tauri/Cargo.toml --features bench --lib bench_support
+
       - name: Clippy (writer 混入ガード)
         run: cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -A clippy::all -D clippy::disallowed-methods

--- a/src-tauri/benches/search_bench.rs
+++ b/src-tauri/benches/search_bench.rs
@@ -4,17 +4,13 @@ use std::time::Duration;
 
 use criterion::{BenchmarkId, Criterion};
 use ghost_launcher_lib::bench_support::{
-    open_bench_db, order_by, search_where_prefixed, seed_ghosts_db, Q_COMMON, Q_NONE, Q_RARE,
+    open_bench_db, order_by, search_where_prefixed, seed_ghosts_db, select_cols_prefixed,
+    Q_COMMON, Q_NONE, Q_RARE,
 };
 use rusqlite::Connection;
 
 const RK: &str = "bench-rk";
 const LIMIT: i64 = 50;
-// 本番 GHOST_SELECT_COLUMNS_PREFIXED と同じ 18 列（materialize コストを再現）
-const SELECT_COLS: &str = "g.name, g.sakura_name, g.kero_name, g.craftman, g.craftmanw, \
-    g.directory_name, g.path, g.source, g.name_lower, g.sakura_name_lower, g.kero_name_lower, \
-    g.craftman_lower, g.craftmanw_lower, g.directory_name_lower, g.thumbnail_path, \
-    g.thumbnail_use_self_alpha, g.thumbnail_kind, g.ghost_identity_key";
 
 /// seed 済み一時 DB を本番読み取り PRAGMA で開き直して返す（seed 接続の書き込み PRAGMA を継がない）。
 /// tag は N ごとに一意化してディレクトリ名衝突を避ける。
@@ -41,15 +37,17 @@ fn run_select<P: rusqlite::Params>(conn: &Connection, sql: &str, params: P) -> u
 
 fn dump_query_plans() {
     let (_g, conn) = seeded_readonly_db("plan", 1000);
+    // 本番 GHOST_SELECT_COLUMNS_PREFIXED と同形の投影（fixture 連動・materialize コストを再現）
+    let select_cols = select_cols_prefixed();
     let where_c = search_where_prefixed();
     // EXPLAIN QUERY PLAN は未束縛 ? を嫌うため、リテラル値で組む（プランは値非依存で SCAN/index が判る）。
     let where_lit = where_c.replace("LIKE ?", "LIKE '%さくら%'");
     let shapes: Vec<(&str, String)> = vec![
-        ("empty+name", format!("SELECT {SELECT_COLS} FROM ghosts g WHERE g.request_key='{RK}' ORDER BY {} LIMIT 50", order_by("name"))),
-        ("like+name", format!("SELECT {SELECT_COLS} FROM ghosts g WHERE g.request_key='{RK}' AND ({where_lit}) ORDER BY {} LIMIT 50", order_by("name"))),
-        ("empty+recent", format!("SELECT {SELECT_COLS} FROM ghosts g WHERE g.request_key='{RK}' ORDER BY {} LIMIT 50", order_by("recent"))),
-        ("empty+frequency", format!("SELECT {SELECT_COLS} FROM ghosts g WHERE g.request_key='{RK}' ORDER BY {} LIMIT 50", order_by("frequency"))),
-        ("empty+random", format!("SELECT {SELECT_COLS} FROM ghosts g WHERE g.request_key='{RK}' ORDER BY {} LIMIT 50", order_by("random"))),
+        ("empty+name", format!("SELECT {select_cols} FROM ghosts g WHERE g.request_key='{RK}' ORDER BY {} LIMIT 50", order_by("name"))),
+        ("like+name", format!("SELECT {select_cols} FROM ghosts g WHERE g.request_key='{RK}' AND ({where_lit}) ORDER BY {} LIMIT 50", order_by("name"))),
+        ("empty+recent", format!("SELECT {select_cols} FROM ghosts g WHERE g.request_key='{RK}' ORDER BY {} LIMIT 50", order_by("recent"))),
+        ("empty+frequency", format!("SELECT {select_cols} FROM ghosts g WHERE g.request_key='{RK}' ORDER BY {} LIMIT 50", order_by("frequency"))),
+        ("empty+random", format!("SELECT {select_cols} FROM ghosts g WHERE g.request_key='{RK}' ORDER BY {} LIMIT 50", order_by("random"))),
     ];
     println!("\n===== EXPLAIN QUERY PLAN (n=1000) =====");
     for (label, sql) in shapes {
@@ -66,6 +64,8 @@ fn dump_query_plans() {
 }
 
 fn bench_search(c: &mut Criterion) {
+    // 本番 GHOST_SELECT_COLUMNS_PREFIXED と同形の投影（fixture 連動・materialize コストを再現）
+    let select_cols = select_cols_prefixed();
     let where_c = search_where_prefixed();
     // COUNT は本番 countGhostsByQuery と同形（前置きなし 6 列 OR）
     let count_where = where_c.replace("g.", "");
@@ -83,7 +83,7 @@ fn bench_search(c: &mut Criterion) {
         // 空クエリ × 各ソート（無名 ? 統一。params: [rk, limit]）
         for sort in ["name", "recent", "frequency", "random"] {
             let sql = format!(
-                "SELECT {SELECT_COLS} FROM ghosts g WHERE g.request_key=? ORDER BY {} LIMIT ?",
+                "SELECT {select_cols} FROM ghosts g WHERE g.request_key=? ORDER BY {} LIMIT ?",
                 order_by(sort)
             );
             group.bench_with_input(BenchmarkId::new("empty_sort", sort), &sql, |b, sql| {
@@ -94,7 +94,7 @@ fn bench_search(c: &mut Criterion) {
         // LIKE 選択率 3 種（sort=name 固定。params: [rk, like×6, limit]）
         for (label, like) in [("none", &like_none), ("rare", &like_rare), ("common", &like_common)] {
             let sql = format!(
-                "SELECT {SELECT_COLS} FROM ghosts g WHERE g.request_key=? AND ({where_c}) \
+                "SELECT {select_cols} FROM ghosts g WHERE g.request_key=? AND ({where_c}) \
                  ORDER BY {} LIMIT ?",
                 order_by("name")
             );
@@ -112,7 +112,7 @@ fn bench_search(c: &mut Criterion) {
         // OFFSET 深度（空クエリ・sort=name。params: [rk, limit, offset]）
         for (label, offset) in [("0", 0i64), ("mid", (n as i64) / 2), ("deep", (n as i64 - LIMIT).max(0))] {
             let sql = format!(
-                "SELECT {SELECT_COLS} FROM ghosts g WHERE g.request_key=? ORDER BY {} LIMIT ? OFFSET ?",
+                "SELECT {select_cols} FROM ghosts g WHERE g.request_key=? ORDER BY {} LIMIT ? OFFSET ?",
                 order_by("name")
             );
             group.bench_with_input(BenchmarkId::new("offset", label), &offset, |b, &offset| {
@@ -127,7 +127,7 @@ fn bench_search(c: &mut Criterion) {
         );
         // select は g. 前置き（本番 searchGhosts）、params: [rk, like×6, limit]
         let select_sql = format!(
-            "SELECT {SELECT_COLS} FROM ghosts g WHERE g.request_key=? AND ({where_c}) \
+            "SELECT {select_cols} FROM ghosts g WHERE g.request_key=? AND ({where_c}) \
              ORDER BY {} LIMIT ?",
             order_by("name")
         );

--- a/src-tauri/src/bench_support.rs
+++ b/src-tauri/src/bench_support.rs
@@ -141,6 +141,16 @@ pub const SEARCH_LOWER_COLUMNS: [&str; 6] = [
     "directory_name_lower",
 ];
 
+/// searchGhosts と同形の SELECT 投影（g. 前置き）。列の単一権威は共有 fixture
+/// ghost-view-columns.json（本番 GHOST_VIEW_COLUMNS・DB スキーマと機械照合済み）。
+/// include_str! で取り込むため、fixture の列増減は再コンパイルで自動追従する。
+pub fn select_cols_prefixed() -> String {
+    const RAW: &str = include_str!("../../src/test/fixtures/ghost-view-columns.json");
+    let cols: Vec<String> =
+        serde_json::from_str(RAW).expect("ghost-view-columns.json をパースできること");
+    cols.iter().map(|c| format!("g.{c}")).collect::<Vec<_>>().join(", ")
+}
+
 /// searchGhosts と同形の WHERE（g. 前置き・6 列 OR）。
 pub fn search_where_prefixed() -> String {
     SEARCH_LOWER_COLUMNS
@@ -445,6 +455,19 @@ mod tests {
             order_by("frequency"),
             v["orderBy"]["frequency"].as_str().unwrap()
         );
+    }
+
+    #[test]
+    fn select_cols_prefixed_が実スキーマに対して有効な投影を返す() {
+        let cols = select_cols_prefixed();
+        assert!(cols.starts_with("g."), "g. 前置きの投影であること");
+
+        // 導出列が現行スキーマに実在することを prepare で機械検証する
+        // （fixture ↔ スキーマの照合は本番側テストが担うが、bench 側でも SELECT が通ることを縛る）
+        let tmp = TempDirGuard::new("bench_select_cols");
+        let conn = open_bench_db(&tmp.path().join("ghosts.db")).unwrap();
+        conn.prepare(&format!("SELECT {cols} FROM ghosts g LIMIT 0"))
+            .expect("fixture 由来の全列が ghosts スキーマに存在すること");
     }
 
     #[test]


### PR DESCRIPTION
読み経路性能設計書（`docs/superpowers/specs/2026-07-17-read-path-performance-design.md`・PR #157）の Phase 0。

Closes #138
Closes #139

## Summary

- **#139**: `search_bench.rs` の手書き 18 列 `SELECT_COLS` リテラルを廃し、`bench_support::select_cols_prefixed()`（共有 fixture `ghost-view-columns.json` を `include_str!` で導出）へ置換。既存の `sql形状が共有fixtureと一致する` と同じ「共有 fixture 照合」パターンの投影版で、`GhostView` の列増減に再コンパイルで自動追従する
- **#138**: CI に 2 ステップ追加——`cargo check --features bench --benches`（signature ドリフト検出）・`cargo test --features bench --lib bench_support`（形状パリティ等のガード実行・数秒）。`cargo bench` 実走は設計どおり入れない
- `/commit` チェックリストへ「bench 系ゲートは CI 専用」の意図的非対称を明記（機構/規範の区別）

## Test plan

- [x] TDD: 新ガードテストの Red（関数未定義でコンパイル失敗）→ Green を確認
- [x] プローブ検証: fixture へ偽列注入 → ガードテスト FAIL / bench_support 関数改名 → `cargo check --benches` が E0432 で失敗（いずれも revert 済み）
- [x] `cargo test --features bench --lib bench_support`（17 passed）・`cargo check --features bench --benches`
- [x] `npm run build` / `npm test`（174 件）/ UI ガイドライン 2 種
- [x] `cargo test --workspace`（97 件）/ ghost-meta features / clippy writer ガード / 生成型 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)