### PR TITLE
perf: 検索のクエリ発行規律を導入し COUNT 増幅を解消（epic #140 Phase 1）

### DIFF
--- a/docs/perf/baseline-100k.md
+++ b/docs/perf/baseline-100k.md
@@ -64,6 +64,13 @@ cargo bench --manifest-path src-tauri/Cargo.toml --features bench --bench scan_b
 
 **like/rare と like/common の逆転について（フィクスチャ由来・一般化不可）**: n=100k で `like/rare`（42.186 ms）が `like/common`（68.390 ms）より速いという、素朴な「マッチ率が高いほど早期終了で速い」という予測に反する結果が出た。原因は `bench_support.rs::synth_ghost` の合成データ生成ロジックにある。`Q_RARE`（`craftman='作者777'`、`i % 1000 == 777`）にマッチする行は必ず `i` が奇数かつ `i % 5 == 2` になるため、名前が例外なく `en[2]="Ghost"` 由来の `"Ghost{i}"` になる。この "Ghost" プレフィックスは ASCII のため `name_lower` 順で非常に早い位置に集まり、`ORDER BY name_lower LIMIT 50` が早期に 50 件へ到達する。一方 `Q_COMMON`（`name` が `"さくら…"`、`i % 10 == 0`）はソートキーである `name_lower` 自身が一致条件のため、集団は "さくら" の Unicode 位置（全角カタカナ・漢字圏内、他の日本語プレフィックスの中間あたり）まで走査が進んでから初めて見つかる。この逆転は **合成データにおける「マッチ列と並び替え列の相関」というフィクスチャ固有の副作用であり、一般化できる知見ではない**（実データでは craftman と name は独立なので、この逆転は起きない見込み）。一般化できる知見は次の一点のみ: **先頭ワイルドカード LIKE は index 最適化されず、`request_key` の絞り込み以降は行ごとの残余フィルタになる**（`like/none` が index 経路の 3662 倍という事実。詳細は後述の所見を参照）。
 
+### Phase 1 検収記録（select-only ページフェッチ形状）
+
+- 計測日: 2026-07-17（epic #140 Phase 1・クエリ発行規律）
+- **実行環境が上記ベースラインと異なる**（AMD Ryzen 7 8840U / Windows 11 Home / 約 24 GB）ため、本節の絶対値を上表と比較してはならない。意味を持つのは**同一実行内のペア差**のみ
+- n=100k・common クエリのレイテンシ中央値: `count_plus_select_common` 214.16 ms / `select_only_common` 162.37 ms → **ペア差 ≈ 52 ms（約 24%）**
+- 解釈: Phase 1 で COUNT の発行はリセット時（requestKey/query/sort/epoch 変更）の 1 回に限定され、スクロールのページ送りは select-only になった。従来ページ毎に払っていた COUNT 分（このペア差）が消える
+
 ## FS 走査層（scan_bench）
 
 | 形状 | n=1k | n=10k | n=100k(indicative) |

--- a/src-tauri/benches/search_bench.rs
+++ b/src-tauri/benches/search_bench.rs
@@ -145,6 +145,19 @@ fn bench_search(c: &mut Criterion) {
             });
         });
 
+        // Phase 1 検収: COUNT 併走を外した select-only ページフェッチ。
+        // count_plus_select_common との差が「スクロール毎に消えた COUNT 増幅」に相当する
+        group.bench_function("select_only_common", |b| {
+            b.iter(|| {
+                let lc = &like_common;
+                run_select(
+                    &conn,
+                    &select_sql,
+                    rusqlite::params![RK, lc, lc, lc, lc, lc, lc, LIMIT],
+                );
+            });
+        });
+
         group.finish();
     }
 }

--- a/src/hooks/useSearch.test.ts
+++ b/src/hooks/useSearch.test.ts
@@ -64,8 +64,7 @@ describe("useSearch", () => {
   it("offset 変更時はバッファをマージする", async () => {
     vi.mocked(searchGhostsInitialPage).mockResolvedValueOnce([reimu]);
     vi.mocked(countGhostsByQuery).mockResolvedValueOnce(2);
-    vi.mocked(searchGhosts)
-      .mockResolvedValueOnce({ ghosts: [marisa], total: 2 });
+    vi.mocked(searchGhosts).mockResolvedValueOnce([marisa]);
 
     const { result, rerender } = renderHook(
       ({ offset }) => useSearch("rk1", "", 1, offset, 1),
@@ -94,8 +93,7 @@ describe("useSearch", () => {
   it("隣接ウィンドウのマージ: 重複部分は上書きされ旧データが保持される", async () => {
     vi.mocked(searchGhostsInitialPage).mockResolvedValueOnce([reimu, marisa]);
     vi.mocked(countGhostsByQuery).mockResolvedValueOnce(3);
-    vi.mocked(searchGhosts)
-      .mockResolvedValueOnce({ ghosts: [marisa, alice], total: 3 });
+    vi.mocked(searchGhosts).mockResolvedValueOnce([marisa, alice]);
 
     const { result, rerender } = renderHook(
       ({ offset }) => useSearch("rk1", "", 2, offset, 1),
@@ -122,9 +120,8 @@ describe("useSearch", () => {
 
   it("query 変更時はバッファがクリアされる", async () => {
     vi.mocked(searchGhostsInitialPage).mockResolvedValueOnce([reimu, marisa]);
-    vi.mocked(countGhostsByQuery).mockResolvedValueOnce(2);
-    vi.mocked(searchGhosts)
-      .mockResolvedValueOnce({ ghosts: [marisa], total: 1 });
+    vi.mocked(countGhostsByQuery).mockResolvedValueOnce(2).mockResolvedValueOnce(1);
+    vi.mocked(searchGhosts).mockResolvedValueOnce([marisa]);
 
     const { result, rerender } = renderHook(
       ({ query }) => useSearch("rk1", query, 100, 0, 1),
@@ -180,8 +177,7 @@ describe("useSearch", () => {
   it("バッファサイズ上限超過時は全置換にフォールバックする", async () => {
     vi.mocked(searchGhostsInitialPage).mockResolvedValueOnce([reimu]);
     vi.mocked(countGhostsByQuery).mockResolvedValueOnce(50000);
-    vi.mocked(searchGhosts)
-      .mockResolvedValueOnce({ ghosts: [marisa], total: 50000 });
+    vi.mocked(searchGhosts).mockResolvedValueOnce([marisa]);
 
     const farOffset = MAX_BUFFER_SIZE + 100;
 
@@ -262,10 +258,41 @@ describe("useSearch", () => {
     expect(searchGhostsInitialPage).toHaveBeenCalledWith("rk1", 100, "name");
   });
 
-  it("sortEpoch の変化で全置換リフェッチが走る（マージ分岐に旧シードのバッファが混ざらない）", async () => {
+  it("スクロールによる offset 変更時は COUNT が発行されない（リセット時の 1 回のみ）", async () => {
+    vi.mocked(countGhostsByQuery).mockResolvedValueOnce(10);
     vi.mocked(searchGhosts)
-      .mockResolvedValueOnce({ ghosts: [reimu, marisa], total: 5 })
-      .mockResolvedValueOnce({ ghosts: [alice], total: 5 });
+      .mockResolvedValueOnce([reimu])
+      .mockResolvedValueOnce([marisa]);
+
+    const { result, rerender } = renderHook(
+      ({ offset }) => useSearch("rk1", "ki", 1, offset, 1),
+      { initialProps: { offset: 0 } }
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+      expect(result.current.ghosts).toHaveLength(1);
+    });
+    expect(countGhostsByQuery).toHaveBeenCalledTimes(1);
+    expect(result.current.total).toBe(10);
+
+    rerender({ offset: 1 });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+      expect(result.current.ghosts).toHaveLength(2);
+    });
+
+    // ページ送りでは COUNT が再発行されず、total はリセット時の値を保持する
+    expect(countGhostsByQuery).toHaveBeenCalledTimes(1);
+    expect(result.current.total).toBe(10);
+  });
+
+  it("sortEpoch の変化で全置換リフェッチが走る（マージ分岐に旧シードのバッファが混ざらない）", async () => {
+    vi.mocked(countGhostsByQuery).mockResolvedValueOnce(5).mockResolvedValueOnce(5);
+    vi.mocked(searchGhosts)
+      .mockResolvedValueOnce([reimu, marisa])
+      .mockResolvedValueOnce([alice]);
 
     const { result, rerender } = renderHook(
       ({ sortEpoch }) => useSearch("rk1", "ki", 2, 3, 1, "random", sortEpoch),

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -73,45 +73,50 @@ export function useSearch(
           return;
         }
 
-        const result = await searchGhosts(requestKey, query, limit, offset, sortOrder);
+        // COUNT はリセット時のみ発行する（total が変わるのはコンテキスト変更時だけ。
+        // スクロールのページ送りで再発行しない）。SELECT と並行して待ち時間を重ねない
+        const [pageGhosts, newTotal] = await Promise.all([
+          searchGhosts(requestKey, query, limit, offset, sortOrder),
+          isReset ? countGhostsByQuery(requestKey, query) : Promise.resolve(null),
+        ]);
         if (!isActive) return;
 
         resetKeyRef.current = resetKey;
 
         if (isReset) {
           // コンテキスト変更 → バッファクリアして全置換
-          setGhosts(result.ghosts);
+          setGhosts(pageGhosts);
           setLoadedStart(offset);
-          bufferRef.current = { ghosts: result.ghosts, start: offset };
+          bufferRef.current = { ghosts: pageGhosts, start: offset };
+          setTotal(newTotal ?? 0);
         } else {
-          // スクロールによる offset 変更 → マージ
+          // スクロールによる offset 変更 → マージ（total はリセット時の値を保持）
           const prev = bufferRef.current;
           const prevEnd = prev.start + prev.ghosts.length;
-          const newEnd = offset + result.ghosts.length;
+          const newEnd = offset + pageGhosts.length;
           const hasOverlap = offset <= prevEnd && newEnd >= prev.start;
           const mergedStart = Math.min(prev.start, offset);
           const mergedEnd = Math.max(prevEnd, newEnd);
 
           if (!hasOverlap || mergedEnd - mergedStart > MAX_BUFFER_SIZE) {
             // ギャップあり or バッファ上限超過 → 全置換
-            setGhosts(result.ghosts);
+            setGhosts(pageGhosts);
             setLoadedStart(offset);
-            bufferRef.current = { ghosts: result.ghosts, start: offset };
+            bufferRef.current = { ghosts: pageGhosts, start: offset };
           } else {
             // 隣接/重複 → マージ
             const merged = new Array<GhostView>(mergedEnd - mergedStart);
             for (let i = 0; i < prev.ghosts.length; i++) {
               merged[prev.start - mergedStart + i] = prev.ghosts[i];
             }
-            for (let i = 0; i < result.ghosts.length; i++) {
-              merged[offset - mergedStart + i] = result.ghosts[i];
+            for (let i = 0; i < pageGhosts.length; i++) {
+              merged[offset - mergedStart + i] = pageGhosts[i];
             }
             setGhosts(merged);
             setLoadedStart(mergedStart);
             bufferRef.current = { ghosts: merged, start: mergedStart };
           }
         }
-        setTotal(result.total);
       } catch (err) {
         console.error("Failed to search ghosts from SQLite:", err);
         if (isActive) {

--- a/src/lib/ghostDatabase.test.ts
+++ b/src/lib/ghostDatabase.test.ts
@@ -15,6 +15,14 @@ vi.mock("@tauri-apps/plugin-sql", () => ({
   },
 }));
 
+// reportDbSize は getDb 内から fire-and-forget で select（PRAGMA page_count 等）を
+// 発行し、mockSelect の呼び出し順・mockResolvedValueOnce のキューを汚染するため
+// パススルーでモックする（measureSearch は計測せず fn を素通しする）
+vi.mock("./dbMonitor", () => ({
+  measureSearch: <T,>(_label: string, fn: () => Promise<T>) => fn(),
+  reportDbSize: vi.fn().mockResolvedValue(undefined),
+}));
+
 beforeEach(() => {
   vi.resetModules();
   mockExecute.mockClear();
@@ -81,14 +89,87 @@ describe("ghostDatabase - getDb", () => {
 
 describe("ghostDatabase - searchGhosts NFKC正規化", () => {
   it("全角英字クエリを NFKC 正規化してから小文字化した LIKE パターンで検索する", async () => {
-    mockSelect.mockResolvedValue([{ count: 0 }]);
+    mockSelect.mockResolvedValue([]);
     const { searchGhosts } = await import("./ghostDatabase");
     await searchGhosts("rk1", "Ａｌｉｃｅ", 50, 0);
 
+    const selectCall = mockSelect.mock.calls.find((c) =>
+      (c[0] as string).includes("LIKE"));
+    expect(selectCall).toBeDefined();
+    expect(selectCall![1][1]).toBe("%alice%");
+  });
+});
+
+describe("ghostDatabase - searchGhosts クエリ発行規律", () => {
+  it("COUNT を発行しない（総件数の取得はリセット時に useSearch が countGhostsByQuery で行う）", async () => {
+    mockSelect.mockResolvedValue([]);
+    const { searchGhosts } = await import("./ghostDatabase");
+    const rows = await searchGhosts("rk1", "Ａｌｉｃｅ", 50, 0);
+
+    expect(rows).toEqual([]);
     const countCall = mockSelect.mock.calls.find((c) =>
-      (c[0] as string).includes("COUNT(*)"));
-    expect(countCall).toBeDefined();
-    expect(countCall![1][1]).toBe("%alice%");
+      (c[0] as string).includes("COUNT"));
+    expect(countCall).toBeUndefined();
+  });
+
+  it("空クエリ時は LIKE なしの SQL でページを取得する", async () => {
+    mockSelect.mockResolvedValue([]);
+    const { searchGhosts } = await import("./ghostDatabase");
+    await searchGhosts("rk1", "", 50, 100);
+
+    expect(mockSelect).toHaveBeenCalledTimes(1);
+    const [sql, params] = mockSelect.mock.calls[0] as [string, unknown[]];
+    expect(sql).not.toContain("LIKE");
+    expect(sql).toContain("WHERE g.request_key = ?");
+    expect(sql).toContain("OFFSET");
+    expect(params).toEqual(["rk1", 50, 100]);
+  });
+});
+
+describe("ghostDatabase - hasGhosts", () => {
+  it("EXISTS で 1 行観測する（COUNT 全数を発行しない）", async () => {
+    mockSelect.mockResolvedValue([{ has: 1 }]);
+    const { hasGhosts } = await import("./ghostDatabase");
+    const result = await hasGhosts("rk1");
+
+    expect(result).toBe(true);
+    const [sql, params] = mockSelect.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain("EXISTS");
+    expect(sql).not.toContain("COUNT");
+    expect(params).toEqual(["rk1"]);
+  });
+
+  it("該当行がなければ false を返す", async () => {
+    mockSelect.mockResolvedValue([{ has: 0 }]);
+    const { hasGhosts } = await import("./ghostDatabase");
+    expect(await hasGhosts("rk-missing")).toBe(false);
+  });
+});
+
+describe("ghostDatabase - getRandomGhost", () => {
+  it("ORDER BY RANDOM() を使わず COUNT + 乱数 OFFSET で 1 体選ぶ", async () => {
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.5);
+    mockSelect
+      .mockResolvedValueOnce([{ count: 5 }])
+      .mockResolvedValueOnce([{ name: "Reimu" }]);
+    const { getRandomGhost } = await import("./ghostDatabase");
+    const ghost = await getRandomGhost("rk1");
+
+    expect(ghost).toEqual({ name: "Reimu" });
+    const [selectSql, selectParams] = mockSelect.mock.calls[1] as [string, unknown[]];
+    expect(selectSql).not.toContain("RANDOM()");
+    expect(selectSql).toContain("LIMIT 1 OFFSET ?");
+    expect(selectParams).toEqual(["rk1", 2]); // floor(0.5 * 5) = 2
+    randomSpy.mockRestore();
+  });
+
+  it("0 件時は SELECT を発行せず null を返す", async () => {
+    mockSelect.mockResolvedValueOnce([{ count: 0 }]);
+    const { getRandomGhost } = await import("./ghostDatabase");
+    const ghost = await getRandomGhost("rk-empty");
+
+    expect(ghost).toBeNull();
+    expect(mockSelect).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/lib/ghostDatabase.ts
+++ b/src/lib/ghostDatabase.ts
@@ -67,12 +67,12 @@ export async function getCachedFingerprint(requestKey: string): Promise<string |
 
 export async function hasGhosts(requestKey: string): Promise<boolean> {
   const db = await getDb();
-  const countResult = await db.select<{ count: number }[]>(
-    "SELECT COUNT(*) as count FROM ghosts WHERE request_key = ?",
+  // EXISTS は最初の 1 行で観測が止まる（COUNT(*) はパーティション全数を数える）
+  const rows = await db.select<{ has: number }[]>(
+    "SELECT EXISTS(SELECT 1 FROM ghosts WHERE request_key = ?) as has",
     [requestKey]
   );
-  const total = countResult.length > 0 ? countResult[0].count : 0;
-  return total > 0;
+  return rows.length > 0 && rows[0].has === 1;
 }
 
 // SELECT 対象列の単一権威。satisfies が GhostView に無い列名（typo・削除漏れ）を弾く。
@@ -114,6 +114,9 @@ export const GHOST_SEARCH_LOWER_COLUMNS = [
 
 const GHOST_SEARCH_WHERE =
   GHOST_SEARCH_LOWER_COLUMNS.map((col) => `${col} LIKE ?`).join(" OR ");
+
+const GHOST_SEARCH_WHERE_PREFIXED =
+  GHOST_SEARCH_LOWER_COLUMNS.map((col) => `g.${col} LIKE ?`).join(" OR ");
 
 const GHOST_SELECT_COLUMNS_PREFIXED: [MissingGhostViewColumns] extends [never] ? string : never =
   GHOST_VIEW_COLUMNS.map((c) => `g.${c}`).join(", ");
@@ -185,26 +188,33 @@ export async function countGhostsByQuery(requestKey: string, query: string): Pro
   return countResult.length > 0 ? countResult[0].count : 0;
 }
 
-export async function searchGhosts(requestKey: string, query: string, limit: number, offset: number, sortOrder: SortOrder = "name"): Promise<{ ghosts: GhostView[], total: number }> {
+// ページフェッチ（SELECT のみ）。総件数は返さない: total が変わるのはリセット時
+// （requestKey/query/sort/epoch 変更）だけなので、COUNT の発行は useSearch が
+// リセット時に 1 回だけ countGhostsByQuery で行う（スクロールの各ページで併走させない）。
+export async function searchGhosts(requestKey: string, query: string, limit: number, offset: number, sortOrder: SortOrder = "name"): Promise<GhostView[]> {
   return measureSearch("searchGhosts", async () => {
     const db = await getDb();
 
     const normalizedQuery = normalizeForKey(query);
-    const likePattern = `%${normalizedQuery}%`;
     const orderBy = buildOrderBy(sortOrder);
-    const searchWhere = GHOST_SEARCH_LOWER_COLUMNS.map((col) => `g.${col} LIKE ?`).join(" OR ");
 
-    const [total, rows] = await Promise.all([
-      countGhostsByQuery(requestKey, query),
-      db.select<GhostView[]>(
-        `SELECT ${GHOST_SELECT_COLUMNS_PREFIXED} FROM ghosts g WHERE g.request_key = ? AND (${searchWhere}) ORDER BY ${orderBy} LIMIT ? OFFSET ?`,
+    let rows: GhostView[];
+    if (normalizedQuery === "") {
+      // 空クエリに LIKE '%%' の行ごと評価をさせない
+      rows = await db.select<GhostView[]>(
+        `SELECT ${GHOST_SELECT_COLUMNS_PREFIXED} FROM ghosts g WHERE g.request_key = ? ORDER BY ${orderBy} LIMIT ? OFFSET ?`,
+        [requestKey, limit, offset]
+      );
+    } else {
+      const likePattern = `%${normalizedQuery}%`;
+      rows = await db.select<GhostView[]>(
+        `SELECT ${GHOST_SELECT_COLUMNS_PREFIXED} FROM ghosts g WHERE g.request_key = ? AND (${GHOST_SEARCH_WHERE_PREFIXED}) ORDER BY ${orderBy} LIMIT ? OFFSET ?`,
         [requestKey, ...GHOST_SEARCH_LOWER_COLUMNS.map(() => likePattern), limit, offset]
-      ),
-    ]);
+      );
+    }
 
-    console.log(`[ghostDatabase] searchGhosts(requestKey=${requestKey}, query="${query}", limit=${limit}, offset=${offset}, sort=${sortOrder}) → total=${total}`);
-    console.log(`[ghostDatabase] Fetched ${rows.length} rows`);
-    return { ghosts: rows, total };
+    console.log(`[ghostDatabase] searchGhosts(requestKey=${requestKey}, query="${query}", limit=${limit}, offset=${offset}, sort=${sortOrder}) → rows=${rows.length}`);
+    return rows;
   });
 }
 
@@ -214,9 +224,21 @@ export async function recordLaunch(ghostIdentityKey: string): Promise<void> {
 
 export async function getRandomGhost(requestKey: string): Promise<GhostView | null> {
   const db = await getDb();
-  const rows = await db.select<GhostView[]>(
-    `SELECT ${GHOST_SELECT_COLUMNS_PREFIXED} FROM ghosts g WHERE g.request_key = ? ORDER BY RANDOM() LIMIT 1`,
+  // ORDER BY RANDOM() はパーティション全走査＋全行ソートになるため、
+  // COUNT（index-only scan）＋乱数 OFFSET の単発取得で 1 体を選ぶ。
+  // ORDER BY なしの LIMIT 1 は行順が不定だが、無作為抽出には順序の権威が不要
+  const countResult = await db.select<{ count: number }[]>(
+    "SELECT COUNT(*) as count FROM ghosts WHERE request_key = ?",
     [requestKey]
+  );
+  const total = countResult.length > 0 ? countResult[0].count : 0;
+  if (total === 0) {
+    return null;
+  }
+  const randomOffset = Math.floor(Math.random() * total);
+  const rows = await db.select<GhostView[]>(
+    `SELECT ${GHOST_SELECT_COLUMNS_PREFIXED} FROM ghosts g WHERE g.request_key = ? LIMIT 1 OFFSET ?`,
+    [requestKey, randomOffset]
   );
   return rows.length > 0 ? rows[0] : null;
 }


### PR DESCRIPTION
## Summary

読み経路性能設計書（docs/superpowers/specs/2026-07-17-read-path-performance-design.md）の Phase 1。スキーマ不変・JS のみの変更で、#135 の体感の過半を占める「COUNT の増幅」を解消する。関連: epic #140・#135（クローズは Phase 2 の検索方式ゲートで判断）。

- **COUNT の発行をリセット時 1 回に限定**: `searchGhosts` から COUNT 併走を除去（戻り値を `GhostView[]` へ変更）。`useSearch` がリセット時（requestKey/query/sort/epoch 変更）のみ `countGhostsByQuery` を SELECT と並行発行し、スクロールのページ送りは select-only になった
- **空クエリ分岐**: 正規化後クエリが空なら LIKE 節なしの SQL を発行（`LIKE '%%'` の行ごと評価を排除）
- **`hasGhosts` の EXISTS 化**: COUNT(*) 全数 → `EXISTS(SELECT 1 …)` の 1 行観測
- **`getRandomGhost` の RANDOM() 廃止**: `ORDER BY RANDOM()`（パーティション全走査＋全行ソート）→ COUNT + 乱数 OFFSET の単発取得
- **検収形状の追加**: `search_bench` に `select_only_common` を追加。10万体・同一実行内ペア差で COUNT 増幅 **~52ms/回（約 24%）** の除去を確認し `docs/perf/baseline-100k.md` に記録（計測環境がベースライン表と異なるため、ペア差のみを比較対象とする注記付き）

受け入れ基準（設計書 Phase 1）は vitest で担保: 「スクロールによる offset 変更時に COUNT が発行されない」「空クエリの SQL に LIKE が含まれない」。

レビュー: sqlite-tuning（問題なし・COUNT→SELECT 間 TOCTOU は null を返す穏当な劣化で許容）・IPC 境界（契約不変）・/symmetry-check（SELECT スケルトン 4 箇所の重複は投影定数を単一権威とする意図的許容）。

## Test plan

- [x] npm run build
- [x] npm test（181 passed）
- [x] npm run check:ui-guidelines / test:ui-guidelines-check
- [x] cargo test --workspace / cargo test -p ghost-meta --features thumbnail,serde
- [x] cargo clippy（writer 混入ガード）
- [x] cargo check --features bench --benches / cargo test --features bench --lib bench_support（bench 変更のため手動実行）
- [x] E2E: 10 passed / 1 skipped（正常水準。skip は SSP 設定済み環境の既知要因）

🤖 Generated with [Claude Code](https://claude.com/claude-code)