### PR TITLE
chore: vite/vitest config の型検査を有効化しゲート化

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@tauri-apps/cli": "^2.11.2",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
+        "@types/node": "^26.1.1",
         "@types/react": "^19.2.16",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.2",
@@ -2724,6 +2725,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
@@ -4920,6 +4931,13 @@
       "engines": {
         "node": ">=20.18.1"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc && tsc -b tsconfig.node.json && vite build",
     "test": "vitest run",
     "test:watch": "vitest",
     "check:ui-guidelines": "node scripts/check-ui-guidelines.mjs",
@@ -32,6 +32,7 @@
     "@tauri-apps/cli": "^2.11.2",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@types/node": "^26.1.1",
     "@types/react": "^19.2.16",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,10 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
+    // src はブラウザ/React コード。@types/node（config 用に導入）の global 型漏れを防ぎ
+    // node 組込みの誤用を型で弾く。import.meta.env は src/vite-env.d.ts の参照ディレクティブ、
+    // React 型は import 経由で解決されるため types 空でも影響しない
+    "types": [],
 
     /* Bundler mode */
     "moduleResolution": "bundler",

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -4,7 +4,14 @@
     "skipLibCheck": true,
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    // vite.config.ts / vitest.config.ts は node 組込み（url/path/process）を使うため
+    // node 型をこのプロジェクトにだけ通す（src 側 tsconfig.json には漏らさない）
+    "types": ["node"],
+    // composite は noEmit と両立不可（TS5069）。型検査ゲート専用のため emit 生成物は
+    // gitignore 済みの node_modules 配下へ逃がし、リポジトリを汚さない
+    "outDir": "./node_modules/.tmp/config",
+    "tsBuildInfoFile": "./node_modules/.tmp/config/.tsbuildinfo"
   },
   "include": ["vite.config.ts", "vitest.config.ts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,6 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
-// @ts-expect-error process is a nodejs global
 const host = process.env.TAURI_DEV_HOST;
 
 // https://vite.dev/config/


### PR DESCRIPTION
## Summary
- `vite.config.ts` / `vitest.config.ts` は node 組込み（`url`/`path`/`process`）を使うが `@types/node` 未導入で型検査できず、build/CI（bare `tsc` は `src` のみ検査）の網から外れていた（#171 / #168・PR #170 の検証中に発見した既存の未検査面）
- `@types/node` を導入し、`build` を **`tsc && tsc -b tsconfig.node.json && vite build`** として config の型検査を恒久ゲート化。CI（`ci-build.yml` の `Build frontend`）は `npm run build` 経由で自動適用され、今後 config の型崩れをブロックする
- node 型は `tsconfig.node.json` にのみスコープし、`tsconfig.json` に `types: []` を置いて **src への漏れを塞ぐ**（src のブラウザ純度を維持。`import.meta.env` は `vite-env.d.ts` の参照ディレクティブ、React 型は import 経由で解決されるため無傷）
- node 型解決により不要化する `vite.config.ts` の `@ts-expect-error`（`process is a nodejs global`）を除去（放置すると `TS2578` 未使用ディレクティブになる対称的連鎖）
- `composite` は `noEmit` と両立不可（TS5069）のため、emit 生成物は **gitignore 済みの `node_modules/.tmp/config`** へ逃がし、リポジトリを汚さない

## 検証メモ
- 新ゲートの生存確認: config に型エラーを注入 → `tsc -b` が `TS2322` で捕捉（exit 2）→ 復元で緑、を較正済み
- `types: []` の安全性: bare `tsc`（src）を単独実行し JSX/React が無傷であることを実測

## Test plan
- [x] `npm run build`（統合ゲート `tsc && tsc -b tsconfig.node.json && vite build` 緑）
- [x] `npm test`（25 files / 186 tests）
- [x] `npm run check:ui-guidelines`（6/6）/ `npm run test:ui-guidelines-check`（fail 0）
- [x] `cargo test --workspace` / `cargo test -p ghost-meta --features thumbnail,serde` / `cargo clippy`（Rust 不変・回帰なし）
- [x] 生成型ドリフト `git status --porcelain src/types/generated/`（差分なし）
- [x] リポジトリ汚染なし（emit は `node_modules/.tmp/config` へ隔離）
- [x] E2E: N/A — build 設定変更で実行時バンドル・UI 挙動は不変

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)