### PR TITLE
refactor: スキャン層のデッドコード除去と公開面の最小化

### DIFF
--- a/crates/ghost-meta/src/lib.rs
+++ b/crates/ghost-meta/src/lib.rs
@@ -6,12 +6,12 @@ pub enum GhostMetaError {
     Io(#[from] std::io::Error),
 }
 
-pub mod descript;
-pub mod ghost;
-pub mod thumbnail;
+mod descript;
+mod ghost;
+mod thumbnail;
 
 #[cfg(test)]
 pub(crate) mod testutil;
 
 pub use ghost::{read_ghost, GhostMeta};
-pub use thumbnail::{resolve_thumbnail, AlphaMode, ThumbnailInfo, ThumbnailKind};
+pub use thumbnail::{AlphaMode, ThumbnailInfo, ThumbnailKind};

--- a/src-tauri/src/bench_support.rs
+++ b/src-tauri/src/bench_support.rs
@@ -11,13 +11,6 @@ use crate::commands::ghost::{
     check_parent_mtimes_match, collect_parent_mtimes, scan_ghosts_with_fingerprint_internal, Ghost,
 };
 
-/// クレートルートから内部経路へ到達できることを確認するプレースホルダ。
-/// 後続タスクで seeder / generator / wrapper に置き換える。
-#[doc(hidden)]
-pub fn __bench_support_linked() -> bool {
-    true
-}
-
 /// どの行にもマッチしない語（0 件）
 pub const Q_NONE: &str = "該当なし_zzzq";
 /// 約 0.1% にマッチ（craftman が "作者777" の行 = i % 1000 == 777）
@@ -229,28 +222,6 @@ pub fn layer1_hit(conn: &Connection, request_key: &str, ssp_path: &str) -> bool 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn bench_support_がリンクされる() {
-        assert!(__bench_support_linked());
-    }
-
-    #[test]
-    fn 内部型と関数へ到達できる() {
-        // 再エクスポート4種すべての疎通確認（import できてコンパイルが通れば可視性は正しい）。
-        // 注: この use は #[cfg(test)] 配下のため、feature 有効の非テストビルドでは
-        // 再エクスポートに消費者がなく unused 警告が出る（Task 6 が bench_support 関数で
-        // scan/fingerprint を消費した時点で解消。CI は --features bench をビルドしないため無害）。
-        use crate::commands::ghost::{
-            check_parent_mtimes_match, collect_parent_mtimes,
-            scan_ghosts_with_fingerprint_internal, Ghost,
-        };
-        let _ = std::mem::size_of::<Ghost>();
-        let _ = collect_parent_mtimes as fn(&str, &[String]) -> String;
-        let _ = check_parent_mtimes_match as fn(&Connection, &str, &str) -> bool;
-        let _ = scan_ghosts_with_fingerprint_internal
-            as fn(&str, &[String]) -> Result<(Vec<Ghost>, String), String>;
-    }
 
     use crate::testutil::TempDirGuard;
 

--- a/src-tauri/src/commands/ghost/fingerprint.rs
+++ b/src-tauri/src/commands/ghost/fingerprint.rs
@@ -14,7 +14,7 @@ pub(crate) fn metadata_modified_string(meta: &fs::Metadata) -> String {
 }
 
 /// descript.txt の metadata から (state, modified) のトークン用タプルを取得する
-pub(crate) fn descript_metadata_for_token(descript_path: &Path) -> (String, String) {
+fn descript_metadata_for_token(descript_path: &Path) -> (String, String) {
     match fs::metadata(descript_path) {
         Err(_) => ("missing".to_string(), "-".to_string()),
         Ok(meta) => match meta

--- a/src-tauri/src/commands/ghost/types.rs
+++ b/src-tauri/src/commands/ghost/types.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 #[cfg(test)]
 use ts_rs::TS;
 
@@ -30,7 +30,7 @@ pub struct Ghost {
     pub thumbnail_kind: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 #[cfg_attr(test, derive(TS))]
 #[cfg_attr(test, ts(export))]
 pub struct ScanStoreResult {


### PR DESCRIPTION
## Summary
- #133 完了で役目を終えたベンチ用プレースホルダ `__bench_support_linked()` と可視性スモークテスト（コメント自身が「Task 6 で解消」と明記していたもの）を撤去
- `crates/ghost-meta` のモジュール直接公開（`pub mod`）をやめ、実消費されている再エクスポート 5 種（`read_ghost` / `GhostMeta` / `AlphaMode` / `ThumbnailInfo` / `ThumbnailKind`）のみを公開面に縮小。未使用の `resolve_thumbnail` 再エクスポートを削除。公開面の縮小により、今後は rustc の dead_code lint が未使用シンボルを検知できる構造になる
- IPC を渡らない `ScanStoreResult` の未使用 `Deserialize` derive と、ファイル内でしか使われない `descript_metadata_for_token` の `pub(crate)` を削除

削除リファクタリングのため Red テストは書けず、代替として全削除対象の本番使用ゼロを grep で前提検証済み。フロントエンド側（src/lib・src/hooks・src/types）も調査したが真のデッドコードはゼロ（テストからのみ import される export はすべて parity 検査用の意図的公開のため温存）。

## Test plan
- [x] `npm run build`
- [x] `npm test`（176 passed）
- [x] `npm run check:ui-guidelines`
- [x] `npm run test:ui-guidelines-check`
- [x] `cargo test --workspace`（46 passed、生成型ドリフトなし）
- [x] `cargo test -p ghost-meta --features thumbnail,serde`（34 passed）
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --features bench`（57 passed、bench feature 有効時も警告ゼロ）
- [x] `/ipc-check` 全 4 項目パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)