### PR TITLE
refactor: clippy 警告ゼロ化と store_ghosts_delta の差分ペイロード構造体化

### DIFF
--- a/crates/ghost-meta/src/descript.rs
+++ b/crates/ghost-meta/src/descript.rs
@@ -44,13 +44,13 @@ fn detect_charset(bytes: &[u8]) -> Charset {
     let ascii_content = String::from_utf8_lossy(&bytes[..scan_len]);
     for line in ascii_content.lines() {
         let line = line.trim();
-        if let Some((key, value)) = line.split_once(',') {
-            if key.trim().eq_ignore_ascii_case("charset") {
-                if value.trim().eq_ignore_ascii_case("UTF-8") {
-                    return Charset::Utf8;
-                }
-                return Charset::ShiftJis;
+        if let Some((key, value)) = line.split_once(',')
+            && key.trim().eq_ignore_ascii_case("charset")
+        {
+            if value.trim().eq_ignore_ascii_case("UTF-8") {
+                return Charset::Utf8;
             }
+            return Charset::ShiftJis;
         }
     }
     // デフォルトは Shift_JIS

--- a/crates/ghost-meta/src/ghost.rs
+++ b/crates/ghost-meta/src/ghost.rs
@@ -73,7 +73,7 @@ mod tests {
     use super::*;
     use crate::testutil::TempDirGuard;
 
-    fn create_ghost(root: &PathBuf, dir_name: &str, descript: &str) {
+    fn create_ghost(root: &Path, dir_name: &str, descript: &str) {
         let base = root.join(dir_name).join("ghost").join("master");
         fs::create_dir_all(&base).unwrap();
         fs::write(base.join("descript.txt"), descript).unwrap();

--- a/crates/ghost-meta/src/thumbnail.rs
+++ b/crates/ghost-meta/src/thumbnail.rs
@@ -128,10 +128,10 @@ fn read_seriko_use_self_alpha(ghost_root: &Path) -> AlphaMode {
         .join("shell")
         .join("master")
         .join("descript.txt");
-    if let Ok(fields) = parse_descript(&shell_descript) {
-        if fields.get("seriko.use_self_alpha").map(|v| v.as_str()) == Some("1") {
-            return AlphaMode::SelfAlpha;
-        }
+    if let Ok(fields) = parse_descript(&shell_descript)
+        && fields.get("seriko.use_self_alpha").map(|v| v.as_str()) == Some("1")
+    {
+        return AlphaMode::SelfAlpha;
     }
     AlphaMode::KeyColor
 }
@@ -180,13 +180,13 @@ mod tests {
     use crate::testutil::TempDirGuard;
     use std::path::PathBuf;
 
-    fn create_shell_master(ghost_root: &PathBuf) -> PathBuf {
+    fn create_shell_master(ghost_root: &Path) -> PathBuf {
         let shell_master = ghost_root.join("shell").join("master");
         fs::create_dir_all(&shell_master).unwrap();
         shell_master
     }
 
-    fn write_shell_descript(ghost_root: &PathBuf, content: &str) {
+    fn write_shell_descript(ghost_root: &Path, content: &str) {
         let shell_master = create_shell_master(ghost_root);
         fs::write(shell_master.join("descript.txt"), content).unwrap();
     }

--- a/src-tauri/src/actor/mod.rs
+++ b/src-tauri/src/actor/mod.rs
@@ -30,10 +30,10 @@ pub(crate) fn bootstrap(app: &tauri::App) -> Result<ActorHandle, String> {
     crate::commands::ghost::store::configure_connection(&user_conn)
         .map_err(|e| format!("user-data.db の{e}"))?;
     crate::commands::launch_history::ensure_schema(&user_conn)?;
-    if ghosts_path.exists() {
-        if let Ok(g) = rusqlite::Connection::open(&ghosts_path) {
-            let _ = crate::commands::launch_history::migrate_legacy_launch_history(&g, &user_conn);
-        }
+    if ghosts_path.exists()
+        && let Ok(g) = rusqlite::Connection::open(&ghosts_path)
+    {
+        let _ = crate::commands::launch_history::migrate_legacy_launch_history(&g, &user_conn);
     }
 
     // (3) ghosts を開きスキーマ確定（webview ロード前なので初回 SELECT は必ず確定後）。

--- a/src-tauri/src/bench_support.rs
+++ b/src-tauri/src/bench_support.rs
@@ -8,7 +8,7 @@ use rayon::prelude::*;
 use rusqlite::Connection;
 
 use crate::commands::ghost::store::{
-    configure_connection, ghost_identity_key, store_ghosts_delta, ScanEntryRow,
+    configure_connection, ghost_identity_key, store_ghosts_delta, GhostDelta, ScanEntryRow,
 };
 use crate::commands::ghost::{
     apply_scan_delta, check_parent_mtimes_match, collect_parent_mtimes,
@@ -47,9 +47,9 @@ fn synth_ghost(i: usize) -> Ghost {
     let jp = ["さくら", "うにゅう", "ゴースト", "妖精", "式神"];
     let en = ["Alice", "Bob", "Ghost", "Fairy", "Nova"];
     // i % 10 == 0 の行だけ名前を "さくら…" にして Q_COMMON の選択率を ~10% に固定
-    let base = if i % 10 == 0 {
+    let base = if i.is_multiple_of(10) {
         "さくら"
-    } else if i % 2 == 0 {
+    } else if i.is_multiple_of(2) {
         jp[i % jp.len()]
     } else {
         en[i % en.len()]
@@ -57,8 +57,8 @@ fn synth_ghost(i: usize) -> Ghost {
     Ghost {
         diff_fingerprint: format!("fp-{i}"),
         name: format!("{base}{i}"),
-        sakura_name: if i % 3 == 0 { format!("{base}の精") } else { String::new() },
-        kero_name: if i % 5 == 0 { format!("相方{i}") } else { String::new() },
+        sakura_name: if i.is_multiple_of(3) { format!("{base}の精") } else { String::new() },
+        kero_name: if i.is_multiple_of(5) { format!("相方{i}") } else { String::new() },
         // i % 1000 == 777 の行だけ craftman が "作者777" → Q_RARE の選択率 ~0.1%
         craftman: format!("作者{}", i % 1000),
         craftmanw: String::new(),
@@ -97,10 +97,12 @@ fn delta_store_ghosts(
     store_ghosts_delta(
         conn,
         request_key,
-        ghosts,
-        &[],
-        &scan_rows,
-        &[],
+        &GhostDelta {
+            upserts: ghosts,
+            deletes: &[],
+            scan_upserts: &scan_rows,
+            scan_deletes: &[],
+        },
         fingerprint,
         parent_mtimes,
     )
@@ -172,7 +174,7 @@ pub fn generate_ghost_tree(ssp_root: &Path, n: usize) -> Result<PathBuf, String>
             g.craftman
         );
         let descript_path = master.join("descript.txt");
-        if i % 7 == 0 {
+        if i.is_multiple_of(7) {
             // Shift_JIS（charset 明示）で文字コード判定経路を踏む
             let sjis_body = format!("charset,Shift_JIS\n{descript}");
             let (bytes, _, _) = encoding_rs::SHIFT_JIS.encode(&sjis_body);
@@ -183,7 +185,7 @@ pub fn generate_ghost_tree(ssp_root: &Path, n: usize) -> Result<PathBuf, String>
         }
 
         // 一部に surface0.png を置き thumbnail 解決を発生させる
-        if i % 3 == 0 {
+        if i.is_multiple_of(3) {
             let shell_master = ghost_dir.join(&g.directory_name).join("shell").join("master");
             fs::create_dir_all(&shell_master).map_err(|e| format!("mkdir shell: {e}"))?;
             fs::write(shell_master.join("surface0.png"), b"")

--- a/src-tauri/src/commands/ghost/mod.rs
+++ b/src-tauri/src/commands/ghost/mod.rs
@@ -248,10 +248,12 @@ pub(crate) fn apply_scan_delta(
     store::store_ghosts_delta(
         conn,
         request_key,
-        &upserts,
-        &delete_identities,
-        &scan_upserts,
-        &scan_deletes,
+        &store::GhostDelta {
+            upserts: &upserts,
+            deletes: &delete_identities,
+            scan_upserts: &scan_upserts,
+            scan_deletes: &scan_deletes,
+        },
         fingerprint,
         parent_mtimes,
     )
@@ -264,14 +266,14 @@ mod tests {
     use super::scan::scan_ghosts_with_fingerprint_internal;
     use crate::testutil::TempDirGuard;
     use std::fs;
-    use std::path::PathBuf;
+    use std::path::Path;
 
-    fn create_ghost_dir(root: &PathBuf, name: &str) -> Result<(), String> {
+    fn create_ghost_dir(root: &Path, name: &str) -> Result<(), String> {
         create_ghost_dir_with_descript(root, name, "name,Test Ghost\ncharset,UTF-8\n")
     }
 
     fn create_ghost_dir_with_descript(
-        root: &PathBuf,
+        root: &Path,
         name: &str,
         descript: &str,
     ) -> Result<(), String> {
@@ -780,7 +782,7 @@ mod tests {
     fn seed_ghost_and_pending_launch(
         conn: &rusqlite::Connection,
         user_conn: &rusqlite::Connection,
-        ssp_root: &PathBuf,
+        ssp_root: &Path,
     ) -> Result<(String, String), String> {
         let ssp_ghost = ssp_root.join("ghost");
         fs::create_dir_all(&ssp_ghost).map_err(|e| format!("ssp ghost dir: {e}"))?;

--- a/src-tauri/src/commands/ghost/scan.rs
+++ b/src-tauri/src/commands/ghost/scan.rs
@@ -201,10 +201,10 @@ pub(crate) fn walk_parent(
     // 逐次: 結果をマージ
     for result in results {
         tokens.push(result.token);
-        if let Some(ghost) = result.ghost {
-            if let Some((_, ref mut ghost_list)) = ghosts {
-                ghost_list.push(ghost);
-            }
+        if let Some(ghost) = result.ghost
+            && let Some((_, ref mut ghost_list)) = ghosts
+        {
+            ghost_list.push(ghost);
         }
     }
 

--- a/src-tauri/src/commands/ghost/store.rs
+++ b/src-tauri/src/commands/ghost/store.rs
@@ -94,13 +94,35 @@ pub(crate) fn read_scan_entries(
     Ok(map)
 }
 
-/// delta 差分書き込み（1 トランザクション）。全行読み取りをせず、変更子だけを操作する。
+/// `store_ghosts_delta` へ渡す差分ペイロード（借用）。`deletes`/`scan_deletes` が同型（&[String]）で
+/// 隣接する位置引数だと取り違えをコンパイラが検知できないため、名前付きフィールドで構造的に防ぐ。
 ///
 /// - `upserts`: 変更子（parse 成功）。`ON CONFLICT … DO UPDATE … WHERE row_fingerprint 相違` で、
 ///   新規は INSERT・メタ変化は UPDATE・不変は no-op（updated_at を bump しない）。初回/移行時
 ///   （ghosts 既存・scan_entries 空）でも UNIQUE 衝突せず UPDATE で吸収する。
 /// - `deletes`: DELETE 対象 `ghost_identity_key`（削除子＋parse 失敗子）。upsert より先に適用する。
 /// - `scan_upserts` / `scan_deletes`: `ghost_scan_entries` の差分（変更子を UPSERT・削除子を DELETE）。
+pub(crate) struct GhostDelta<'a> {
+    pub upserts: &'a [Ghost],
+    pub deletes: &'a [String],
+    pub scan_upserts: &'a [ScanEntryRow<'a>],
+    pub scan_deletes: &'a [String],
+}
+
+#[cfg(test)]
+impl GhostDelta<'_> {
+    /// 0 子変更の delta（fingerprint / parent_mtimes だけを書きたいテスト用）。
+    pub(crate) const EMPTY: GhostDelta<'static> = GhostDelta {
+        upserts: &[],
+        deletes: &[],
+        scan_upserts: &[],
+        scan_deletes: &[],
+    };
+}
+
+/// delta 差分書き込み（1 トランザクション）。全行読み取りをせず、変更子だけを操作する。
+///
+/// - `delta`: 差分ペイロード（各フィールドの意味は `GhostDelta` を参照）。
 /// - `fingerprint` / `parent_mtimes`: `ghost_fingerprints` を更新（0 子変更でも必ず書き、次回 Layer 1 を再 hit させる）。
 /// - 集計列 `last_launched` / `launch_count` は不可侵（INSERT 時は既定値・UPDATE 時は無触）。commit 後に backfill する。
 ///
@@ -110,10 +132,7 @@ pub(crate) fn read_scan_entries(
 pub(crate) fn store_ghosts_delta(
     conn: &Connection,
     request_key: &str,
-    upserts: &[Ghost],
-    deletes: &[String],
-    scan_upserts: &[ScanEntryRow],
-    scan_deletes: &[String],
+    delta: &GhostDelta,
     fingerprint: &str,
     parent_mtimes: &str,
 ) -> Result<usize, String> {
@@ -124,20 +143,20 @@ pub(crate) fn store_ghosts_delta(
     {
         // 1) DELETE（削除子＋parse 失敗子）を先に適用する。
         //    NFKC 衝突の corner（同一 identity の削除子と upsert が併存）で upsert を勝たせる。
-        if !deletes.is_empty() {
+        if !delta.deletes.is_empty() {
             let mut stmt = tx
                 .prepare_cached(
                     "DELETE FROM ghosts WHERE request_key = ?1 AND ghost_identity_key = ?2",
                 )
                 .map_err(|e| format!("DELETE 準備エラー: {e}"))?;
-            for identity_key in deletes {
+            for identity_key in delta.deletes {
                 stmt.execute(rusqlite::params![request_key, identity_key])
                     .map_err(|e| format!("DELETE エラー: {e}"))?;
             }
         }
 
         // 2) 変更子を UPSERT（INSERT / 既存は row_fingerprint 相違時のみ UPDATE）。
-        if !upserts.is_empty() {
+        if !delta.upserts.is_empty() {
             let mut stmt = tx
                 .prepare_cached(
                     "INSERT INTO ghosts (\
@@ -169,7 +188,7 @@ pub(crate) fn store_ghosts_delta(
                 )
                 .map_err(|e| format!("UPSERT 準備エラー: {e}"))?;
 
-            for ghost in upserts {
+            for ghost in delta.upserts {
                 let identity_key = build_ghost_identity_key(ghost);
                 stmt.execute(rusqlite::params![
                     request_key,
@@ -198,25 +217,25 @@ pub(crate) fn store_ghosts_delta(
         }
 
         // 3) ghost_scan_entries の差分（削除子を DELETE・変更子を UPSERT）。不変子は無触。
-        if !scan_deletes.is_empty() {
+        if !delta.scan_deletes.is_empty() {
             let mut stmt = tx
                 .prepare_cached(
                     "DELETE FROM ghost_scan_entries WHERE request_key = ?1 AND scan_key = ?2",
                 )
                 .map_err(|e| format!("scan_entries DELETE 準備エラー: {e}"))?;
-            for scan_key in scan_deletes {
+            for scan_key in delta.scan_deletes {
                 stmt.execute(rusqlite::params![request_key, scan_key])
                     .map_err(|e| format!("scan_entries DELETE エラー: {e}"))?;
             }
         }
-        if !scan_upserts.is_empty() {
+        if !delta.scan_upserts.is_empty() {
             let mut stmt = tx
                 .prepare_cached(
                     "INSERT OR REPLACE INTO ghost_scan_entries \
                      (request_key, scan_key, token, ghost_identity_key) VALUES (?1, ?2, ?3, ?4)",
                 )
                 .map_err(|e| format!("scan_entries UPSERT 準備エラー: {e}"))?;
-            for row in scan_upserts {
+            for row in delta.scan_upserts {
                 stmt.execute(rusqlite::params![
                     request_key,
                     row.scan_key,
@@ -332,10 +351,11 @@ mod tests {
         store_ghosts_delta(
             &conn,
             "rk1",
-            std::slice::from_ref(&ghost),
-            &[],
-            &[scan_row("sk", "tok", &k)],
-            &[],
+            &GhostDelta {
+                upserts: std::slice::from_ref(&ghost),
+                scan_upserts: &[scan_row("sk", "tok", &k)],
+                ..GhostDelta::EMPTY
+            },
             "fp-nfkc",
             "",
         )
@@ -359,10 +379,11 @@ mod tests {
         store_ghosts_delta(
             &conn,
             "rk1",
-            std::slice::from_ref(&ghost),
-            &[],
-            &[scan_row("sk", "tok", &k)],
-            &[],
+            &GhostDelta {
+                upserts: std::slice::from_ref(&ghost),
+                scan_upserts: &[scan_row("sk", "tok", &k)],
+                ..GhostDelta::EMPTY
+            },
             "fp-id",
             "",
         )
@@ -383,7 +404,7 @@ mod tests {
     #[test]
     fn check_parent_mtimes_match_が一致時にtrueを返す() {
         let conn = setup_db();
-        store_ghosts_delta(&conn, "rk1", &[], &[], &[], &[], "fp-1", "c:/ssp/ghost:12345").unwrap();
+        store_ghosts_delta(&conn, "rk1", &GhostDelta::EMPTY, "fp-1", "c:/ssp/ghost:12345").unwrap();
 
         assert!(super::super::fingerprint::check_parent_mtimes_match(
             &conn,
@@ -395,7 +416,7 @@ mod tests {
     #[test]
     fn check_parent_mtimes_match_が不一致時にfalseを返す() {
         let conn = setup_db();
-        store_ghosts_delta(&conn, "rk1", &[], &[], &[], &[], "fp-1", "c:/ssp/ghost:12345").unwrap();
+        store_ghosts_delta(&conn, "rk1", &GhostDelta::EMPTY, "fp-1", "c:/ssp/ghost:12345").unwrap();
 
         assert!(!super::super::fingerprint::check_parent_mtimes_match(
             &conn,
@@ -471,13 +492,14 @@ mod tests {
         let total = store_ghosts_delta(
             &conn,
             "rk1",
-            &[alice, bob],
-            &[],
-            &[
-                scan_row("sk-a", "tok-a", &ka),
-                scan_row("sk-b", "tok-b", &kb),
-            ],
-            &[],
+            &GhostDelta {
+                upserts: &[alice, bob],
+                scan_upserts: &[
+                    scan_row("sk-a", "tok-a", &ka),
+                    scan_row("sk-b", "tok-b", &kb),
+                ],
+                ..GhostDelta::EMPTY
+            },
             "fp-1",
             "mt-1",
         )
@@ -505,10 +527,11 @@ mod tests {
         store_ghosts_delta(
             &conn,
             "rk1",
-            std::slice::from_ref(&alice),
-            &[],
-            &[scan_row("sk-a", "tok-a", &ka)],
-            &[],
+            &GhostDelta {
+                upserts: std::slice::from_ref(&alice),
+                scan_upserts: &[scan_row("sk-a", "tok-a", &ka)],
+                ..GhostDelta::EMPTY
+            },
             "fp-1",
             "mt-1",
         )
@@ -525,10 +548,11 @@ mod tests {
         store_ghosts_delta(
             &conn,
             "rk1",
-            std::slice::from_ref(&alice),
-            &[],
-            &[scan_row("sk-a", "tok-a-changed", &ka)],
-            &[],
+            &GhostDelta {
+                upserts: std::slice::from_ref(&alice),
+                scan_upserts: &[scan_row("sk-a", "tok-a-changed", &ka)],
+                ..GhostDelta::EMPTY
+            },
             "fp-2",
             "mt-2",
         )
@@ -548,10 +572,11 @@ mod tests {
         store_ghosts_delta(
             &conn,
             "rk1",
-            std::slice::from_ref(&alice),
-            &[],
-            &[scan_row("sk-a", "tok-a-2", &ka)],
-            &[],
+            &GhostDelta {
+                upserts: std::slice::from_ref(&alice),
+                scan_upserts: &[scan_row("sk-a", "tok-a-2", &ka)],
+                ..GhostDelta::EMPTY
+            },
             "fp-3",
             "mt-3",
         )
@@ -577,10 +602,11 @@ mod tests {
         store_ghosts_delta(
             &conn,
             "rk1",
-            &[alice, bob],
-            &[],
-            &[scan_row("sk-a", "tok-a", &ka), scan_row("sk-b", "tok-b", &kb)],
-            &[],
+            &GhostDelta {
+                upserts: &[alice, bob],
+                scan_upserts: &[scan_row("sk-a", "tok-a", &ka), scan_row("sk-b", "tok-b", &kb)],
+                ..GhostDelta::EMPTY
+            },
             "fp-1",
             "mt-1",
         )
@@ -590,10 +616,11 @@ mod tests {
         let total = store_ghosts_delta(
             &conn,
             "rk1",
-            &[],
-            std::slice::from_ref(&kb),
-            &[],
-            std::slice::from_ref(&"sk-b".to_string()),
+            &GhostDelta {
+                deletes: std::slice::from_ref(&kb),
+                scan_deletes: std::slice::from_ref(&"sk-b".to_string()),
+                ..GhostDelta::EMPTY
+            },
             "fp-2",
             "mt-2",
         )
@@ -615,7 +642,7 @@ mod tests {
     fn store_ghosts_delta_が_0変更でもfingerprintとparent_mtimesを書く() {
         let conn = setup_db();
         let total =
-            store_ghosts_delta(&conn, "rk1", &[], &[], &[], &[], "fp-only", "mt-only").unwrap();
+            store_ghosts_delta(&conn, "rk1", &GhostDelta::EMPTY, "fp-only", "mt-only").unwrap();
         assert_eq!(total, 0);
 
         let (fp, mt): (String, String) = conn
@@ -721,10 +748,11 @@ mod tests {
         store_ghosts_delta(
             &conn,
             "rk1",
-            std::slice::from_ref(&alice),
-            &[],
-            &[scan_row("sk-a", "tok-a", &ka)],
-            &[],
+            &GhostDelta {
+                upserts: std::slice::from_ref(&alice),
+                scan_upserts: &[scan_row("sk-a", "tok-a", &ka)],
+                ..GhostDelta::EMPTY
+            },
             "fp-seed",
             "mt-seed",
         )
@@ -734,10 +762,11 @@ mod tests {
         let result = store_ghosts_delta(
             &conn,
             "rk1",
-            std::slice::from_ref(&alice),
-            &[],
-            &[scan_row("sk-a", "tok-a-2", &ka)],
-            &[],
+            &GhostDelta {
+                upserts: std::slice::from_ref(&alice),
+                scan_upserts: &[scan_row("sk-a", "tok-a-2", &ka)],
+                ..GhostDelta::EMPTY
+            },
             "fp-1",
             "mt-1",
         );

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,35 @@ pub(crate) mod testutil;
 #[cfg(feature = "bench")]
 pub mod bench_support;
 
+#[cfg_attr(mobile, tauri::mobile_entry_point)]
+pub fn run() {
+    use tauri::Manager;
+    tauri::Builder::default()
+        .plugin(tauri_plugin_sql::Builder::default().build())
+        .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_store::Builder::default().build())
+        .plugin(tauri_plugin_window_state::Builder::default().build())
+        .setup(|app| {
+            match actor::bootstrap(app) {
+                Ok(handle) => {
+                    app.manage(handle);
+                }
+                Err(e) => return Err(format!("DB アクターの起動に失敗しました: {e}").into()),
+            }
+            Ok(())
+        })
+        .invoke_handler(tauri::generate_handler![
+            commands::ghost::scan_and_store,
+            commands::ghost::cleanup_ghost_caches,
+            commands::launch_history::record_launch,
+            commands::ssp::launch_ghost,
+            commands::ssp::validate_ssp_path,
+            commands::locale::read_user_locale,
+        ])
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
+}
+
 #[cfg(test)]
 mod tests {
     use rusqlite::Connection;
@@ -39,33 +68,4 @@ mod tests {
             );
         }
     }
-}
-
-#[cfg_attr(mobile, tauri::mobile_entry_point)]
-pub fn run() {
-    use tauri::Manager;
-    tauri::Builder::default()
-        .plugin(tauri_plugin_sql::Builder::default().build())
-        .plugin(tauri_plugin_dialog::init())
-        .plugin(tauri_plugin_store::Builder::default().build())
-        .plugin(tauri_plugin_window_state::Builder::default().build())
-        .setup(|app| {
-            match actor::bootstrap(app) {
-                Ok(handle) => {
-                    app.manage(handle);
-                }
-                Err(e) => return Err(format!("DB アクターの起動に失敗しました: {e}").into()),
-            }
-            Ok(())
-        })
-        .invoke_handler(tauri::generate_handler![
-            commands::ghost::scan_and_store,
-            commands::ghost::cleanup_ghost_caches,
-            commands::launch_history::record_launch,
-            commands::ssp::launch_ghost,
-            commands::ssp::validate_ssp_path,
-            commands::locale::read_user_locale,
-        ])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
 }


### PR DESCRIPTION
## Summary
- actor 化・delta スキャン（#134/#146 系）並行マージ後のコードベースを再調査。真のデッドコード（未使用シンボル・削除済みコマンド `reset_ghost_db` の invoke 残骸・locale 未使用キー・旧アーキテクチャの化石）は Rust/TS とも**ゼロ**を確認し、clippy が指摘する改善点を解消
- `store_ghosts_delta` の 8 引数を `GhostDelta` 構造体に集約。`deletes`/`scan_deletes`（同型 `&[String]`）と `fingerprint`/`parent_mtimes`（同型 `&str`）が隣接する位置引数で、取り違えてもコンパイルが通る構造だったのを名前付きフィールドで構造的に防止（`too_many_arguments` の解消を兼ねる）
- `collapsible_if` ×4 を edition 2024 の let-chains で平坦化、テストヘルパの `&PathBuf` → `&Path`（`ptr_arg` ×4）、bench_support の `i % n == 0` → `is_multiple_of`（bench feature 限定 lint）、lib.rs の `run()` をテストモジュールより前へ（`items_after_test_module`）
- 等価リファクタリングのため新規テストなし。IPC 境界・DB スキーマ・fingerprint のセマンティクスは不変

## Test plan
- [x] `npm run build`
- [x] `npm test`（186 passed）
- [x] `npm run check:ui-guidelines` / `npm run test:ui-guidelines-check`
- [x] `cargo test --workspace`（64 passed、生成型ドリフトなし）
- [x] `cargo test -p ghost-meta --features thumbnail,serde`（34 passed）
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --features bench`（79 passed。bench 関連ファイル変更のため CI 専用ゲート相当を手動実行）
- [x] `cargo clippy`（workspace / bench feature の全構成で警告ゼロ。CI の disallowed-methods ゲートもパス）
- [x] `/ipc-check` 全 4 項目パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)