### PR TITLE
chore: clippy ゲートを -D warnings へ昇格し全構成を CI で縛る

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -35,12 +35,12 @@ npm run test:ui-guidelines-check
 # グループ B（順次実行。ci-build.yml の Rust ゲートと同期させる——機構でなく規範。乖離は /health-check 項目 6 が検出する）
 cargo test --workspace
 cargo test -p ghost-meta --features thumbnail,serde
-cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -A clippy::all -D clippy::disallowed-methods
+cargo clippy --workspace --all-targets -- -D warnings
 ```
 
 グループ A とグループ B は互いに独立しているため並列実行してよい（グループ B 内は target ディレクトリのロック競合を避けるため順次）。
 
-> **CI のみのゲート（意図的非対称）**: bench ハーネス系（`cargo check --features bench --benches`・`cargo test --features bench --lib bench_support`）は CI 専用で、本チェックリストには含めない（bench コードの変更頻度が低く、毎コミットのローカル実行コストに見合わないため）。bench 関連ファイルを変更したときのみ手動で実行する。
+> **CI のみのゲート（意図的非対称）**: bench ハーネス系（`cargo check --features bench --benches`・`cargo test --features bench --lib bench_support`・`cargo clippy --features bench --all-targets -- -D warnings`）は CI 専用で、本チェックリストには含めない（bench コードの変更頻度が低く、毎コミットのローカル実行コストに見合わないため）。bench 関連ファイルを変更したときのみ手動で実行する。
 
 ### 追加の確認事項
 

--- a/.claude/skills/deps-update/SKILL.md
+++ b/.claude/skills/deps-update/SKILL.md
@@ -38,6 +38,8 @@ cargo update        # Cargo.lock の更新
 
 `/commit` のコミット前チェックリストを全実行する。UI に波及しうる更新（React・Fluent UI・i18next・tauri 系）の場合は `/e2e` の手動実行を推奨する。
 
+> **toolchain 更新（rustup stable の bump）時の clippy 再ゼロ化**: CI（`ci-build.yml`）は `dtolnay/rust-toolchain@stable`（浮動）で clippy を `-D warnings` ゲートしている。`cargo update` とは別に stable が上がると新 lint で CI が突然赤くなりうる。`rustup update` で stable を上げたら、依存更新と同一 PR かは問わず `cargo clippy --workspace --all-targets -- -D warnings` と bench 構成（`--features bench --all-targets`）を再実行し、**警告ゼロを回復してからコミットする**。toolchain は固定していない（新 lint を早期検知する方針・#175）。
+
 ## ステップ 5: コミットと PR
 
 `/commit` → `/pr` へ接続する。更新内容（何をどの版からどの版へ）を PR 本文に列挙する。

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -63,5 +63,12 @@ jobs:
       - name: Test bench_support guards
         run: cargo test --manifest-path src-tauri/Cargo.toml --features bench --lib bench_support
 
-      - name: Clippy (writer 混入ガード)
-        run: cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -A clippy::all -D clippy::disallowed-methods
+      # clippy 警告を 1 件でも許さない全面ゲート。writer 混入ガード（disallowed-methods）は
+      # -D warnings に含意されるため（clippy 自身が "implied by -D warnings" と報告する）明示不要。
+      - name: Clippy (workspace, deny warnings)
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+      # bench feature 配下のコード（bench_support・benches/）は required-features でスキップされるため
+      # 別ステップで lint する。bench 限定の新 lint 素通りを防ぐ。
+      - name: Clippy (bench feature, deny warnings)
+        run: cargo clippy --manifest-path src-tauri/Cargo.toml --features bench --all-targets -- -D warnings


### PR DESCRIPTION
Closes #175

## Summary
- CI/`/commit` の clippy ゲートを `-A clippy::all -D clippy::disallowed-methods`（writer 混入ガード以外を素通り）から **`-D warnings`** へ昇格。#174 で発覚した「検知器はあるが警報が切ってある」状態を解消
- CI は **workspace / bench feature の 2 構成**で `-D warnings` ゲート。benches は `required-features = ["bench"]` で workspace 構成からスキップされるため、bench 限定 lint の素通りを防ぐ別ステップを追加
- writer 混入ガード（`disallowed-methods`）は `-D warnings` に**含意される**（clippy 自身が `-D clippy::disallowed-methods` implied by `-D warnings` と報告。一時的な違反注入で実証済み）。明示指定は廃止
- `/commit` グループ B を CI の workspace clippy と同一コマンドへ同期。bench clippy は既存の bench ハーネス系と同じく意図的 CI 専用ゲートとして非対称ノートに追記
- toolchain は固定せず（浮動 stable で新 lint を早期検知する方針）、代わりに `/deps-update` へ「rustup stable bump 時は clippy 再ゼロ化してからコミット」を明記（issue の 4 択で選択）

## Test plan
- [x] `npm run build`
- [x] `npm test`（186 passed）
- [x] `npm run check:ui-guidelines` / `npm run test:ui-guidelines-check`
- [x] `cargo test --workspace` / `cargo test -p ghost-meta --features thumbnail,serde`（生成型ドリフトなし）
- [x] `cargo clippy --workspace --all-targets -- -D warnings`（exit 0）
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml --features bench --all-targets -- -D warnings`（exit 0）
- [x] 一時的な `rusqlite::Connection::open` 違反を注入し、`-D warnings` 単独で `disallowed_methods` が error 化することを確認（revert 済み）

## 受け入れ基準の充足
- clippy 警告が 1 件でもあると CI が fail する（`-D warnings`）
- `/commit` チェックリストと CI のゲートが同一コマンド（workspace clippy）

🤖 Generated with [Claude Code](https://claude.com/claude-code)