### PR TITLE
docs: /post-merge-sync に lockfile 変更時の依存再同期ステップを追加

### DIFF
--- a/.claude/skills/post-merge-sync/SKILL.md
+++ b/.claude/skills/post-merge-sync/SKILL.md
@@ -28,10 +28,23 @@ gh pr view <PR番号 or ブランチ> --json number,state,headRefName,mergedAt
 
 ```bash
 git switch main
+before_sync=$(git rev-parse HEAD)   # ステップ 3 の依存再同期の差分基点（pull 前の tip を控える）
 git pull origin main --ff-only
 ```
 
-## ステップ 3: ローカル作業ブランチの削除
+## ステップ 3: 依存の再同期（lockfile 変更時のみ）
+
+pull が lockfile を更新していたら、ローカルの依存を実体に合わせる。更新漏れのまま作業に入ると、`npm run build` が `@types/node` 欠落等で失敗し、コードの問題と切り分けにくい（#176 で実測）。判定は裁量でなく**機械的に**行う:
+
+```bash
+git diff --name-only "$before_sync"..HEAD -- package-lock.json Cargo.lock
+```
+
+- 出力に `package-lock.json` があれば `npm install`
+- 出力に `Cargo.lock` があれば `cargo fetch`
+- 出力が空なら何もしない（依存は不変）
+
+## ステップ 4: ローカル作業ブランチの削除
 
 ```bash
 git branch -D <branch>
@@ -39,6 +52,6 @@ git branch -D <branch>
 
 （スカッシュマージでは元コミットが main の祖先に入らないため `-d` は「未マージ」と誤検知する。内容が取り込まれているかは `git diff main..<branch> --stat` がほぼゼロであることで確認済みなら `-D` で削除してよい。）
 
-## ステップ 4: 結果の報告
+## ステップ 5: 結果の報告
 
 `git log --oneline -3 main` と `git status` を示し、main が最新・作業ツリーが clean になったことを伝える。


### PR DESCRIPTION
Closes #176

## Summary
- `/post-merge-sync` に **ステップ 3「依存の再同期（lockfile 変更時のみ）」** を新設。main の pull 後に `npm install` を忘れ、`@types/node` 欠落で `npm run build` が `error TS2688` で失敗した実測（#174 作業中、コードでなく環境要因で切り分けに時間を要した）を再発防止する
- 判定は裁量でなく機械的に: `git diff --name-only "$before_sync"..HEAD -- package-lock.json Cargo.lock` の出力に `package-lock.json` があれば `npm install`、`Cargo.lock` があれば `cargo fetch`、空なら何もしない
- 差分基点はステップ 2 で pull 前の tip を `before_sync=$(git rev-parse HEAD)` で明示捕捉（`HEAD@{1}` は直前の `git switch` や no-op pull で基点がずれるため不採用）
- 後続ステップを 3→4、4→5 へ繰り下げ（節番号 1〜5 で整合）

## Test plan
- 変更は `.claude/skills/post-merge-sync/SKILL.md`（.md）のみに閉じるため、コミット前チェックリストのコード系ゲートは docs-only 免除で非該当（`src/`・`src-tauri/`・`crates/` 不変）
- [x] 節番号が 1〜5 で連番であることを確認

## 受け入れ基準の充足
- 手順どおり実行すれば、lockfile 変更を含む pull 直後でも `npm run build` / `cargo check` が環境要因で失敗しない

🤖 Generated with [Claude Code](https://claude.com/claude-code)