### PR TITLE
chore: jest-dom を 7.0.0 へ更新し CI の Node を 24 へ上げる

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Setup Rust

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Setup Rust

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
       "devDependencies": {
         "@playwright/test": "^1.60.0",
         "@tauri-apps/cli": "^2.11.2",
-        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/jest-dom": "^7.0.0",
         "@testing-library/react": "^16.3.2",
         "@types/node": "^26.1.1",
         "@types/react": "^19.2.16",
@@ -2627,9 +2627,9 @@
       }
     },
     "node_modules/@testing-library/jest-dom": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
-      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.0.tgz",
+      "integrity": "sha512-HKAH9C6mBo5yBG6yRO5i43L2iisencAo5z+o5P/saHUoY+miC5ivXRxHBJcFyB5ypPNxHJdK3BoF/3O4DIptMg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2641,9 +2641,12 @@
         "redent": "^3.0.0"
       },
       "engines": {
-        "node": ">=14",
+        "node": ">=22",
         "npm": ">=6",
         "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=10 <11"
       }
     },
     "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@playwright/test": "^1.60.0",
     "@tauri-apps/cli": "^2.11.2",
-    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^26.1.1",
     "@types/react": "^19.2.16",


### PR DESCRIPTION
## Summary

`@testing-library/jest-dom` 6.9.1 → **7.0.0**。PR #184 で唯一のメジャーとして意図的に見送っていた分。

調査の結果、この更新の実質的な争点はマッチャーではなく **CI の Node 版**だった。

### 7.0.0 の breaking change は 2 つ

| 変更 | 対応 |
|---|---|
| `engines.node` が `">=22"` へ | **CI の `node-version` を 20 → 24 へ**（`ci-build.yml` / `release.yml` の両方） |
| `@testing-library/dom` が必須 peer dependency 化 | **対応不要**。`@testing-library/react` 16.3.2 の peer 経由で 10.4.1 が既に解決済みで、要求 `">=10 <11"` を満たす |

`exports` の `"./matchers"` サブパスは 7 系にも存続しているため、`src/test/setup.ts` は無変更。issue #185 が懸念していた「マッチャーの削除・改名による広範囲の波及」は起きていない（`npm view @testing-library/jest-dom@7 exports` で実測）。

### Node を 24 にした理由

| 版 | maintenance end |
|---|---|
| 20（現行） | **2026-04-30** — 既に経過 |
| 22 | 2027-04-30 |
| 24 | 2028-04-30 |

jest-dom の要求を満たす最小は 22 だが、1 年足らずで同じ作業が再発するうえローカル開発環境（v24.18.0）とも一致しない。24 なら CI とローカルの乖離も解消する。

`release.yml` は `npm test` を持たず jest-dom を読み込まないが、片方だけ EOL の Node に残すと drift になるため揃えた。

### 強制ではなく「サポート範囲内に収める」変更である点

`.npmrc` が無く `engine-strict` は既定 off のため、`npm ci` は Node 20 でも警告どまりで失敗しない。CI が赤くなるから直す、という性質のものではない。

### 意図的に見送ったもの

- `src/test/setup.ts` を 7 系推奨の `"./vitest"` サブパスへ移行すること
- `@testing-library/dom` を明示 devDependency に追加すること

いずれも現状で正しく動作しており、不要な差分になるため見送った。

## Test plan

- [x] `npm run build`
- [x] `npm test` — 25 files / **186 tests passed**（jest-dom 7 でマッチャーの回帰なし）
- [x] `npm run check:ui-guidelines`
- [x] `npm run test:ui-guidelines-check`
- [x] `cargo test --workspace`
- [x] `cargo test -p ghost-meta --features thumbnail,serde`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `git status --porcelain src/types/generated/` に差分なし
- [x] `npm install` 時に peer dependency の警告なし

依存と CI 設定の変更のため、振る舞いのテストは追加していない（既存 186 テストが回帰網）。アプリ本体のバイナリが変わらないため E2E は不要と判断した。

Rust には一切触れていないが、変更に `.md` 以外が含まれる以上 `/commit` の docs-only 免除は効かないため、グループ B も規則どおり全実行している。

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)