### PR TITLE
fix: openSettings をダイアログの可視性待ちにして E2E の間欠失敗を解消する

### DIFF
--- a/e2e/CLAUDE.md
+++ b/e2e/CLAUDE.md
@@ -7,7 +7,7 @@
 - `e2e/helpers/harness.ts` が tauri-driver の起動・WebDriver セッション確立・後片付けを担当
 - E2E テストはリリースビルドが前提（`npm run tauri build` 後に実行）
 - **CI には含まれないため、UI 操作・言語表示・フォーム入力に関わる変更をした場合はローカルで手動実行が必須**
-- **既知の失敗テスト（依存更新と独立した既存問題）**: issue #69（SearchBox placeholder 反映）。この失敗は環境/実装側の課題であり、依存更新後に再発しても deps 起因と即断しないこと。失敗がブランチの退行か判断に迷ったら main のビルドで同一テストを実行しベースライン比較する。（#90 のスクロールテスト stale flake は #107 で解消済み — `visibleGhostNames` を要素単位 try-catch で `StaleElementReferenceError` のみ吸収し他例外は再送出する方式に修正）
+- **既知の失敗テスト（依存更新と独立した既存問題）**: issue #69（SearchBox placeholder 反映）。この失敗は環境/実装側の課題であり、依存更新後に再発しても deps 起因と即断しないこと。失敗がブランチの退行か判断に迷ったら main のビルドで同一テストを実行しベースライン比較する。（#90 のスクロールテスト stale flake は #107 で解消済み — `visibleGhostNames` を要素単位 try-catch で `StaleElementReferenceError` のみ吸収し他例外は再送出する方式に修正。#183 のダイアログ可視性 flake は `openSettings` を可視性待ちに変更して解消済み）
 
 ## 実行方法
 
@@ -30,6 +30,7 @@ npm run e2e
 ## 記述パターン
 
 - セレクタは日英両言語対応（XPath で `text()='起動' or text()='Launch'` のように記述）
+- **可視性が要る場面で `until.elementLocated` を使わない**。存在しか見ないため、Fluent UI Dialog の `<dialog>`（`open` 属性が付くまで子孫ごと `display:none`）では開くアニメーション途中の不可視要素を掴む。ダイアログを開いた後の操作・アサーションは `openSettings` の可視性待ちに委ね、呼び出し側で待ち直さない（#183。その場対処を呼び出し側に置くとヘルパー本体に還元されず、他の呼び出し側で再発する）
 - SSP パス未設定など環境依存のテストは `test.skip()` で安全にスキップ
 
 ## テスト追加の手順

--- a/e2e/ghost-list.e2e.ts
+++ b/e2e/ghost-list.e2e.ts
@@ -1,5 +1,5 @@
 import { test as base, expect } from "@playwright/test";
-import { By, until, Key, error as seleniumError, type WebDriver } from "selenium-webdriver";
+import { By, Key, error as seleniumError, type WebDriver } from "selenium-webdriver";
 import { createHarness, disposeHarness, type Harness } from "./helpers/harness";
 import { waitForAppReady, waitForGhosts, openSettings, closeSettings } from "./helpers/ui";
 
@@ -82,11 +82,9 @@ test("設定ダイアログを開閉できる", async ({ harness }) => {
 
   await openSettings(driver);
 
-  // ダイアログタイトル「設定」または "Settings" が表示される（アニメーション完了まで待機）
-  const dialogTitleEl = await driver.findElement(
-    By.xpath("//h2[text()='設定' or text()='Settings']"),
-  );
-  await driver.wait(until.elementIsVisible(dialogTitleEl), 5_000);
+  // ダイアログタイトル「設定」または "Settings" が描画されている
+  // （可視になるまでの待機は openSettings が担うため、ここでは存在確認のみでよい）
+  await driver.findElement(By.xpath("//h2[text()='設定' or text()='Settings']"));
 
   await closeSettings(driver);
 });

--- a/e2e/helpers/ui.ts
+++ b/e2e/helpers/ui.ts
@@ -37,7 +37,11 @@ export async function openSettings(driver: WebDriver): Promise<void> {
     const btn = await driver.findElement(By.css("[data-testid='settings-button']"));
     await btn.click();
   }
-  await driver.wait(until.elementLocated(By.css("[role='dialog']")), 5_000);
+  // 存在だけでなく可視になるまで待つ。Fluent UI Dialog は <dialog> 要素を使い、
+  // open 属性が付くまで子孫ごと display:none になるため、elementLocated だけでは
+  // 開くアニメーションの途中を掴み「存在するが不可視」の要素を呼び出し側へ渡してしまう。
+  const dialog = await driver.wait(until.elementLocated(By.css("[role='dialog']")), 5_000);
+  await driver.wait(until.elementIsVisible(dialog), 5_000);
 }
 
 /** 設定ダイアログを閉じる */


### PR DESCRIPTION
## Summary

`i18n.e2e.ts` の「言語切り替え: 英語に切り替えると閉じるボタンが 'Close' になる」が間欠的に失敗していた（PR #184 の検証時に **4 試行中 2 失敗**を実測）。

### 根本原因

失敗していたのは `until.elementLocated` ではなく**直後の `isDisplayed()`** で、要素は DOM に存在するが不可視だった。

原因は `e2e/helpers/ui.ts` の `openSettings` が `[role='dialog']` の**存在しか待たない**こと。Fluent UI Dialog は `<dialog>` 要素を使い、`open` 属性が付くまで UA スタイルにより子孫ごと `display: none` になる。そのため開くアニメーションの途中で「存在するが不可視」の状態を呼び出し側へ渡していた。

当該テストは `openSettings` を **2 回**呼ぶ唯一のテストで、2 回目の開き途中を掴んでいた。他のテストが pass していたことと整合する。

`src/lib/i18n.ts` はバンドルリソース＋`initAsync: false` の同期初期化であり、言語切り替えでダイアログが再マウントされることはない。よって競合ウィンドウは**ダイアログを開く瞬間に限定される**。

### 修正

`openSettings` を可視性待ちに変更した一点のみ。

```ts
const dialog = await driver.wait(until.elementLocated(By.css("[role='dialog']")), 5_000);
await driver.wait(until.elementIsVisible(dialog), 5_000);
```

**症状側の `isDisplayed()` アサーション（`i18n.e2e.ts:56`）には手を入れていない。** 両方直すとどちらが効いたか判別できなくなるため。

### 併せて削除したもの

`ghost-list.e2e.ts` の以下は、同じ問題に対する**その場対処**だった。

```ts
// ダイアログタイトル…（アニメーション完了まで待機）
await driver.wait(until.elementIsVisible(dialogTitleEl), 5_000);
```

過去に同じ現象へ遭遇した痕跡だが、知見がヘルパー本体へ還元されなかったため他の呼び出し側に残り続けた。`openSettings` が可視性を保証する以上は冗長なので削除し、再発経路を絶つ規約を `e2e/CLAUDE.md` に記した。

## Test plan

E2E は `e2e/CLAUDE.md` の規約どおり、単発 pass ではなく**連続 pass**で検証した（ベースラインが約 50% の flake 率のため、1 回の pass は根拠にならない）。

- [x] フルスイート — **10 passed / 1 skipped**（規定の合格水準。skip は SSP 設定済み環境で観測できない空状態テストで正当）
- [x] 当該テスト単体 `--repeat-each=10` — **10/10 pass**
- [x] `npm run build`
- [x] `npm test`
- [x] `npm run check:ui-guidelines`
- [x] `npm run test:ui-guidelines-check`
- [x] `cargo test --workspace`
- [x] `cargo test -p ghost-meta --features thumbnail,serde`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `git status --porcelain src/types/generated/` に差分なし

ベースラインの約 50% 失敗に対し、修正が無効なら 10 連続 pass する確率は 0.1% 程度。

変更は `e2e/` に閉じておりアプリ本体のバイナリは変わらないため、`npm run tauri build` は再実行していない（`e2e/CLAUDE.md`「テストのみの変更は再ビルド不要」）。`.md` 以外を含むため `/commit` の docs-only 免除は適用せず、コード系ゲートも規則どおり全実行している。

## 残した潜在リスク（本 PR では対象外）

`i18n.e2e.ts` には `elementLocated('閉じる' / 'Close')` の直後に `closeSettings()` でクリックする箇所が複数ある。不可視要素へのクリックは `ElementNotInteractableError` になるため別種のリスクだが、今回の上流修正で付随的に解消される。単独で顕在化した実測がないため、本 PR では触っていない。

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)