### PR TITLE
docs: E2E の「既知の失敗テスト」記述を是正し盲点を除く

### DIFF
--- a/e2e/CLAUDE.md
+++ b/e2e/CLAUDE.md
@@ -7,7 +7,7 @@
 - `e2e/helpers/harness.ts` が tauri-driver の起動・WebDriver セッション確立・後片付けを担当
 - E2E テストはリリースビルドが前提（`npm run tauri build` 後に実行）
 - **CI には含まれないため、UI 操作・言語表示・フォーム入力に関わる変更をした場合はローカルで手動実行が必須**
-- **既知の失敗テスト（依存更新と独立した既存問題）**: issue #69（SearchBox placeholder 反映）。この失敗は環境/実装側の課題であり、依存更新後に再発しても deps 起因と即断しないこと。失敗がブランチの退行か判断に迷ったら main のビルドで同一テストを実行しベースライン比較する。（#90 のスクロールテスト stale flake は #107 で解消済み — `visibleGhostNames` を要素単位 try-catch で `StaleElementReferenceError` のみ吸収し他例外は再送出する方式に修正。#183 のダイアログ可視性 flake は `openSettings` を可視性待ちに変更して解消済み）
+- **既知の失敗テストは現在ゼロ**。過去の間欠失敗は解消済み（#90 スクロール stale → #107 で `visibleGhostNames` を要素単位 try-catch にし `StaleElementReferenceError` のみ吸収／#183 ダイアログ可視性 → #191 で `openSettings` を可視性待ちに変更／#69 SearchBox placeholder → 再現しなくなりクローズ）。**したがって失敗を「既知」として片付けず、退行として扱う**。ブランチの退行か判断に迷ったら main のビルドで同一テストを実行しベースライン比較する。間欠性の判定は `--repeat-each=N` で行う（単発 pass も単発 fail も根拠にならない）
 
 ## 実行方法
 


### PR DESCRIPTION
## Summary

`e2e/CLAUDE.md` は issue #69（SearchBox placeholder 反映）を**既知の失敗テスト**として挙げていたが、現行 main で再現しない。記述を反転させ、「既知の失敗はゼロ、失敗は退行として扱う」へ改めた。

### 実測（現行 main `eb2c4d7`）

| 観測 | 結果 |
|---|---|
| フルスイート 3 回（PR #184 検証時、PR #191 の修正前後） | 該当 2 件とも毎回 pass |
| 該当 2 件を `--repeat-each=10` | **20/20 pass** |
| 合計 | **26 観測・失敗ゼロ** |

実行条件: `GHOST_LAUNCHER_E2E_APP` にワークスペース直下 `target/release/ghost-launcher.exe`、`EDGEDRIVER_VERSION=150.0.4078.83`（WebView2 Runtime の pv 実測値）。

### なぜ記述の是正が必要か

既知の失敗が実際には存在しないのに「既知」と書いてあると、**将来の作業者が本物の退行を「既知だから」と切り捨てる**。防御のつもりの記述がそのまま盲点として機能する。現に本サイクルでは、この記述があるために #183 の失敗が「既知枠に入るか」を毎回判定する必要があった。

### 切り分け（詳細は #69 のコメント）

- **#69 の推測 2・3 は構造上あてはまらない** — `SearchBox.tsx:95` の `placeholder={t("search.placeholder")}` は `t()` 直結で、`inputValue` のローカル state とは無関係
- **テスト側は起票以降不変** — `git log -- e2e/i18n.e2e.ts` は 2026-05-01 以降ヒットなし
- **推測 1（Fluent UI `Input`）が最有力だが未検証** — 起票翌日の #71 が `@fluentui/react-components` を `^9.58.0` → `^9.73.8` と 15 マイナー跳ばしており符合するが状況証拠

二分探索による原因特定は行っていない。release ビルドを複数回要するうえ、当時と Edge/WebView2 の版が異なり交絡要因が残るため、歴史的帰属の価値に見合わないと判断した（判断の根拠も #69 のコメントに記録済み）。

### あわせて明記したこと

間欠性の判定は `--repeat-each=N` で行う。**単発 pass も単発 fail も根拠にならない** — 本サイクルで #183（4 試行 2 失敗 → 修正後 10/10）と #69（26 観測 0 失敗）の双方を、この基準で判定した。

## Test plan

変更は `.md` のみに閉じており、検証対象（`src/`・`src-tauri/`・`crates/`）が不変のため `/commit` の docs-only 免除を適用し、コード系ゲートは実行していない。

- [x] 該当 2 件を `--repeat-each=10` で実測（20/20 pass）
- [x] 記述に残すポインタ（#107 / #191 / #69）が実在することを確認
- [x] 実測と判断の根拠を #69 のコメントとして記録

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)