### PR TITLE
chore: criterion を 0.5 から 0.8 系へメジャー更新する

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -621,25 +630,24 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
  "itertools",
  "num-traits",
- "once_cell",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -647,9 +655,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
  "itertools",
@@ -1675,12 +1683,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2006,21 +2008,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -2660,6 +2651,16 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "pango"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,7 +37,7 @@ bench = []
 
 [dev-dependencies]
 ts-rs = "12"
-criterion = "0.5"
+criterion = "0.8"
 
 [[bench]]
 name = "search_bench"


### PR DESCRIPTION
Closes #186

## Summary

`criterion` は直接の dev-dependency で自分たちが版を決められるにもかかわらず、`src-tauri/Cargo.toml` の `"0.5"` が上限となり 0.5.1 に据え置かれていた（#184 の依存更新時に検出）。3 メジャー跨ぎだが、**破壊的変更はいずれも本リポジトリに無影響**で、ベンチ 2 本はソース無変更のままコンパイルが通った。変更は版指定 1 行と `Cargo.lock` の追随のみ。

**0.6/0.7/0.8 の破壊的変更と影響**（`criterion` 0.8.2 同梱の CHANGELOG が権威）:

| 版 | 破壊的変更 | 影響 |
|---|---|---|
| 0.6.0 | MSRV を 1.80 へ | なし — `rust-version = "1.93"` で充足 |
| 0.6.0 | `real_blackbox` の無効化・`criterion::black_box` → `std::hint::black_box` | なし — feature 無指定、`black_box` の使用箇所ゼロ |
| 0.7.0 | 記載なし | — |
| 0.8.0 | MSRV を 1.86 へ | なし — 同上 |
| 0.8.0 | async-std サポート削除 | なし — 非同期ベンチを持たない |

**計測の比較可能性**（issue のやること 3）は変更記録の不在に頼らず二重に実証した:

- `Criterion::default()` の既定値が 0.5 と完全一致（sample_size 100 / warm-up 3s / measurement 5s / bootstrap 100,000 resamples / confidence 0.95 / significance 0.05）。`docs/perf/baseline-100k.md:13` の「criterion の warm-up（3 秒）」という記述も引き続き正しい
- `cargo bench -- --test` が n=100,000 まで全ベンチマークを Success で完走。ベンチマーク ID も `search_n{N}/…` の形で不変のため、既存ベースラインと名前で突き合わせられる

**クレートの素性検証**（`src-tauri/CLAUDE.md` の依存更新規約）: 総 DL 2.45 億・2017 年から継続公開・ライセンス不変・default features も `[rayon, plotters, cargo_bench_support]` で 0.5.1 と同一。repository が `bheisler/criterion.rs` → `criterion-rs/criterion.rs` へ org 移管されているが、crates.io 上の系譜は連続しておりトロルパッケージではない。

**依存グラフの変化**: criterion 0.5.1→0.8.2 / criterion-plot 0.5.0→0.8.2 / itertools 0.10.5→0.13.0、`alloca` 0.4.0・`page_size` 0.6.0 が追加、`hermit-abi`・`is-terminal` が脱落。新規の `alloca` は `cargo tree -i` で criterion 経由の dev-dependency のみと確認済みで、本番ビルドには入らない（ベンチ 2 本は `required-features = ["bench"]`）。

## Test plan

変更前の criterion 0.5.1 でも同じ bench ゲートが緑であることを先に確認し（計器の較正）、そのうえで bump 後を検証した。

- [x] `cargo check --manifest-path src-tauri/Cargo.toml --features bench --benches`（ソース無変更で通過）
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --features bench --lib bench_support` — 15 passed
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml --features bench --all-targets -- -D warnings`
- [x] `cargo bench --features bench --bench search_bench -- --test` — n=1k/10k/100k の全ベンチマークが Success（exit 0）
- [x] `npm run build`
- [x] `npm test` — 25 files / 186 tests passed
- [x] `npm run check:ui-guidelines` — 6 件成功 / `npm run test:ui-guidelines-check` — 6 pass
- [x] `cargo test --workspace`
- [x] `cargo test -p ghost-meta --features thumbnail,serde` — 34 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] 生成型の照合（`git status --porcelain src/types/generated/` が空）

E2E は非該当（UI 操作・言語表示・フォームのいずれにも触れていない）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)