### PR TITLE
fix: bench プロファイルの panic strategy 衝突を crate-type の縮小で解消する

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -40,7 +40,7 @@ cargo clippy --workspace --all-targets -- -D warnings
 
 グループ A とグループ B は互いに独立しているため並列実行してよい（グループ B 内は target ディレクトリのロック競合を避けるため順次）。
 
-> **CI のみのゲート（意図的非対称）**: bench ハーネス系（`cargo check --features bench --benches`・`cargo test --features bench --lib bench_support`・`cargo clippy --features bench --all-targets -- -D warnings`）は CI 専用で、本チェックリストには含めない（bench コードの変更頻度が低く、毎コミットのローカル実行コストに見合わないため）。bench 関連ファイルを変更したときのみ手動で実行する。
+> **CI のみのゲート（意図的非対称）**: bench ハーネス系（`cargo check --features bench --benches`・`cargo test --features bench --lib bench_support`・`cargo clippy --features bench --all-targets -- -D warnings`）と、bench プロファイルのコンパイルゲート（`cargo bench --features bench --bench search_bench --no-run` → 同 `--bench scan_bench --no-run` の順次実行）は CI 専用で、本チェックリストには含めない（bench コードの変更頻度が低く、毎コミットのローカル実行コストに見合わないため。とりわけ後者は release 継承プロファイルのフルビルドを伴う）。bench 関連ファイル・`[lib] crate-type`・`[profile.*]` を変更したときのみ手動で実行する。
 
 ### 追加の確認事項
 

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -72,3 +72,13 @@ jobs:
       # 別ステップで lint する。bench 限定の新 lint 素通りを防ぐ。
       - name: Clippy (bench feature, deny warnings)
         run: cargo clippy --manifest-path src-tauri/Cargo.toml --features bench --all-targets -- -D warnings
+
+      # bench プロファイル（release 継承・panic = "abort" を持つ）を PR 時にコンパイルするゲート。
+      # 上の cargo check は dev プロファイルのため panic strategy の不整合を原理的に捕まえず、
+      # release.yml の tauri build は tag 時のみで PR を守らない。
+      # docs/perf/baseline-100k.md の実行手順と同じ順序で 2 本続けて通す（#201 の再現経路そのもの）。
+      # 実行は不要（衝突はリンク時に出る）ため --no-run でコンパイルのみに留める。
+      - name: Bench profile compiles (panic strategy drift guard)
+        run: |
+          cargo bench --manifest-path src-tauri/Cargo.toml --features bench --bench search_bench --no-run
+          cargo bench --manifest-path src-tauri/Cargo.toml --features bench --bench scan_bench --no-run

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -11,7 +11,15 @@ readme = "../README.md"
 
 [lib]
 name = "ghost_launcher_lib"
-crate-type = ["staticlib", "cdylib", "rlib"]
+# rlib 単独に絞る（#201）。cdylib/staticlib を含む lib target には cargo が
+# -C extra-filename を付けないため、rlib が deps/libghost_launcher_lib.rlib という
+# 単一パスへ出力される。release を継承するプロファイル（bench・test --release）では
+# 同じ lib が panic=abort（bin 経由・[profile.release] 由来）と panic=unwind
+# （bench/test target は常に unwind 強制）の 2 unit としてビルドされ、
+# この単一パスを奪い合って後勝ちになり、リンク時に panic strategy 不整合で落ちる。
+# モバイル（iOS/Android）へ移植する際は staticlib/cdylib を戻したうえで、
+# [profile.release] の panic 設定を見直すこと。
+crate-type = ["rlib"]
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }


### PR DESCRIPTION
## Summary

`cargo bench` を `docs/perf/baseline-100k.md` の実行手順どおり 2 本連続で回すと `panic strategy` の不整合でビルドが落ちる問題を根本修正する。

**機序**（`-v` の rustc 実引数で確認）: cargo は cdylib/staticlib を含む lib target に `-C extra-filename` を付けない。このため rlib が `deps/libghost_launcher_lib.rlib` という**ハッシュ接尾辞の無い単一パス**へ出力されていた。release を継承する bench プロファイルでは、同じ lib が

| unit | 依存元 | panic |
|---|---|---|
| `-C metadata=746f06…` | `ghost_launcher` bin（cargo は bench 時も bin をビルドする） | `abort`（`[profile.release]` 由来） |
| `-C metadata=0d4dcc…` | `search_bench` / `scan_bench` | `unwind`（bench target は常に unwind 強制） |

の 2 unit としてビルドされ、この単一パスを後勝ちで奪い合う。fingerprint は unit ごとに独立しているため、2 本目の bench は「両方 fresh」と判断されたまま abort 版 rlib をリンクし、199 件の不整合エラーで落ちる。**単独実行で通るのは書き込み順序が偶然揃うだけで、順序依存は症状にすぎない。**

- `src-tauri/Cargo.toml`: `crate-type` を `["rlib"]` へ縮小。各 unit がハッシュ付きの別ファイルへ分離し衝突が消える。`cdylib`/`staticlib` は Tauri のモバイル（iOS/Android）向けで、本 repo に消費者は無い（`main.rs` の `ghost_launcher_lib::run()` のみが rlib を消費）。**出荷バイナリの `panic = "abort"` は据え置き**
- `.github/workflows/ci-build.yml`: bench プロファイルをコンパイルする CI ゲートを追加（受け入れ基準 3）。既存の bench ゲートは dev プロファイルの `cargo check` 止まりで、`panic = "abort"` を持つプロファイルを PR 時に通す経路が無かった（`release.yml` の `tauri build` は tag 時のみ）。実行は不要（衝突はリンク時に出る）ため `--no-run` に留める
- `.claude/skills/commit/SKILL.md`: 「CI のみのゲート」注記へ新ゲートを同期（安全網の変更に対する CLAUDE.md の横断同期規則）

### 検討したが採らなかった案

- **`[profile.release]` から `panic = "abort"` を外す**: 一行で確実に直るが、出荷バイナリの panic 挙動をベンチという工具の都合で変えることになる。導入コミット `c7769cd` は理由を残しておらず判断材料が薄い
- **`[profile.bench]` で `panic = "unwind"` を上書き**: 最小クレートでの実測で `warning: panic setting is ignored for bench profile` が出る。値は結果的に消えるが、cargo が「無視する」と明言する設定の副作用に乗る形になり、cargo 更新で壊れる

## Test plan

- [x] `/commit` チェックリストのグループ A・B を全項目実行し通過（生成型の差分なしを含む）
- [x] **較正**: 修正前ツリーで CI ゲートが決定的に失敗することを確認（温まった状態で 2/2 `exit=101`、加えて別の初期状態でも失敗）
- [x] **修正後・フルクリーン（17.8 GiB 削除）から**: `search_bench --no-run` → `scan_bench --no-run` が両方成功
- [x] **再実行で両方 fresh**（`scan_bench` が 0 秒＝再ビルドの奪い合いが消滅）。修正前は同条件で失敗していた
- [x] `cargo build --release` が成功し `ghost-launcher.exe`（7.35 MB）を生成。rlib 単独でデスクトップのリンクが成立
- [x] 成果物名にハッシュ接尾辞が付き 3 unit が共存することを確認（機序の直接証拠）
- [x] **CI ゲートの実測所要時間**: 本 PR の初回 CI 実行（run 32635695931）で **8 分 20 秒**（11:15:53Z → 11:24:13Z）。job 全体は 16 分 5 秒。直近の main 4 本は 8m58s / 8m35s / 6m25s / 8m53s なので、**このゲートは CI 時間をおよそ倍にする**（ローカルの Ryzen 7 9700X では 285 秒だった）

> **コストの申し送り**: 上記のとおり増分は小さくない。issue #201 が求めた「CI 時間のコストと引き合い」の実数はこの 8 分 20 秒であり、割に合わないと判断するなら、ゲートを別ワークフロー（`Cargo.toml` / `benches/` の path filter ＋ 週次 schedule）へ切り出す余地がある。判断材料として記録しておく。

### 限界の明示

較正した 3 状態はいずれも「汚れた target」からのもので、**完全クリーンな target での修正前失敗は未検証**（フルクリーンの実行は修正後にしか行っていない）。機序が書き込み順序の競合である以上、CI のクリーン環境で将来の退行（例えば `cdylib` が戻された場合）を確実に捕らえる保証までは取れていない。

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)

