### PR TITLE
chore: bench プロファイルのゲートを path filter ＋ 週次の別ワークフローへ切り出す

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -40,7 +40,9 @@ cargo clippy --workspace --all-targets -- -D warnings
 
 グループ A とグループ B は互いに独立しているため並列実行してよい（グループ B 内は target ディレクトリのロック競合を避けるため順次）。
 
-> **CI のみのゲート（意図的非対称）**: bench ハーネス系（`cargo check --features bench --benches`・`cargo test --features bench --lib bench_support`・`cargo clippy --features bench --all-targets -- -D warnings`）と、bench プロファイルのコンパイルゲート（`cargo bench --features bench --bench search_bench --no-run` → 同 `--bench scan_bench --no-run` の順次実行）は CI 専用で、本チェックリストには含めない（bench コードの変更頻度が低く、毎コミットのローカル実行コストに見合わないため。とりわけ後者は release 継承プロファイルのフルビルドを伴う）。bench 関連ファイル・`[lib] crate-type`・`[profile.*]` を変更したときのみ手動で実行する。
+> **CI のみのゲート（意図的非対称）**: bench ハーネス系（`cargo check --features bench --benches`・`cargo test --features bench --lib bench_support`・`cargo clippy --features bench --all-targets -- -D warnings`）は `ci-build.yml` の CI 専用ステップで、本チェックリストには含めない（bench コードの変更頻度が低く、毎コミットのローカル実行コストに見合わないため）。bench 関連ファイルを変更したときのみ手動で実行する。
+>
+> bench プロファイルのコンパイルゲート（`cargo bench --no-run` を 2 本順次）は `ci-bench-profile.yml` が単一権威。`Cargo.toml`・`Cargo.lock`・`benches/` の変更で自動発火し、加えて週次と `workflow_dispatch` でも走るため、ローカルでの手動実行もこのチェックリストへの追加も不要（release 継承プロファイルのフルビルドを伴い CI 時間をおよそ倍にしたため #209 で `ci-build.yml` から切り出した）。
 
 ### 追加の確認事項
 

--- a/.claude/skills/health-check/SKILL.md
+++ b/.claude/skills/health-check/SKILL.md
@@ -17,7 +17,7 @@ disable-model-invocation: true
 3. **フォルダ CLAUDE.md**（`src/` `src-tauri/` `e2e/`）— 記述が現在のコードと一致するか、移動・消失したファイルへの言及がないか
 4. **docs/** — `ui-guidelines.md`・`locale-customization.md` の規約が実装と一致するか
 5. **スキルの化石検出** — 各 `.claude/skills/*/SKILL.md` 内のコマンド・パス・バージョン表記・モデル名が現在も有効か
-6. **CI とチェックリスト** — `.github/workflows/ci-build.yml` のステップと `/commit` のチェックリストが整合するか（CI にあってローカルに無いチェック、またはその逆）
+6. **CI とチェックリスト** — `.github/workflows/` 配下**全ワークフロー**のステップと `/commit` のチェックリストが整合するか（CI にあってローカルに無いチェック、またはその逆）。`ci-build.yml` だけを見ると、意図的に切り出したワークフロー（`ci-bench-profile.yml` 等）の記述が化石化しても気付けない
 7. **生成型** — `src/types/generated/` にコミット漏れ・実装に対応しない孤児ファイルがないか（`cargo test --workspace` 後に `git status --porcelain src/types/generated/` で確認）
 8. **RETROSPECTIVE.md** — ネクストアクションが issue 化または消化されているか（`gh issue list` と突き合わせる）
 9. **足場（scaffolding）の残存** — 撤去条件つきで書かれた仮設コード（「後続タスクで置き換え」「仮実装」等）がサイクルを跨いで生存していないか（`grep -rniE 'TODO|FIXME|後続タスク|後で(削除|置き換え|実装)|仮実装|仮置き' src src-tauri crates`）。ヒットが撤去待ちか、恒久的な備考かを区別して報告する（`placeholder` 等は UI 属性・i18n キーで恒常ヒットするため意図句に絞っている）

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -23,7 +23,7 @@ description: コード変更（機能追加・バグ修正・リファクタリ�
 - 関連する関数の使用箇所を検索し、影響範囲を確認する
 - 対称的なコードパス（追加/削除、成功/失敗）がある場合は両方を確認する
 - 変更しないと判断したファイルについても、その根拠を確認する
-- `.github/workflows/ci-build.yml` を読み、変更が CI で正しく検証されるか確認する
+- `.github/workflows/` 配下のワークフローを読み、変更が CI で正しく検証されるか確認する（発火条件に `paths` フィルタを持つものがあり、変更したファイルによっては走らない）
 
 ## ステップ 4: テストを先に書く（Red）
 
@@ -60,7 +60,7 @@ description: コード変更（機能追加・バグ修正・リファクタリ�
   | 振る舞い・DB スキーマ・コマンド仕様 | SPEC.md |
   | `src-tauri/src/commands/` 等へのモジュール（ファイル）新設・移動・削除 | SPEC.md §3.2 モジュール表 |
   | `src/locales/*.json` のキー増減 | `docs/locale-customization.md` のキー一覧 |
-  | 安全網（`ci-build.yml`・`clippy.toml`・`scripts/hooks/`・`.claude/settings.json`）の新設・変更 | `/commit` チェックリスト（グループ A/B）との整合を突合して同期する |
+  | 安全網（`.github/workflows/`・`clippy.toml`・`scripts/hooks/`・`.claude/settings.json`）の新設・変更 | `/commit` チェックリスト（グループ A/B）との整合を突合して同期する |
   | アーキテクチャ・横断パターンの変更（書込経路・キャッシュ機構・スキーマ方式等） | `.claude/skills/` を関連語で grep し、化石化するスキル記述を同一 PR で更新する |
 
 - `/commit` へ接続する（チェックリストの実行とコミットは `/commit` の責務）

--- a/.github/workflows/ci-bench-profile.yml
+++ b/.github/workflows/ci-bench-profile.yml
@@ -1,0 +1,50 @@
+name: Bench Profile
+
+# bench プロファイル（release 継承・panic = "abort" を持つ）をコンパイルするゲート。
+# ci-build.yml の `cargo check --benches` は dev プロファイルのため panic strategy の
+# 不整合を原理的に捕まえず、release.yml の tauri build は tag 時のみ動く。
+#
+# 当初は ci-build.yml の 1 ステップだったが、実測で CI 時間をおよそ倍にし
+# docs-only の PR まで対価を払っていたため #209 で切り出した（#207 で 8m20s）。
+on:
+  pull_request:
+    branches:
+      - main
+    # 設定の所在に対応させる: [profile.*] はルート、[lib] crate-type は src-tauri。
+    # ワークスペースを増やしたときに漏れないよう crates/ 配下も含める。
+    paths:
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'src-tauri/Cargo.toml'
+      - 'crates/**/Cargo.toml'
+      - 'src-tauri/benches/**'
+      - '.github/workflows/ci-bench-profile.yml'
+  # path filter は「変更した人」を守るが「変更していないのに壊れた」を取り逃がす。
+  # cargo 自身の更新や依存構成の変化で成果物パスの決定が変われば差分ゼロでも壊れるため、
+  # 週次で既定ブランチ（main）を回してその穴を埋める。省くと切り出しが検知経路の削除になる。
+  schedule:
+    - cron: '0 0 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  bench-profile:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      # フロントエンドのビルドは不要（build.rs は frontendDist の実在を要求しない。
+      # dist/ を退避した状態で build script を強制再実行して確認済み）。
+      # docs/perf/baseline-100k.md の実行手順と同じ順序で 2 本続けて通す（#201 の再現経路そのもの）。
+      # 実行は不要（衝突はリンク時に出る）ため --no-run でコンパイルのみに留める。
+      - name: Bench profile compiles (panic strategy drift guard)
+        run: |
+          cargo bench --manifest-path src-tauri/Cargo.toml --features bench --bench search_bench --no-run
+          cargo bench --manifest-path src-tauri/Cargo.toml --features bench --bench scan_bench --no-run

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -72,13 +72,3 @@ jobs:
       # 別ステップで lint する。bench 限定の新 lint 素通りを防ぐ。
       - name: Clippy (bench feature, deny warnings)
         run: cargo clippy --manifest-path src-tauri/Cargo.toml --features bench --all-targets -- -D warnings
-
-      # bench プロファイル（release 継承・panic = "abort" を持つ）を PR 時にコンパイルするゲート。
-      # 上の cargo check は dev プロファイルのため panic strategy の不整合を原理的に捕まえず、
-      # release.yml の tauri build は tag 時のみで PR を守らない。
-      # docs/perf/baseline-100k.md の実行手順と同じ順序で 2 本続けて通す（#201 の再現経路そのもの）。
-      # 実行は不要（衝突はリンク時に出る）ため --no-run でコンパイルのみに留める。
-      - name: Bench profile compiles (panic strategy drift guard)
-        run: |
-          cargo bench --manifest-path src-tauri/Cargo.toml --features bench --bench search_bench --no-run
-          cargo bench --manifest-path src-tauri/Cargo.toml --features bench --bench scan_bench --no-run


### PR DESCRIPTION
## Summary

#207 で `ci-build.yml` に置いた bench プロファイルのコンパイルゲートを、専用ワークフロー `ci-bench-profile.yml` へ切り出す。#201 が「CI 時間のコストと引き合いのため」と求めていた、その引き合いの結論。

| 実行 | 変更内容 | job 全体 |
|---|---|---|
| #207 | 本件の修正 | 16m05s（ゲート単体 8m20s） |
| #208 | `CLAUDE.md` の **1 行** | 21m51s |
| 直近 main 4 本（ゲート導入前） | — | 8m58s / 8m35s / 6m25s / 8m53s |

- **発火条件を 3 経路に絞る**: `Cargo.toml`（ルート・`src-tauri`・`crates/**`）・`Cargo.lock`・`src-tauri/benches/**`・当ワークフロー自身の変更による path filter ／ 週次 schedule ／ `workflow_dispatch`
- **週次 schedule は省けない**: この不整合は `Cargo.toml` を触らずとも、cargo 自身の更新や依存構成の変化で成果物パスの決定が変われば再発する。path filter は「変更した人」を守るが「変更していないのに壊れた」を取り逃がす。週次を省くと切り出しが検知経路の実質的な削除になる
- **フロントエンドのビルドは入れない**: `dist/` を退避したうえで build script を強制再実行し、`frontendDist` の実在を要求しないことを確認した（build script が実際に再実行されたことは output ファイルの更新時刻で検算。最初の試行は build script がキャッシュで再実行されず無効な観測だった）
- **スキルの単数参照を広げる**: `/health-check` 項目 6 は「CI とチェックリストの整合」を検算する手段そのもので、`ci-build.yml` 単数のままだと切り出したワークフローの記述が化石化しても気付けない。`/implement` の安全網の行と CI 確認の行も同様に `.github/workflows/` 配下へ広げた

## 較正について

`CLAUDE.md`「計器を先に較正する — ゲートは通ることでなく壊れたツリーで落ちることで較正する」に照らすと、**本 PR ではゲート本体のロジックを変更していない**（#207 でコマンドと較正は済んでおり、移設しただけ）。したがって本 PR で較正すべきは**発火条件が意図どおりか**であり、それは次で確認できる:

- 本 PR は `.github/workflows/ci-bench-profile.yml` を追加するため **path filter に自ら合致し、`Bench Profile` が本 PR 上で走る**
- 同時に `Bench Profile` が消えた `CI Build` が #207 以前の水準（8〜9 分台）へ戻る

この 2 点をマージ前に確認する。逆方向（合致しない PR で走らないこと）は、次に docs-only の PR を出したときに確かめられる。

## Test plan

- [x] `/commit` チェックリストのグループ A・B を全項目実行し通過（`.yml` を含むため docs-only 免除は適用せず）
- [x] 両ワークフローの YAML が妥当にパースし、トリガーと `paths` が意図どおりであることを確認
- [x] `main` にブランチ保護が無く（`branches/main/protection` が 404）ruleset も `enforcement: disabled` であることを確認 — path filter で check が現れない PR があってもマージはブロックされない
- [x] **較正完了**: 本 PR 上で `Bench Profile` が発火して pass（13m28s）、`CI Build` は **9m10s** でゲート導入前の水準（8m58s / 8m35s / 6m25s / 8m53s）へ戻った

### 副次的な収穫: 2 つのワークフローは並列に走る

両者とも 14:52:11Z に開始しており、PR の待ち時間は合計でなく **max** になる。`Cargo.toml` に触れる PR は 13m28s、触れない PR は 9m10s。分割前は 1 ジョブ内の逐次ステップだったため 16m05s / 21m51s を丸ごと待っていた。

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)

