### PR TITLE
chore: CI に cargo ビルドキャッシュを導入する

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -42,7 +42,7 @@ cargo clippy --workspace --all-targets -- -D warnings
 
 > **CI のみのゲート（意図的非対称）**: bench ハーネス系（`cargo check --features bench --benches`・`cargo test --features bench --lib bench_support`・`cargo clippy --features bench --all-targets -- -D warnings`）は `ci-build.yml` の CI 専用ステップで、本チェックリストには含めない（bench コードの変更頻度が低く、毎コミットのローカル実行コストに見合わないため）。bench 関連ファイルを変更したときのみ手動で実行する。
 >
-> bench プロファイルのコンパイルゲート（`cargo bench --no-run` を 2 本順次）は `ci-bench-profile.yml` が単一権威。`Cargo.toml`・`Cargo.lock`・`benches/` の変更で自動発火し、加えて週次と `workflow_dispatch` でも走るため、ローカルでの手動実行もこのチェックリストへの追加も不要（release 継承プロファイルのフルビルドを伴い CI 時間をおよそ倍にしたため #209 で `ci-build.yml` から切り出した）。
+> bench プロファイルのコンパイルゲート（`cargo bench --no-run` を 2 本順次）は `ci-bench-profile.yml` が単一権威。`Cargo.toml`・`Cargo.lock`・`benches/` の変更で自動発火し、加えて main への push・週次・`workflow_dispatch` でも走るため、ローカルでの手動実行もこのチェックリストへの追加も不要（release 継承プロファイルのフルビルドを伴い CI 時間をおよそ倍にしたため #209 で `ci-build.yml` から切り出した）。
 
 ### 追加の確認事項
 

--- a/.github/workflows/ci-bench-profile.yml
+++ b/.github/workflows/ci-bench-profile.yml
@@ -19,6 +19,15 @@ on:
       - 'crates/**/Cargo.toml'
       - 'src-tauri/benches/**'
       - '.github/workflows/ci-bench-profile.yml'
+  # main への push では paths で絞らない。理由は 2 つ。
+  # (1) キャッシュのブランチスコープ: PR ブランチの run が作ったキャッシュは他の PR から
+  #     読めず、全ブランチが読めるのは既定ブランチの run が作ったものだけ。main 側で
+  #     常に温めておかないと、PR ごとに使い捨てのキャッシュを作るだけになる（#211）。
+  # (2) paths を複製すると、PR 側との同期が機械検証されない重複になる。
+  # マージ後の実行なので誰の待ち時間も増やさず、ゲートの main 上での再確認も兼ねる。
+  push:
+    branches:
+      - main
   # path filter は「変更した人」を守るが「変更していないのに壊れた」を取り逃がす。
   # cargo 自身の更新や依存構成の変化で成果物パスの決定が変われば差分ゼロでも壊れるため、
   # 週次で既定ブランチ（main）を回してその穴を埋める。省くと切り出しが検知経路の削除になる。
@@ -39,6 +48,10 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
+
+      # 効果が実測できなければ外す前提で入れている（#211）。
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
 
       # フロントエンドのビルドは不要（build.rs は frontendDist の実在を要求しない。
       # dist/ を退避した状態で build script を強制再実行して確認済み）。

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -30,6 +30,12 @@ jobs:
         with:
           components: clippy
 
+      # cargo registry と target/ の依存ぶんをキャッシュする。既定のキャッシュキーは
+      # github.job を含むため、ci-bench-profile.yml（別プロファイル）とは自動的に分かれる。
+      # 効果が実測できなければ外す前提で入れている（#211）。
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
## Summary

CI にはビルドキャッシュが一切無く、`CI Build`（9m10s）も `Bench Profile`（13m28s）も毎回ゼロから依存をコンパイルしている。両ワークフローの `Setup Rust` 直後に `Swatinem/rust-cache@v2` を入れる。

### 根拠になった実測（ローカル / Ryzen 7 9700X、bench ゲート 2 本の合計）

| シナリオ | 時間 |
|---|---|
| 完全 cold（＝現在の CI 相当） | 285s |
| `rust-cache` ヒット相当（依存は再利用・自クレートのみ再ビルド） | **132s** |
| 完全 warm | 10s |

差の 153s が依存ぶん＝キャッシュの射程。残る 132s は `lto = true` / `codegen-units = 1` の最終リンクで、`rust-cache` は自クレートの成果物を意図的に捨てるため**キャッシュでは消えない**。

CI 側にはもう一段大きい塊がある。`Bench Profile` の cargo ステップは単独ジョブで 12m59s だが、同じ 2 コマンドを #207 の結合ジョブの後段で測ったときは 8m20s だった。差の約 4m39s は前段の cargo コマンドが crates.io のインデックス更新とクレート取得を払い終えていたぶんで、これはキャッシュで消える。

> 別々の run の比較であり、この 4m39s は機序から見た概算。統制された計測ではない。

## `ci-bench-profile.yml` に main への push トリガーを足した理由

**GitHub Actions のキャッシュはブランチスコープを持つ。** PR ブランチの run が作ったキャッシュは他の PR から読めず、全ブランチが読めるのは既定ブランチの run が作ったものだけ。`ci-bench-profile.yml` は PR・週次・手動しか持たなかったため、そのままでは PR ごとに使い捨てのキャッシュを作るだけで再利用されない。

### issue #211 の案からの逸脱

issue では `push` にも同じ `paths` フィルタを付ける案を書いたが、**付けない形にした**。

- `paths` を複製すると、PR 側との同期が機械検証されない重複になる
- マージ後の実行なので誰の待ち時間も増やさない（public repo のため Actions 分数は無料）
- 副次的に、ゲートを main 上でも再確認できる

## Test plan

- [x] `/commit` チェックリストのグループ A・B を全項目実行し通過（`.yml` を含むため docs-only 免除は適用せず）
- [x] 両ワークフローの YAML が妥当にパースし、トリガーとステップ順が意図どおりであることを確認
- [x] `Swatinem/rust-cache` の最新リリースが v2.9.2（2026-08-06）であり、major タグ `v2` でのピンが本 repo の慣習（`actions/checkout@v4` 等）と揃うことを確認
- [x] `/commit` チェックリストのゲート記述を、増えたトリガー（main への push）へ同期
- [x] **効果の実測** — 下記のとおり明確な短縮を確認。残す判断とした

## 効果の測り方（未了）

**1 回目の run はキャッシュ作成のみで効果が出ない。** この PR に 2 つ目のコミットを積み、run #1 と run #2 を比較する。あわせて run #2 のログでキャッシュが実際にヒットしていること（「入れた」ではなく「効いた」）を確認する。

## 実測結果（残す判断）

| | ベースライン（#210 の run・キャッシュ無し） | run #1（キャッシュ作成） | run #2（ヒット） | 削減 |
|---|---|---|---|---|
| `CI Build` | 9m10s | 9m18s | **3m57s** | **−57%** |
| `Bench Profile` | 13m28s | 13m54s | **7m19s** | **−46%** |

2 ワークフローは並列に走るため、PR の待ち時間は max を取り **13m28s → 7m19s**。

### 「効いた」の証拠

```
build          Cache cargo build  Restored from cache key "v0-rust-build-Windows_NT-x64-368f6b88-b0d7fb88" full match: true.
bench-profile  Cache cargo build  Restored from cache key "v0-rust-bench-profile-Windows_NT-x64-368f6b88-b0d7fb88" full match: true.
```

キーは予想どおり job 名で分離されており、両ワークフローが互いのキャッシュを踏まない。ステップ単位では `Test Rust crates` が 2m27s → 44s。

### コストの実数

- **復元**: 19s（build）／ 22s（bench-profile）。削減分に対して十分小さい
- **保存**: run #1 の +8s / +26s がそれに当たる。ヒット時は `Post Cache cargo build` が 0s（full match のため保存をスキップ）
- **サイズ**: 720 MiB × 2 = 1.44 GiB。リポジトリ合計 1.89 GiB で上限 10 GB に対し余裕がある

### 計測方法と、その限界

`gh run rerun` で**同一 SHA を再実行**した。ビルド内容が完全に同一で、変わったのはキャッシュの有無だけという統制された比較になる（空コミットだとソースが変わり比較に変数が混じる）。

限界を 2 つ明示する。

1. **ベースラインは #210 の別 run** であり、ランナー個体差は統制していない。ただし観測された振れ幅（+8s / +26s）に対し効果量は 5 分超で、桁が 2 つ違う。単発の数字で速い遅いを言わない規律に照らしても、この差はノイズに帰せられない
2. **run #2 は同一ブランチのキャッシュから復元している。** 実際の PR が読むのは main のキャッシュで、これはマージ後の push run が作る（`ci-build.yml` は元から、`ci-bench-profile.yml` は本 PR で追加した push トリガーで）。キーはブランチ非依存のため同じヒットになる見込みだが、**マージ後の最初の PR で実地確認する余地は残る**

### いつミスするか

キャッシュキーは lockfile のハッシュと rustc のバージョンを含む。`Cargo.lock` / `package-lock.json` の変更、および浮動している `stable` の bump のたびに 1 回フルミスする（その run が新しいキャッシュを作る）。

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)
